### PR TITLE
Add parameter to exclude any folder containing "test" from code scan

### DIFF
--- a/.github/workflows/sonarcloud-apps.yml
+++ b/.github/workflows/sonarcloud-apps.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
         run: |
           dotnet tool install --global dotnet-coverage
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"Authorization_${{ matrix.shortName }}" /o:"altinn" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.scanAll=false /d:sonar.coverage.exclusions="**/Migration/**" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"Authorization_${{ matrix.shortName }}" /o:"altinn" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.scanAll=false /d:sonar.coverage.exclusions="**/Migration/**" /d:sonar.exclusions="**/*test*/**" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
 
           dotnet build --no-incremental
           dotnet coverage collect 'dotnet test --no-build --results-directory TestResults/' -f xml -o 'TestResults/coverage.xml'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current Sonarcloud scans show 160 code smells in AccessManagement and 243 code smells in Authorization, all pertaining to "Missing XML comment for publicly visible type or member" on things within the test folder. This PR includes a simple parameter fix to the Sonarcloud analysis command that excludes everything in the test folder from code scans. These folders have previously been excluded from code coverage analysis in a different parameter in the Sonarcloud analysis.

https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&rules=external_roslyn%3ACS1591&issueStatuses=OPEN%2CCONFIRMED&id=Altinn_AccessManagement

https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&rules=external_roslyn%3ACS1591&issueStatuses=OPEN%2CCONFIRMED&id=Altinn_Authorization

## Related Issue(s)
- #152 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
