### PR TITLE
Change expected response for failing test

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/K6/src/tests/access-management/maskinporten/maskinporten.js
+++ b/src/apps/Altinn.AccessManagement/test/K6/src/tests/access-management/maskinporten/maskinporten.js
@@ -373,7 +373,7 @@ export function postMaskinportenSystemResourceCannotBeDelegatedTest() {
     'post Maskinporten Systemresource Cannot be delegated - status is 400': (r) => r.status === 400,
     'post Maskinporten Systemresource Cannot be delegated - `One or more validation errors occurred.`': (r) => r.json('title') == 'One or more validation errors occurred.',
     'post Maskinporten Systemresource Cannot be delegated - errors is not null': (r) => r.json('errors') != null,
-    'post Maskinporten Systemresource Cannot be delegated - Invalid resource type': (r) => r.body.includes('This operation only support requests for Maskinporten schema resources. Invalid resource: Identifier: altinn_maskinporten_scope_delegation, ResourceType: Systemresource'),
+    'post Maskinporten Systemresource Cannot be delegated - Not available for delegation': (r) => r.body.includes('The resource: altinn_maskinporten_scope_delegation, does not exist or is not available for delegation'),
   });
 
   addErrorCount(success);


### PR DESCRIPTION
Systemresource is not visible or delegable. Corrected expected response

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

