### PR TITLE
Bugfix - PostgresException - Nullable UUID in Connection Query

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ConnectionController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ConnectionController.cs
@@ -196,12 +196,6 @@ public class ConnectionController(IHttpContextAccessor accessor, IConnectionServ
             return BadRequest();
         }
 
-        var audit = new ChangeRequestOptions()
-        {
-            ChangedBy = Accessor.GetPartyUuid(),
-            ChangedBySystem = AuditDefaults.EnduserApi
-        };
-
         var res = await connectionService.GetPackages(fromId: from, toId: to);
 
         return Ok(res);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Models/Connection.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Models/Connection.cs
@@ -13,7 +13,7 @@ public class Connection
     /// <summary>
     /// The entity identity the connection is from (origin, client, source etc) 
     /// </summary>
-    public Guid? FromId { get; set; }
+    public Guid FromId { get; set; }
 
     /// <summary>
     /// The role To identifies as
@@ -23,7 +23,7 @@ public class Connection
     /// <summary>
     /// The entity identity the connection is to (destination, agent, etc)
     /// </summary>
-    public Guid? ToId { get; set; }
+    public Guid ToId { get; set; }
 
     /// <summary>
     /// The entity betweeen from and to. When connection is delegated.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/Helpers/GenericFilterBuilder.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/Helpers/GenericFilterBuilder.cs
@@ -43,6 +43,19 @@ public class GenericFilterBuilder<T> : IEnumerable<GenericFilter>
     /// </summary>
     /// <typeparam name="TProperty">The type of the property.</typeparam>
     /// <param name="property">An expression selecting the property to filter on.</param>
+    /// <returns>The current instance of <see cref="GenericFilterBuilder{T}"/>, enabling a fluent API.</returns>
+    public GenericFilterBuilder<T> IsNull<TProperty>(Expression<Func<T, TProperty>> property)
+    {
+        var propertyInfo = ExtractPropertyInfo(property);
+        _filters.Add(new GenericFilter(propertyInfo.Name, null, FilterComparer.Equals));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an equality filter condition for the specified property.
+    /// </summary>
+    /// <typeparam name="TProperty">The type of the property.</typeparam>
+    /// <param name="property">An expression selecting the property to filter on.</param>
     /// <param name="values">The value the property should equal.</param>
     /// <returns>The current instance of <see cref="GenericFilterBuilder{T}"/>, enabling a fluent API.</returns>
     public GenericFilterBuilder<T> In<TProperty>(Expression<Func<T, TProperty>> property, IEnumerable<TProperty> values)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Definitions/ConnectionDefinition.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Definitions/ConnectionDefinition.cs
@@ -131,8 +131,8 @@ public class ConnectionDefinition : BaseDbDefinition<Connection>, IDbDefinition
         sb.AppendLine("SELECT a.id, a.fromid, NULL::uuid AS viaid, NULL::uuid AS viaroleid, a.toid, a.roleid,");
         sb.AppendLine("'DIRECT' AS source, 1 AS isdirect, 0 AS isparent, 0 AS isrolemap, 0 AS iskeyrole");
         sb.AppendLine("FROM dbo.assignment a");
-        sb.AppendLine("WHERE a.fromid = COALESCE(@fromid::uuid, a.fromid)");
-        sb.AppendLine("AND a.toid   = COALESCE(@toid::uuid, a.toid)");
+        sb.AppendLine("WHERE a.fromid = COALESCE(@fromid, a.fromid)::uuid");
+        sb.AppendLine("AND a.toid   = COALESCE(@toid, a.toid)::uuid");
 
         sb.AppendLine("UNION ALL");
 
@@ -151,8 +151,8 @@ public class ConnectionDefinition : BaseDbDefinition<Connection>, IDbDefinition
         sb.AppendLine("0 AS iskeyrole");
         sb.AppendLine("FROM dbo.assignment a");
         sb.AppendLine("JOIN dbo.entity fe   ON a.fromid = fe.parentid");
-        sb.AppendLine("WHERE fe.id    = COALESCE(@fromid::uuid, fe.id)");
-        sb.AppendLine("AND a.toid   = COALESCE(@toid::uuid, a.toid)");
+        sb.AppendLine("WHERE fe.id    = COALESCE(@fromid, fe.id)::uuid");
+        sb.AppendLine("AND a.toid   = COALESCE(@toid, a.toid)::uuid");
 
         sb.AppendLine("),");
 
@@ -199,8 +199,8 @@ public class ConnectionDefinition : BaseDbDefinition<Connection>, IDbDefinition
         sb.AppendLine("LEFT JOIN dbo.entity ve ON a.viaid = ve.id");
         sb.AppendLine("LEFT JOIN dbo.role vr ON a.viaroleid = vr.id");
         
-        sb.AppendLine("WHERE a.fromid = COALESCE(@fromid::uuid, a.fromid)");
-        sb.AppendLine("AND a.toid = COALESCE(@toid::uuid, a.toid);");
+        sb.AppendLine("WHERE a.fromid = COALESCE(@fromid, a.fromid)::uuid");
+        sb.AppendLine("AND a.toid = COALESCE(@toid, a.toid)::uuid;");
 
         return sb.ToString();
     }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Definitions/ConnectionDefinition.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Definitions/ConnectionDefinition.cs
@@ -22,9 +22,9 @@ public class ConnectionDefinition : BaseDbDefinition<Connection>, IDbDefinition
             def.SetType(DbDefinitionType.Query);
 
             def.RegisterProperty(t => t.Id);
-            def.RegisterProperty(t => t.FromId, nullable: true);
+            def.RegisterProperty(t => t.FromId);
             def.RegisterProperty(t => t.RoleId);
-            def.RegisterProperty(t => t.ToId, nullable: true);
+            def.RegisterProperty(t => t.ToId);
             def.RegisterProperty(t => t.FacilitatorId, nullable: true);
             def.RegisterProperty(t => t.FacilitatorRoleId, nullable: true);
 
@@ -35,9 +35,9 @@ public class ConnectionDefinition : BaseDbDefinition<Connection>, IDbDefinition
             def.RegisterProperty(t => t.IsRoleMap);
             def.RegisterProperty(t => t.IsKeyRole);
 
-            def.RegisterExtendedProperty<ExtConnection, Entity>(t => t.FromId, t => t.Id, t => t.From, optional: true);
+            def.RegisterExtendedProperty<ExtConnection, Entity>(t => t.FromId, t => t.Id, t => t.From);
             def.RegisterExtendedProperty<ExtConnection, Role>(t => t.RoleId, t => t.Id, t => t.Role);
-            def.RegisterExtendedProperty<ExtConnection, Entity>(t => t.ToId, t => t.Id, t => t.To, optional: true);
+            def.RegisterExtendedProperty<ExtConnection, Entity>(t => t.ToId, t => t.Id, t => t.To);
             def.RegisterExtendedProperty<ExtConnection, Entity>(t => t.FacilitatorId, t => t.Id, t => t.Facilitator, optional: true);
             def.RegisterExtendedProperty<ExtConnection, Role>(t => t.FacilitatorRoleId, t => t.Id, t => t.FacilitatorRole, optional: true);
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Definitions/ConnectionPackageDefinition.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Definitions/ConnectionPackageDefinition.cs
@@ -54,8 +54,8 @@ public class ConnectionPackageDefinition : BaseDbDefinition<ConnectionPackage>, 
             sb.AppendLine("SELECT a.id, a.fromid, NULL::uuid AS viaid, NULL::uuid AS viaroleid, a.toid, a.roleid,");
             sb.AppendLine("'DIRECT' AS source, 1 AS isdirect, 0 AS isparent, 0 AS isrolemap, 0 AS iskeyrole");
             sb.AppendLine("FROM dbo.assignment a");
-            sb.AppendLine("WHERE a.fromid = COALESCE(@fromid::uuid, a.fromid)");
-            sb.AppendLine("AND a.toid   = COALESCE(@toid::uuid, a.toid)");
+            sb.AppendLine("WHERE a.fromid = COALESCE(@fromid, a.fromid)::uuid");
+            sb.AppendLine("AND a.toid   = COALESCE(@toid, a.toid)::uuid");
 
             sb.AppendLine("UNION ALL");
 
@@ -74,8 +74,8 @@ public class ConnectionPackageDefinition : BaseDbDefinition<ConnectionPackage>, 
             sb.AppendLine("0 AS iskeyrole");
             sb.AppendLine("FROM dbo.assignment a");
             sb.AppendLine("JOIN dbo.entity fe   ON a.fromid = fe.parentid");
-            sb.AppendLine("WHERE fe.id    = COALESCE(@fromid::uuid, fe.id)");
-            sb.AppendLine("AND a.toid   = COALESCE(@toid::uuid, a.toid)");
+            sb.AppendLine("WHERE fe.id    = COALESCE(@fromid, fe.id)::uuid");
+            sb.AppendLine("AND a.toid   = COALESCE(@toid, a.toid)::uuid");
 
             sb.AppendLine("),");
 
@@ -115,8 +115,8 @@ public class ConnectionPackageDefinition : BaseDbDefinition<ConnectionPackage>, 
             sb.AppendLine("SELECT result.*");
             sb.AppendLine("FROM result");
 
-            sb.AppendLine("WHERE result.fromid = COALESCE(@fromid::uuid, result.fromid)");
-            sb.AppendLine("AND result.toid = COALESCE(@toid::uuid, result.toid);");
+            sb.AppendLine("WHERE result.fromid = COALESCE(@fromid, result.fromid)::uuid");
+            sb.AppendLine("AND result.toid = COALESCE(@toid, result.toid)::uuid;");
 
 
             def.SetQuery(sb.ToString());

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/ConnectionService.cs
@@ -174,10 +174,26 @@ public class ConnectionService(
         */
 
         var filter = connectionPackageRepository.CreateFilterBuilder();
-        filter.Equal(t => t.FromId, fromId);
-        filter.Equal(t => t.ToId, toId);
-        return await connectionPackageRepository.Get(filter, cancellationToken: cancellationToken);
 
+        if (fromId.HasValue)
+        {
+            filter.Equal(t => t.FromId, fromId.Value);
+        }
+        else
+        {
+            filter.IsNull(t => fromId);
+        }
+
+        if (toId.HasValue)
+        {
+            filter.Equal(t => t.ToId, toId.Value);
+        }
+        else
+        {
+            filter.IsNull(t => t.ToId);
+        }
+
+        return await connectionPackageRepository.Get(filter, cancellationToken: cancellationToken);
     }
 
     private async Task<IEnumerable<ExtConnectionPackage>> GetConnectionPackages(Guid fromId, Guid toId, Guid packageId, CancellationToken cancellationToken = default)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/ConnectionService.cs
@@ -28,7 +28,7 @@ public class ConnectionService(
     {
         var filter = connectionRepository.CreateFilterBuilder();
         filter.Equal(t => t.ToId, toId);
-        filter.Equal(t => t.FromId, null);
+        filter.IsNull(t => t.FromId);
         return await connectionRepository.GetExtended(filter, cancellationToken: cancellationToken);
     }
 
@@ -37,7 +37,7 @@ public class ConnectionService(
     {
         var filter = connectionRepository.CreateFilterBuilder();
         filter.Equal(t => t.FromId, fromId);
-        filter.Equal(t => t.ToId, null);
+        filter.IsNull(t => t.ToId);
         return await connectionRepository.GetExtended(filter, cancellationToken: cancellationToken);
     }
 
@@ -394,7 +394,7 @@ public static class ConnectionConverter
         return new CreateDelegationResponse()
         {
             DelegationId = connection.Id,
-            FromEntityId = connection.FromId.Value
+            FromEntityId = connection.FromId
         };
     }
 


### PR DESCRIPTION
## Description
Fixed query to support nullable uuid in connection and connectionpackage query.

## Fix
`WHERE fe.id    = COALESCE(@fromid::uuid, fe.id)")` => `WHERE a.fromid = COALESCE(@fromid, a.fromid)::uuid`
`@fromid::uuid` will never be null, and never hit a.fromid

## Related Issue(s)
- #656 
- #669 