### PR TITLE
Update PackageService.cs

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/PackageService.cs
@@ -88,6 +88,11 @@ public class PackageService(
     /// <inheritdoc/>
     public async Task<PackageDto> GetPackageByUrnValue(string urnValue)
     {
+        if (!urnValue.StartsWith("urn:") && !urnValue.StartsWith(':'))
+        {
+            urnValue = ":" + urnValue;
+        }
+
         var filter = packageRepository.CreateFilterBuilder();
         filter.Add(t => t.Urn, urnValue, FilterComparer.EndsWith);
         var packages = await packageRepository.GetExtended(filter);


### PR DESCRIPTION
## Description
Bug where multiple packages was returned for a single result query with urnValue as filter.

- Added ':' to start of filterstring if not present

## Related Issue(s)
- #802 
