### PR TITLE
Avoid calling GetAuthInfo

### DIFF
--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/XacmlResourceAttributes.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/XacmlResourceAttributes.cs
@@ -59,5 +59,10 @@ namespace Altinn.Platform.Authorization.Models
         /// Gets or sets the value for resource party uuid attribute
         /// </summary>
         public Guid PartyUuid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value for resource endevent attribute
+        /// </summary>
+        public string EndEventValue { get; set; }
     }
 }

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Authorization.ABAC.Constants;
@@ -38,7 +36,6 @@ namespace Altinn.Platform.Authorization.Services.Implementation
     {
         private readonly string _uidUserProfileCacheKeyPrefix = "profile:uid:";
         private readonly string _pidUserProfileCacheKeyPrefix = "profile:pid:";
-        private ILogger<ContextHandler> _logger;
 
 #pragma warning disable SA1401 // Fields should be private
 #pragma warning disable SA1600 // Elements should be documented
@@ -70,9 +67,8 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// <param name="prp">service handling policy retireval</param>
         /// <param name="accessManagementWrapper">accessmanagement pip api wrapper</param>
         /// <param name="featureManager">Feature manager</param>
-        /// <param name="logger">the logger</param>
         public ContextHandler(
-            IInstanceMetadataRepository policyInformationRepository, IRoles rolesWrapper, IOedRoleAssignmentWrapper oedRolesWrapper, IParties partiesWrapper, IProfile profileWrapper, IMemoryCache memoryCache, IOptions<GeneralSettings> settings, IRegisterService registerService, IPolicyRetrievalPoint prp, IAccessManagementWrapper accessManagementWrapper, IFeatureManager featureManager, ILogger<ContextHandler> logger)
+            IInstanceMetadataRepository policyInformationRepository, IRoles rolesWrapper, IOedRoleAssignmentWrapper oedRolesWrapper, IParties partiesWrapper, IProfile profileWrapper, IMemoryCache memoryCache, IOptions<GeneralSettings> settings, IRegisterService registerService, IPolicyRetrievalPoint prp, IAccessManagementWrapper accessManagementWrapper, IFeatureManager featureManager)
         {
             _policyInformationRepository = policyInformationRepository;
             _rolesWrapper = rolesWrapper;
@@ -85,7 +81,6 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             _prp = prp;
             _accessManagementWrapper = accessManagementWrapper;
             _featureManager = featureManager;
-            _logger = logger;
         }
 
         /// <inheritdoc/>
@@ -112,12 +107,6 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
             if (!resourceAttributeComplete && !string.IsNullOrEmpty(resourceAttributes.InstanceValue))
             {
-                if (_logger != null)
-                {
-                    _logger.LogError("Authinfo debug3a {Instance} - {Request}", resourceAttributes.InstanceValue, JsonSerializer.Serialize(request));
-                    _logger.LogError("Authinfo debug3b {Instance} - {ResAttr}", resourceAttributes.InstanceValue, JsonSerializer.Serialize(resourceAttributes));
-                }
-
                 Instance instanceData = null;
                 if (!_generalSettings.UseStorageApiForInstanceAuthInfo)
                 {

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
@@ -167,7 +167,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 !string.IsNullOrEmpty(resourceAttributes.AppValue) &&
                 !string.IsNullOrEmpty(resourceAttributes.InstanceValue) &&
                 !string.IsNullOrEmpty(resourceAttributes.ResourcePartyValue) &&
-                !string.IsNullOrEmpty(resourceAttributes.TaskValue))
+                (!string.IsNullOrEmpty(resourceAttributes.TaskValue) || !string.IsNullOrEmpty(resourceAttributes.EndEventValue)))
             {
                 // The resource attributes are complete
                 resourceAttributeComplete = true;
@@ -288,6 +288,11 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.TaskAttribute))
                 {
                     resourceAttributes.TaskValue = attribute.AttributeValues.First().Value;
+                }
+
+                if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.EndEventAttribute))
+                {
+                    resourceAttributes.EndEventValue = attribute.AttributeValues.First().Value;
                 }
 
                 if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.AppResourceAttribute))

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
@@ -114,7 +114,8 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             {
                 if (_logger != null)
                 {
-                    _logger.LogError("Authinfo debug3 {Instance} - {ResAttr}", resourceAttributes.InstanceValue, JsonSerializer.Serialize(resourceAttributes));
+                    _logger.LogError("Authinfo debug3a {Instance} - {Request}", resourceAttributes.InstanceValue, JsonSerializer.Serialize(request));
+                    _logger.LogError("Authinfo debug3b {Instance} - {ResAttr}", resourceAttributes.InstanceValue, JsonSerializer.Serialize(resourceAttributes));
                 }
 
                 Instance instanceData = null;

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
@@ -114,7 +114,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             {
                 if (_logger != null)
                 {
-                    _logger.LogError("Authinfo debug2 {Instance} - {ResAttr}", resourceAttributes.InstanceValue, JsonSerializer.Serialize(resourceAttributes.InstanceValue));
+                    _logger.LogError("Authinfo debug3 {Instance} - {ResAttr}", resourceAttributes.InstanceValue, JsonSerializer.Serialize(resourceAttributes));
                 }
 
                 Instance instanceData = null;

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Authorization.ABAC.Constants;
@@ -36,6 +37,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
     {
         private readonly string _uidUserProfileCacheKeyPrefix = "profile:uid:";
         private readonly string _pidUserProfileCacheKeyPrefix = "profile:pid:";
+        private ILogger<ContextHandler> _logger;
 
 #pragma warning disable SA1401 // Fields should be private
 #pragma warning disable SA1600 // Elements should be documented
@@ -67,8 +69,9 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// <param name="prp">service handling policy retireval</param>
         /// <param name="accessManagementWrapper">accessmanagement pip api wrapper</param>
         /// <param name="featureManager">Feature manager</param>
+        /// <param name="logger">the logger</param>
         public ContextHandler(
-            IInstanceMetadataRepository policyInformationRepository, IRoles rolesWrapper, IOedRoleAssignmentWrapper oedRolesWrapper, IParties partiesWrapper, IProfile profileWrapper, IMemoryCache memoryCache, IOptions<GeneralSettings> settings, IRegisterService registerService, IPolicyRetrievalPoint prp, IAccessManagementWrapper accessManagementWrapper, IFeatureManager featureManager)
+            IInstanceMetadataRepository policyInformationRepository, IRoles rolesWrapper, IOedRoleAssignmentWrapper oedRolesWrapper, IParties partiesWrapper, IProfile profileWrapper, IMemoryCache memoryCache, IOptions<GeneralSettings> settings, IRegisterService registerService, IPolicyRetrievalPoint prp, IAccessManagementWrapper accessManagementWrapper, IFeatureManager featureManager, ILogger<ContextHandler> logger)
         {
             _policyInformationRepository = policyInformationRepository;
             _rolesWrapper = rolesWrapper;
@@ -81,6 +84,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             _prp = prp;
             _accessManagementWrapper = accessManagementWrapper;
             _featureManager = featureManager;
+            _logger = logger;
         }
 
         /// <inheritdoc/>
@@ -107,6 +111,11 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
             if (!resourceAttributeComplete && !string.IsNullOrEmpty(resourceAttributes.InstanceValue))
             {
+                if (_logger != null)
+                {
+                    _logger.LogError("Authinfo debug {ResAttr}", JsonSerializer.Serialize(resourceAttributes.InstanceValue));
+                }
+
                 Instance instanceData = null;
                 if (!_generalSettings.UseStorageApiForInstanceAuthInfo)
                 {

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -113,7 +114,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             {
                 if (_logger != null)
                 {
-                    _logger.LogError("Authinfo debug {ResAttr}", JsonSerializer.Serialize(resourceAttributes.InstanceValue));
+                    _logger.LogError("Authinfo debug2 {Instance} - {ResAttr}", resourceAttributes.InstanceValue, JsonSerializer.Serialize(resourceAttributes.InstanceValue));
                 }
 
                 Instance instanceData = null;

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/DelegationContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/DelegationContextHandler.cs
@@ -40,7 +40,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// <param name="prp">the policy retrieval point service</param>
         /// <param name="accMgmt">Access Management PIP API wrapper</param>
         public DelegationContextHandler(IInstanceMetadataRepository policyInformationRepository, IRoles rolesWrapper, IOedRoleAssignmentWrapper oedRolesWrapper, IParties partiesWrapper, IProfile profileWrapper, IMemoryCache memoryCache, IOptions<GeneralSettings> settings, IRegisterService registerService, IPolicyRetrievalPoint prp, IAccessManagementWrapper accMgmt, IFeatureManager featureManager)
-            : base(policyInformationRepository, rolesWrapper, oedRolesWrapper, partiesWrapper, profileWrapper, memoryCache, settings, registerService, prp, accMgmt, featureManager, null)
+            : base(policyInformationRepository, rolesWrapper, oedRolesWrapper, partiesWrapper, profileWrapper, memoryCache, settings, registerService, prp, accMgmt, featureManager)
         {
         }
 

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/DelegationContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/DelegationContextHandler.cs
@@ -40,7 +40,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// <param name="prp">the policy retrieval point service</param>
         /// <param name="accMgmt">Access Management PIP API wrapper</param>
         public DelegationContextHandler(IInstanceMetadataRepository policyInformationRepository, IRoles rolesWrapper, IOedRoleAssignmentWrapper oedRolesWrapper, IParties partiesWrapper, IProfile profileWrapper, IMemoryCache memoryCache, IOptions<GeneralSettings> settings, IRegisterService registerService, IPolicyRetrievalPoint prp, IAccessManagementWrapper accMgmt, IFeatureManager featureManager)
-            : base(policyInformationRepository, rolesWrapper, oedRolesWrapper, partiesWrapper, profileWrapper, memoryCache, settings, registerService, prp, accMgmt, featureManager)
+            : base(policyInformationRepository, rolesWrapper, oedRolesWrapper, partiesWrapper, profileWrapper, memoryCache, settings, registerService, prp, accMgmt, featureManager, null)
         {
         }
 


### PR DESCRIPTION
## Description
- Added EndEventValue to XacmlResourceAttributes
- Avoid calling storage for auth info if either task og endvalue is available - not only task

## Related Issue(s)
-  storage #677

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
