### PR TITLE
Fix for AuthenticationClient to use HttpRequestMessage

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Clients/Interfaces/IAuthenticationClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Clients/Interfaces/IAuthenticationClient.cs
@@ -8,7 +8,6 @@ namespace Altinn.AccessManagement.Core.Clients.Interfaces
     /// </summary>
     public interface IAuthenticationClient
     {
-
         /// <summary>
         /// Fetching a System user from Authentication
         /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Clients/Interfaces/IAuthenticationClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Clients/Interfaces/IAuthenticationClient.cs
@@ -8,12 +8,6 @@ namespace Altinn.AccessManagement.Core.Clients.Interfaces
     /// </summary>
     public interface IAuthenticationClient
     {
-        /// <summary>
-        /// Refreshes the AltinnStudioRuntime JwtToken.
-        /// </summary>
-        /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>Response message from Altinn Platform with refreshed token.</returns>
-        Task<string> RefreshToken(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fetching a System user from Authentication

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/JwtTokenUtil.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/JwtTokenUtil.cs
@@ -37,20 +37,5 @@ namespace Altinn.AccessManagement.Core.Helpers
 
             return token;
         }
-
-        /// <summary>
-        /// Updates http client by including authorization token in request header
-        /// </summary>
-        /// <param name="client">The HTTP client</param>
-        /// <param name="token">The authorization token</param>
-        public static void AddTokenToRequestHeader(HttpClient client, string token)
-        {
-            if (client.DefaultRequestHeaders.Contains("Authorization"))
-            {
-                client.DefaultRequestHeaders.Remove("Authorization");
-            }
-
-            client.DefaultRequestHeaders.Add("Authorization", "Bearer " + token);
-        }
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/AuthenticationClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/AuthenticationClient.cs
@@ -1,21 +1,19 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
-using Altinn.AccessManagement.Core.Helpers.Extensions;
-using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.Core.Extensions;
 using Altinn.AccessManagement.Core.Models.Authentication;
 using Altinn.AccessManagement.Integration.Configuration;
-using Altinn.Common.AccessTokenClient.Services;
-using Altinn.Platform.Register.Models;
 using AltinnCore.Authentication.Utils;
+using Azure.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Npgsql.Internal;
 using DefaultRight = Altinn.AccessManagement.Core.Models.Authentication.DefaultRight;
 
 namespace Altinn.AccessManagement.Integration.Clients
@@ -54,52 +52,19 @@ namespace Altinn.AccessManagement.Integration.Clients
         }
 
         /// <inheritdoc />
-        public async Task<string> RefreshToken(CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                string endpointUrl = $"refresh";
-                string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-                _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-                HttpResponseMessage response = await _client.GetAsync(endpointUrl, cancellationToken);
-
-                if (response.StatusCode == System.Net.HttpStatusCode.OK)
-                {
-                    string refreshedToken = await response.Content.ReadAsStringAsync(cancellationToken);
-                    refreshedToken = refreshedToken.Replace('"', ' ').Trim();
-                    return refreshedToken;
-                }
-                else
-                {
-                    _logger.LogError("Refreshing JwtToken failed with status code");
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "AccessManagement // AuthenticationClient // Refresh // Exception");
-                throw;
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc />
         public async Task<SystemUser> GetSystemUser(int partyId, string systemUserId, CancellationToken cancellationToken = default)
         {
             try
             {
                 string endpointUrl = $"systemuser/{partyId}/{systemUserId}";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-                _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-                HttpResponseMessage response = await _client.GetAsync(endpointUrl, cancellationToken);
-
-                string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, cancellationToken: cancellationToken);
 
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    SystemUser systemUser = JsonSerializer.Deserialize<SystemUser>(responseContent, _serializerOptions);
-                    
+                    SystemUser systemUser = await response.Content.ReadFromJsonAsync<SystemUser>(_serializerOptions, cancellationToken);
+
                     // The endpoint is not using the partyId input so added a check here to ensure the partyId is correct.
                     if (int.TryParse(systemUser?.PartyId, out int ownerParsed) && ownerParsed != partyId)
                     {
@@ -112,8 +77,8 @@ namespace Altinn.AccessManagement.Integration.Clients
                 }
                 else
                 {
-                    HttpStatusCode statusCode = response.StatusCode;
-                    _logger.LogError("Fetching system user failed with status code: {statusCode}, details: {responseContent}", statusCode, responseContent);
+                    string content = await response.Content.ReadAsStringAsync(cancellationToken);
+                    _logger.LogError("Fetching system user failed with status code: {statusCode}, details: {responseContent}", response.StatusCode, content);
                 }
             }
             catch (Exception ex)
@@ -134,25 +99,22 @@ namespace Altinn.AccessManagement.Integration.Clients
             {
                 string endpointUrl = $"systemregister/{systemId}/rights?useoldformatforapp=true";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
-                _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-                HttpResponseMessage response = await _client.GetAsync(endpointUrl, cancellationToken);
 
-                string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, cancellationToken: cancellationToken);
 
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    result = JsonSerializer.Deserialize<List<DefaultRight>>(responseContent, _serializerOptions);
-                    return result;
+                    return await response.Content.ReadFromJsonAsync<List<DefaultRight>>(_serializerOptions, cancellationToken);
                 }
                 else
                 {
-                    HttpStatusCode statusCode = response.StatusCode;
-                    _logger.LogError("Fetching system user default rights failed with status code: {statusCode}, details: {responseContent}", statusCode, responseContent);
+                    string content = await response.Content.ReadAsStringAsync(cancellationToken);
+                    _logger.LogError("Fetching system user default rights failed with status code: {statusCode}, content: {content}", response.StatusCode, content);
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "AccessManagement // AuthenticationClient // GetSystemUser // Exception");
+                _logger.LogError(ex, "AccessManagement // AuthenticationClient // GetDefaultRightsForRegisteredSystem // Exception");
                 throw;
             }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Extensions/IntegrationDependencyInjectionExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Extensions/IntegrationDependencyInjectionExtensions.cs
@@ -31,8 +31,8 @@ public static class IntegrationDependencyInjectionExtensions
         builder.Services.AddHttpClient<IAccessListsAuthorizationClient, AccessListAuthorizationClient>();
         builder.Services.AddHttpClient<IAltinnRolesClient, AltinnRolesClient>();
         builder.Services.AddHttpClient<IAltinn2RightsClient, Altinn2RightsClient>();
-        builder.Services.AddSingleton<IAuthenticationClient, AuthenticationClient>();
-        builder.Services.AddSingleton<IResourceRegistryClient, ResourceRegistryClient>();
+        builder.Services.AddHttpClient<IAuthenticationClient, AuthenticationClient>();
+        builder.Services.AddHttpClient<IResourceRegistryClient, ResourceRegistryClient>();
 
         return builder;
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PolicyInformationPointControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PolicyInformationPointControllerTest.cs
@@ -51,6 +51,7 @@ public class PolicyInformationPointControllerTest : IClassFixture<CustomWebAppli
                 services.AddSingleton(delegationMetadataRepositoryMock);
                 services.AddSingleton<IPartiesClient, PartiesClientMock>();
                 services.AddSingleton<IProfileClient, ProfileClientMock>();
+                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
             });
         }).CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/AuthenticationMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/AuthenticationMock.cs
@@ -1,14 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Text.Json;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.Core.Models.Authentication;
-using Altinn.AccessManagement.Tests.Util;
-using Altinn.Platform.Register.Models;
-using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 
 namespace Altinn.AccessManagement.Tests.Mocks
 {
@@ -18,9 +10,6 @@ namespace Altinn.AccessManagement.Tests.Mocks
     public class AuthenticationMock : IAuthenticationClient
     {
         private readonly JsonSerializerOptions _jsonSerializerOptions = new() { PropertyNameCaseInsensitive = true };
-
-        /// <inheritdoc/>
-        public async Task<string> RefreshToken(CancellationToken cancellationToken = default) => await Task.FromResult(PrincipalUtil.GetAccessToken("sbl-authorization"));
 
         /// <inheritdoc/>
         public async Task<SystemUser> GetSystemUser(int partyId, string systemUserId, CancellationToken cancellationToken = default)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Removed some unused helpers setting DefaultRequestHeaders
- Rewrite of AuthenticationClient to not use DefaultRequestHeaders and use HttpRequestMessage
- Removed unused Refresh token method no longer used after AM and BFF split

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
