### PR TITLE
AccMgmt | AuthorizedParties for systemuser fix for unknown users

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/AuthorizedPartyRepoService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/AuthorizedPartyRepoService.cs
@@ -8,8 +8,6 @@ using Altinn.AccessManagement.Core.Repositories.Interfaces;
 using Altinn.AccessManagement.Core.Services.Contracts;
 using Altinn.AccessManagement.Core.Services.Interfaces;
 using Altinn.AccessMgmt.Core.Models;
-using Altinn.AccessMgmt.Persistence.Core.Models;
-using Altinn.AccessMgmt.Persistence.Repositories.Contracts;
 using Altinn.AccessMgmt.Persistence.Services.Contracts;
 using Altinn.AccessMgmt.Persistence.Services.Models;
 using Altinn.Authorization.ProblemDetails;
@@ -19,7 +17,6 @@ namespace Altinn.AccessMgmt.Persistence.Services;
 
 /// <inheritdoc/>
 public class AuthorizedPartyRepoService(
-    IEntityRepository entityRepository,
     IDelegationMetadataRepository resourceDelegationRepository,
     IRelationService relationService,
     IContextRetrievalService contextRetrievalService
@@ -29,16 +26,6 @@ public class AuthorizedPartyRepoService(
     public async Task<Result<IEnumerable<AuthorizedParty>>> Get(Guid toId, CancellationToken cancellationToken = default)
     {
         Dictionary<Guid, AuthorizedParty> parties = new();
-        ValidationErrorBuilder errors = default;
-
-        var toEntity = await entityRepository.GetExtended(toId, cancellationToken: cancellationToken);
-        ValidatePartyIsNotNull(toId, toEntity, ref errors, "$QUERY/to");
-        ValidatePartyIsSystemUser(toEntity, ref errors, "$QUERY/to");
-
-        if (errors.TryBuild(out var errorResult))
-        {
-            return errorResult;
-        }
 
         // Get AccessPackage Delegations
         var connections = await relationService.GetConnectionsFromOthers(toId, null, null, null, cancellationToken: cancellationToken);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed check that party uuid exists in local register import.

SystemUsers aren't synced through Register yet, so only those who have received klientdelegation will actually exist in AccMgmt.

So for AuthorizedParties to work for SystemUsers with App/Resource access we must simply skip this check for now.

## Related Issue(s)
- #869

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
