### PR TITLE
chores: check if key vault endpoint exists

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
@@ -123,7 +123,7 @@ internal static partial class AccessManagementHost
         {
             var appsettings = new AccessManagementAppsettings(builder.Configuration);
             appsettings.Platform.Token.TestTool.Environment = appsettings.Environment;
-            if (builder.Configuration.GetValue<string>("kvSetting:Endpoint") is var endpoint && endpoint != null)
+            if (builder.Configuration.GetValue<string>("kvSetting:SecretUri") is var endpoint && endpoint != null)
             {
                 appsettings.Platform.Token.KeyVault.Endpoint = new Uri(endpoint);
             }


### PR DESCRIPTION
Sync job will not start as it default to use Test Token Tool Generator if key vault configuration do not exsists. However, access management host check wrong field..

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
