### PR TITLE
Update TestToolsTokenGenerator.js for undefined partyUuid

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/TestToolsTokenGenerator.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/TestToolsTokenGenerator.js
@@ -17,7 +17,7 @@ exports.getToken = async function (getTokenParameters) {
   if (tokenType == "Personal") {
     const tokenUser = getTokenParameters.auth_userId;
     const tokenParty = getTokenParameters.auth_partyId;
-    const tokenPartyUuid = getTokenParameters.auth_partyUuid;
+    const tokenPartyUuid = getTokenParameters.auth_partyUuid ?? "00000000-0000-0000-0000-000000000000";
     const tokenPid = getTokenParameters.auth_ssn;
 
     tokenUrl = `${tokenBaseUrl}/api/Get${tokenType}Token?env=${tokenEnv}&scopes=${tokenScopes}&pid=${tokenPid}&userid=${tokenUser}&partyid=${tokenParty}&partyuuid=${tokenPartyUuid}&authLvl=3&ttl=3000`;


### PR DESCRIPTION
Fix for all tests not having set auth_partyuuid now failing
