### PR TITLE
chores: use platform access token instead of A2 token?? when calling role stream

### DIFF
--- a/src/libs/Altinn.Authorization.Integration/src/Altinn.Authorization.Integration.Platform/Register/RoleStreamEndpoint.cs
+++ b/src/libs/Altinn.Authorization.Integration/src/Altinn.Authorization.Integration.Platform/Register/RoleStreamEndpoint.cs
@@ -16,7 +16,7 @@ public partial class RegisterClient
             RequestComposer.WithSetUri(RegisterOptions.Value.Endpoint, "/register/api/v2/internal/parties/external-roles/assignments/events/stream"),
             RequestComposer.WithSetUri(nextPage),
             RequestComposer.WithAppendQueryParam("fields", fields),
-            RequestComposer.WithJWTToken(await TokenGenerator.CreatePlatformAccessToken(cancellationToken))
+            RequestComposer.WithPlatformAccessToken(await TokenGenerator.CreatePlatformAccessToken(cancellationToken))
         ];
 
         var response = await HttpClient.SendAsync(RequestComposer.New([.. request]), cancellationToken);


### PR DESCRIPTION
## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
