### PR TITLE
Patching Altinn.Urn.Swashbuckle from 2.5.1 to 2.6.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Altinn.Swashbuckle.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Altinn.Swashbuckle" Version="2.2.0" />
     <PackageVersion Include="Altinn.Urn" Version="2.6.0" />
-    <PackageVersion Include="Altinn.Urn.Swashbuckle" Version="2.5.1" />
+    <PackageVersion Include="Altinn.Urn.Swashbuckle" Version="2.6.1" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.0.0" />
     <PackageVersion Include="AutoMapper" Version="13.0.1" />
     <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Altinn.Platform.Storage.Interface" Version="4.0.5" />
     <PackageVersion Include="Altinn.Swashbuckle.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Altinn.Swashbuckle" Version="2.2.0" />
-    <PackageVersion Include="Altinn.Urn" Version="2.6.0" />
+    <PackageVersion Include="Altinn.Urn" Version="2.6.1" />
     <PackageVersion Include="Altinn.Urn.Swashbuckle" Version="2.6.1" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.0.0" />
     <PackageVersion Include="AutoMapper" Version="13.0.1" />


### PR DESCRIPTION
Patching Altinn.Urn.Swashbuckle from 2.5.1 to 2.6.1