### PR TITLE
Fix default ports for PlatformSettings

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.Development.json
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.Development.json
@@ -8,20 +8,10 @@
   "SblBridgeSettings": {
     "BaseApiUrl": "https://at22.altinn.cloud/sblbridge/"
   },
-  "PlatformSettings": {
-    "ApiResourceRegistryEndpoint": "http://localhost:5100/resourceregistry/api/v1/",
-    "ApiRegisterEndpoint": "http://localhost:5020/register/api/v1/",
-    "ApiProfileEndpoint": "http://localhost:5030/profile/api/v1/",
-    "ApiAuthorizationEndpoint": "http://localhost:49723/authorization/api/v1/"
-  },
   "OidcProviders": {
     "altinn": {
       "Issuer": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/",
       "WellKnownConfigEndpoint": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/.well-known/openid-configuration"
-    },
-    "maskinporten-ver2": {
-      "Issuer": "https://ver2.maskinporten.no/",
-      "WellKnownConfigEndpoint": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server"
     },
     "maskinporten-test": {
       "Issuer": "https://test.maskinporten.no/",

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.json
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.json
@@ -10,11 +10,11 @@
     "RightsCacheTimeout": 5
   },
   "PlatformSettings": {
-    "ApiAuthenticationEndpoint": "http://localhost:5101/authentication/api/v1/",
-    "ApiAuthorizationEndpoint": "http://localhost:5101/authorization/api/v1/",
-    "ApiProfileEndpoint": "http://localhost:5101/profile/api/v1/",
-    "ApiRegisterEndpoint": "http://localhost:5101/register/api/v1/",
-    "ApiResourceRegistryEndpoint": "http://localhost:5101/resourceregistry/api/v1/",
+    "ApiAuthenticationEndpoint": "http://localhost:5040/authentication/api/v1/",
+    "ApiAuthorizationEndpoint": "http://localhost:5050/authorization/api/v1/",
+    "ApiProfileEndpoint": "http://localhost:5030/profile/api/v1/",
+    "ApiRegisterEndpoint": "http://localhost:5020/register/api/v1/",
+    "ApiResourceRegistryEndpoint": "http://localhost:5100/resourceregistry/api/v1/",
     "JwtCookieName": "AltinnStudioRuntime",
     "SubscriptionKeyHeaderName": "Ocp-Apim-Subscription-Key"
   },


### PR DESCRIPTION
## Description
Since frontend no longer runs access management locally we can remove localtest ports in default appsettings and set these to the correct defaults

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
