### PR TITLE
Feature/152 fix test folders exclusion

### DIFF
--- a/.github/workflows/pr-apps.yml
+++ b/.github/workflows/pr-apps.yml
@@ -117,7 +117,7 @@ jobs:
         shell: bash
         run: |
           dotnet tool install --global dotnet-coverage
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"Authorization_${{ matrix.shortName }}" /o:"altinn" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.scanAll=false /d:sonar.coverage.exclusions="**/Migration/**" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"Authorization_${{ matrix.shortName }}" /o:"altinn" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.scanAll=false /d:sonar.coverage.exclusions="**/Migration/**" /d:sonar.exclusions="test/**/*" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
 
           dotnet build --no-incremental
           dotnet coverage collect 'dotnet test --no-build --results-directory TestResults/' -f xml -o 'TestResults/coverage.xml'

--- a/.github/workflows/pr-apps.yml
+++ b/.github/workflows/pr-apps.yml
@@ -117,7 +117,7 @@ jobs:
         shell: bash
         run: |
           dotnet tool install --global dotnet-coverage
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"Authorization_${{ matrix.shortName }}" /o:"altinn" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.scanAll=false /d:sonar.coverage.exclusions="**/Migration/**" /d:sonar.exclusions="test/**/*" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"Authorization_${{ matrix.shortName }}" /o:"altinn" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.scanAll=false /d:sonar.coverage.exclusions="**/Migration/**" /d:sonar.test.exclusions="test/**/*" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
 
           dotnet build --no-incremental
           dotnet coverage collect 'dotnet test --no-build --results-directory TestResults/' -f xml -o 'TestResults/coverage.xml'

--- a/.github/workflows/sonarcloud-apps.yml
+++ b/.github/workflows/sonarcloud-apps.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
         run: |
           dotnet tool install --global dotnet-coverage
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"Authorization_${{ matrix.shortName }}" /o:"altinn" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.scanAll=false /d:sonar.coverage.exclusions="**/Migration/**" /d:sonar.exclusions="test/**/*" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"Authorization_${{ matrix.shortName }}" /o:"altinn" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.scanAll=false /d:sonar.coverage.exclusions="**/Migration/**" /d:sonar.test.exclusions="test/**/*" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
 
           dotnet build --no-incremental
           dotnet coverage collect 'dotnet test --no-build --results-directory TestResults/' -f xml -o 'TestResults/coverage.xml'

--- a/.github/workflows/sonarcloud-apps.yml
+++ b/.github/workflows/sonarcloud-apps.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
         run: |
           dotnet tool install --global dotnet-coverage
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"Authorization_${{ matrix.shortName }}" /o:"altinn" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.scanAll=false /d:sonar.coverage.exclusions="**/Migration/**" /d:sonar.exclusions="**/*test*/**" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"Authorization_${{ matrix.shortName }}" /o:"altinn" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.scanAll=false /d:sonar.coverage.exclusions="**/Migration/**" /d:sonar.exclusions="test/**/*" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
 
           dotnet build --no-incremental
           dotnet coverage collect 'dotnet test --no-build --results-directory TestResults/' -f xml -o 'TestResults/coverage.xml'

--- a/.github/workflows/sonarcloud-apps.yml
+++ b/.github/workflows/sonarcloud-apps.yml
@@ -42,31 +42,6 @@ jobs:
       - name: Assert that no sln files have changed
         run: git diff --exit-code
 
-  build-and-test:
-    name: Build and Test
-    needs: find-verticals
-    strategy:
-      matrix: ${{ fromJson(needs.find-verticals.outputs.matrix) }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-
-      - name: Restore dotnet workloads
-        working-directory: ${{ matrix.path }}
-        run: dotnet workload restore
-
-      - name: Build & Test
-        working-directory: ${{ matrix.path }}
-        run: |
-          dotnet build -v m
-          dotnet test --no-build -v m
-
   analyze:
     name: Analyze
     needs: find-verticals


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current Sonarcloud scans show code smells in AccessManagement and Authorization, all pertaining to things within the test folders. This PR includes a simple fix to the correct Sonarcloud parameter in the analysis command (sonar.test.exclude) that excludes everything in the test folder from code scans. These folders have previously been excluded from code coverage analysis in a different parameter in the Sonarcloud analysis.

As a result of this change, maintainability issues (code smells) in AccessManagement went down from 620 to 229, and in Authorization down from 472 to 151.

Also removed build-and-test job from the manually triggered apps-sonarcloud.yml workflow. This job is still in place in the pr-apps.yml workflow.

## Related Issue(s)
- #152 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
