### PR TITLE
AccMgmt | Maskinporten API | GET maskinporten/delegations without scope param

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/Interfaces/IResourceAdministrationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/Interfaces/IResourceAdministrationPoint.cs
@@ -26,8 +26,9 @@ namespace Altinn.AccessManagement.Core.Services.Interfaces
         /// Gets a list of Resources from ResourceRegister
         /// </summary>
         /// <param name="scope">The scope of the resource</param>
+        /// <param name="cancellationToken"> Cancellation token to cancel the operation</param>
         /// <returns>resource list based on given scope</returns>
-        Task<IEnumerable<ServiceResource>> GetResources(string scope);
+        Task<IEnumerable<ServiceResource>> GetResources(string scope, CancellationToken cancellationToken);
 
         /// <summary>
         /// Integration point for retrieving a single resoure by it's resource id

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/Interfaces/IResourceAdministrationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/Interfaces/IResourceAdministrationPoint.cs
@@ -27,7 +27,7 @@ namespace Altinn.AccessManagement.Core.Services.Interfaces
         /// </summary>
         /// <param name="scope">The scope of the resource</param>
         /// <returns>resource list based on given scope</returns>
-        Task<List<ServiceResource>> GetResources(string scope);
+        Task<IEnumerable<ServiceResource>> GetResources(string scope);
 
         /// <summary>
         /// Integration point for retrieving a single resoure by it's resource id

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/MaskinportenSchemaService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/MaskinportenSchemaService.cs
@@ -358,8 +358,8 @@ namespace Altinn.AccessManagement.Core.Services
         {
             List<Delegation> delegations = new List<Delegation>();
 
-            List<ServiceResource> resources = await _resourceAdministrationPoint.GetResources(scopes);
-            if (resources.Count == 0)
+            IEnumerable<ServiceResource> resources = await _resourceAdministrationPoint.GetResources(scopes);
+            if (!resources.Any())
             {
                 return delegations;
             }
@@ -373,7 +373,7 @@ namespace Altinn.AccessManagement.Core.Services
             return await BuildDelegationsResponse(delegationChanges, resources);
         }
 
-        private async Task<List<Delegation>> BuildDelegationsResponse(List<DelegationChange> delegationChanges, List<ServiceResource> resources = null)
+        private async Task<List<Delegation>> BuildDelegationsResponse(List<DelegationChange> delegationChanges, IEnumerable<ServiceResource> resources = null)
         {
             List<Delegation> delegations = new List<Delegation>();
             List<int> parties = delegationChanges.Select(d => d.OfferedByPartyId).ToList();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/MaskinportenSchemaService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/MaskinportenSchemaService.cs
@@ -358,7 +358,7 @@ namespace Altinn.AccessManagement.Core.Services
         {
             List<Delegation> delegations = new List<Delegation>();
 
-            IEnumerable<ServiceResource> resources = await _resourceAdministrationPoint.GetResources(scopes);
+            IEnumerable<ServiceResource> resources = await _resourceAdministrationPoint.GetResources(scopes, cancellationToken);
             if (!resources.Any())
             {
                 return delegations;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ResourceAdministrationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ResourceAdministrationPoint.cs
@@ -53,7 +53,7 @@ namespace Altinn.AccessManagement.Core.Services
 
             if (string.IsNullOrWhiteSpace(scope))
             {
-                return resources.Where(r => r.ResourceType == ResourceType.MaskinportenSchema && r.ResourceReferences != null);
+                return resources.Where(r => r.ResourceType == ResourceType.MaskinportenSchema && r.ResourceReferences != null && r.ResourceReferences.Any(rf => rf.ReferenceType == ReferenceType.MaskinportenScope));
             }
             else
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ResourceAdministrationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ResourceAdministrationPoint.cs
@@ -45,11 +45,9 @@ namespace Altinn.AccessManagement.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<ServiceResource>> GetResources(string scope)
+        public async Task<IEnumerable<ServiceResource>> GetResources(string scope, CancellationToken cancellationToken)
         {
-            List<ServiceResource> filteredResources = new List<ServiceResource>();
-
-            List<ServiceResource> resources = await _contextRetrievalService.GetResources();
+            List<ServiceResource> resources = await _contextRetrievalService.GetResources(cancellationToken);
 
             if (string.IsNullOrWhiteSpace(scope))
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ResourceAdministrationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ResourceAdministrationPoint.cs
@@ -45,21 +45,20 @@ namespace Altinn.AccessManagement.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<List<ServiceResource>> GetResources(string scope)
+        public async Task<IEnumerable<ServiceResource>> GetResources(string scope)
         {
             List<ServiceResource> filteredResources = new List<ServiceResource>();
 
             List<ServiceResource> resources = await _contextRetrievalService.GetResources();
 
-            foreach (ServiceResource resource in resources.Where(r => r.ResourceType == ResourceType.MaskinportenSchema && r.ResourceReferences != null))
+            if (string.IsNullOrWhiteSpace(scope))
             {
-                foreach (ResourceReference reference in resource.ResourceReferences.Where(rf => rf.ReferenceType == ReferenceType.MaskinportenScope && rf.Reference.Equals(scope)))
-                {
-                    filteredResources.Add(resource);
-                }
+                return resources.Where(r => r.ResourceType == ResourceType.MaskinportenSchema && r.ResourceReferences != null);
             }
-
-            return filteredResources;
+            else
+            {
+                return resources.Where(r => r.ResourceType == ResourceType.MaskinportenSchema && r.ResourceReferences != null && r.ResourceReferences.Any(rf => rf.ReferenceType == ReferenceType.MaskinportenScope && rf.Reference.Equals(scope)));
+            }
         }
 
         /// <inheritdoc />

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Utilities/MaskinportenSchemaAuthorizer.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Utilities/MaskinportenSchemaAuthorizer.cs
@@ -21,6 +21,11 @@ namespace Altinn.AccessManagement.Utilities
                 return true;
             }
 
+            if (string.IsNullOrWhiteSpace(scope))
+            {
+                return false;
+            }
+
             return HasAuthorizedScopePrefixClaim(new[] { scope }, claims);
         }
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/DelegationsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/DelegationsControllerTest.cs
@@ -1454,28 +1454,34 @@ namespace Altinn.AccessManagement.Tests.Controllers
         }
 
         /// <summary>
-        /// Test case: GetMaskinportenSchemaDelegations without sending scopes
-        /// Expected: GetMaskinportenSchemaDelegations returns badrequest
+        /// Test case: GetMaskinportenDelegations authorized with admin scope, without specifying filter scope param
+        /// Expected: GetMaskinportenDelegations returns OK
         /// </summary>
         [Fact]
-        public async Task GetMaskinportenSchemaDelegations_Admin_MissingScope()
+        public async Task GetMaskinportenDelegations_Admin_WithoutScope_Valid()
         {
             // Arrange
             string token = PrincipalUtil.GetOrgToken("DIGDIR", "991825827", "altinn:maskinporten/delegations.admin");
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            string expected = "The scope field is required.";
+            List<string> resourceIds = new List<string>
+            {
+                "nav_aa_distribution",
+                "appid-123"
+            };
+            List<MPDelegationExternal> expectedDelegations = GetExpectedMaskinportenSchemaDelegations("810418672", "810418192", resourceIds);
 
             // Act
-            int supplierOrg = 810418362;
-            int consumerOrg = 810418532;
+            int supplierOrg = 810418672;
+            int consumerOrg = 810418192;
+
             HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope=");
             string responseContent = await response.Content.ReadAsStringAsync();
-            ValidationProblemDetails errorResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
+            List<MPDelegationExternal> actualDelegations = JsonSerializer.Deserialize<List<MPDelegationExternal>>(responseContent);
 
             // Assert
-            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            Assert.Equal(expected, errorResponse.Errors["scope"][0]);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            AssertionUtil.AssertCollections(expectedDelegations, actualDelegations, AssertionUtil.AssertDelegationEqual);
         }
 
         /// <summary>

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinportenSchemaControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinportenSchemaControllerTest.cs
@@ -550,8 +550,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
         }
 
         /// <summary>
-        /// Test case: GetMaskinportenDelegations without sending scopes
-        /// Expected: GetMaskinportenDelegations returns badrequest
+        /// Test case: GetMaskinportenDelegations authorized with admin scope, without specifying filter scope param
+        /// Expected: GetMaskinportenDelegations returns OK
         /// </summary>
         [Fact]
         public async Task GetMaskinportenDelegations_Admin_WithoutScope_Valid()

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/Maskinporten/DigDir/Maskinporten_AsAdmin_WithoutScopeOrOrgs_BadRequest.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/Maskinporten/DigDir/Maskinporten_AsAdmin_WithoutScopeOrOrgs_BadRequest.bru
@@ -1,0 +1,51 @@
+meta {
+  name: Maskinporten_AsAdmin_WithoutScopeOrOrgs_BadRequest
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/maskinporten/delegations
+  body: none
+  auth: inherit
+}
+
+params:query {
+  ~supplierOrg: {{supplierOrg}}
+  ~consumerOrg: {{consumerOrg}}
+  ~scope: {{scope}}
+}
+
+headers {
+  Accept: application/json
+}
+
+script:pre-request {
+  const testdata = require(`./Testdata/maskinportenschema/${bru.getEnvVar("tokenEnv")}testdata.json`);
+  const sharedtestdata = require(`./Testdata/sharedtestdata.json`);
+  bru.setVar("supplierOrg", testdata.org1.orgno);
+  bru.setVar("consumerOrg", testdata.org2.orgno);
+  bru.setVar("scope", sharedtestdata.scopes.k6Read);
+  
+  var getTokenParameters = {
+    auth_org: testdata.digdir.partyid,
+    auth_orgNo: testdata.digdir.orgno,
+    auth_tokenType: sharedtestdata.authTokenType.enterprise,
+    auth_scopes: sharedtestdata.auth_scopes.maskinportenAdmin
+  }
+  
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken",  token);
+}
+
+tests {
+  // Should be the same as the .bru request file. Used as prefix in test name which also shows in test result in pipeline.
+  const requestName = "Maskinporten_AsAdmin_WithoutScopeOrOrgs_BadRequest";
+  const body = res.getBody();
+  
+  test(requestName + "|HttpStatus.BadRequest and Body.Data with ProblemDetails", function() {
+    expect(res.status).to.equal(400);
+    assert.equal(body.status, "400");
+    assert.equal(body.title, "Query without parameter; scope, must provide at least one of; supplierOrg, consumerOrg");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/Maskinporten/DigDir/Maskinporten_AsAdmin_WithoutUrnScope_Ok.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/Maskinporten/DigDir/Maskinporten_AsAdmin_WithoutUrnScope_Ok.bru
@@ -1,0 +1,52 @@
+meta {
+  name: Maskinporten_AsAdmin_WithoutUrnScope_Ok
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/maskinporten/delegations?supplierOrg={{supplierOrg}}&consumerOrg={{consumerOrg}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  supplierOrg: {{supplierOrg}}
+  consumerOrg: {{consumerOrg}}
+  ~scope: {{scope}}
+}
+
+headers {
+  Accept: application/json
+}
+
+script:pre-request {
+  const testdata = require(`./Testdata/maskinportenschema/${bru.getEnvVar("tokenEnv")}testdata.json`);
+  const sharedtestdata = require(`./Testdata/sharedtestdata.json`);
+  bru.setVar("supplierOrg", testdata.org2.orgno);
+  bru.setVar("consumerOrg", testdata.org1.orgno);
+  
+  var getTokenParameters = {
+    auth_org: testdata.digdir.partyid,
+    auth_orgNo: testdata.digdir.orgno,
+    auth_tokenType: sharedtestdata.authTokenType.enterprise,
+    auth_scopes: sharedtestdata.auth_scopes.maskinportenAdmin
+  }
+  
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken",  token);
+}
+
+tests {
+  // Should be the same as the .bru request file. Used as prefix in test name which also shows in test result in pipeline.
+  const testdata = require(`./Testdata/maskinportenschema/${bru.getEnvVar("tokenEnv")}testdata.json`);
+  const requestName = "Maskinporten_AsAdmin_WithoutUrnScope_Ok";
+  const body = res.getBody();
+  
+  test(requestName + "|HttpStatus.OK and Body.Data contain expected delegation", function() {
+    expect(res.status).to.equal(200);
+    expect(body[0]).to.have.property('consumer_org', testdata.org1.orgno);
+    expect(body[0]).to.have.property('supplier_org', testdata.org2.orgno);
+    expect(body[0]).to.have.property('resourceid', 'ttd-am-k6');
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/Maskinporten/DigDir/Maskinporten_AsDigDir_WithoutUrnScope_Forbidden.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/Maskinporten/DigDir/Maskinporten_AsDigDir_WithoutUrnScope_Forbidden.bru
@@ -1,0 +1,50 @@
+meta {
+  name: Maskinporten_AsDigDir_WithoutUrnScope_Forbidden
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/maskinporten/delegations?supplierOrg={{supplierOrg}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  supplierOrg: {{supplierOrg}}
+  ~consumerOrg: {{consumerOrg}}
+  ~scope: {{scope}}
+}
+
+headers {
+  Accept: application/json
+}
+
+script:pre-request {
+  const testdata = require(`./Testdata/maskinportenschema/${bru.getEnvVar("tokenEnv")}testdata.json`);
+  const sharedtestdata = require(`./Testdata/sharedtestdata.json`);
+  bru.setVar("supplierOrg", testdata.org1.orgno);
+  bru.setVar("consumerOrg", testdata.org2.orgno);
+  
+  var getTokenParameters = {
+    auth_org: testdata.digdir.partyid,
+    auth_orgNo: testdata.digdir.orgno,
+    auth_tokenType: sharedtestdata.authTokenType.enterprise,
+    auth_scopes: sharedtestdata.auth_scopes.maskinportenDelegations
+  }
+  
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken",  token);
+}
+
+tests {
+  // Should be the same as the .bru request file. Used as prefix in test name which also shows in test result in pipeline.
+  const requestName = "Maskinporten_AsDigDir_WithoutUrnScope_Forbidden";
+  const body = res.getBody();
+  
+  test(requestName + "|HttpStatus.Forbidden and Body.Data with ProblemDetails", function() {
+    expect(res.status).to.equal(403);
+    assert.equal(body.status, "403");
+    assert.equal(body.title, "Not authorized for lookup of delegations without specifying parameter: scope");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Testdata/sharedtestdata.json
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Testdata/sharedtestdata.json
@@ -6,6 +6,7 @@
     "auth_scopes": {
         "portalEnduser": "altinn:portal/enduser",
         "read": "altinn:instances:read",
+        "maskinportenDelegations": "altinn:maskinporten/delegations",
         "maskinportenAdmin": "altinn:maskinporten/delegations.admin",
         "authorizedParties": "altinn:accessmanagement/authorizedparties",
         "authorizedPartiesResourceOwner": "altinn:accessmanagement/authorizedparties.resourceowner",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Opened up for authorized admin scope to be allowed to lookup maskinporten delegations without specifying scope parameter
- Added input validation as at least one of supplierOrg or consumerOrg must be provided when request is performed without scope
- Added unit tests and bruno automated tests

## Related Issue(s)
- #743

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
