### PR TITLE
AccMgmt | Move package filter in delegation check query to allAssignableUserPackages

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Repositories/RelationPermissionRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Repositories/RelationPermissionRepository.cs
@@ -57,7 +57,6 @@ public class RelationPermissionRepository : ExtendedRepository<Relation, ExtRela
         	    p.isassignable,
         	    p.isdelegable
         	FROM dbo.package p
-        	WHERE (array_length(@packageIds, 1) IS NULL OR p.id = ANY(@packageIds))
         ),
         mainAdminPackages AS (
         	-- Get all packages for main administrator
@@ -308,7 +307,8 @@ public class RelationPermissionRepository : ExtendedRepository<Relation, ExtRela
         		false AS ismainadminpackage,
         		reason
         	FROM userpackages up
-        	WHERE candelegate = true
+        	WHERE (array_length(@packageIds, 1) IS NULL OR packageid = ANY(@packageIds))
+                AND candelegate = true
         		AND isassignable = TRUE
         		AND (packageurn != 'urn:altinn:accesspackage:hovedadministrator' OR isrolepackage = true)	
 
@@ -336,6 +336,7 @@ public class RelationPermissionRepository : ExtendedRepository<Relation, ExtRela
         	FROM userpackages up
         		CROSS JOIN mainAdminPackages admp
         	WHERE up.packageurn = 'urn:altinn:accesspackage:hovedadministrator'
+                AND (array_length(@packageIds, 1) IS NULL OR admp.packageid = ANY(@packageIds))
         		AND admp.isassignable = true
         )
         SELECT

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/EnduserAPI/Connections/DelegationCheck/GET_Enduser_Conn_AccPcks_DelgCheck_Dagl_IdFilter.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/EnduserAPI/Connections/DelegationCheck/GET_Enduser_Conn_AccPcks_DelgCheck_Dagl_IdFilter.bru
@@ -5,15 +5,15 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/accesspackages/delegationcheck?party={{party}}&packageIds=36c245db-3207-449e-92b1-94cb0a0f3031&packageIds=0195efb8-7c80-7e82-9b4f-7d63e773bbca&packageIds=43becc6a-8c6c-4e9e-bb2f-08fe588ada21
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/accesspackages/delegationcheck?party={{party}}&packageIds=0195efb8-7c80-7e82-9b4f-7d63e773bbca&packageIds=bb0569a6-2268-49b5-9d38-8158b26124c3&packageIds=43becc6a-8c6c-4e9e-bb2f-08fe588ada21
   body: json
   auth: inherit
 }
 
 params:query {
   party: {{party}}
-  packageIds: 36c245db-3207-449e-92b1-94cb0a0f3031
   packageIds: 0195efb8-7c80-7e82-9b4f-7d63e773bbca
+  packageIds: bb0569a6-2268-49b5-9d38-8158b26124c3
   packageIds: 43becc6a-8c6c-4e9e-bb2f-08fe588ada21
 }
 
@@ -60,7 +60,7 @@ tests {
     // Assert that all expected package IDs are present
     expect(packageIds).to.include.members([
       "0195efb8-7c80-7e82-9b4f-7d63e773bbca",
-      "36c245db-3207-449e-92b1-94cb0a0f3031",
+      "bb0569a6-2268-49b5-9d38-8158b26124c3",
       "43becc6a-8c6c-4e9e-bb2f-08fe588ada21"
     ]);
   
@@ -69,7 +69,7 @@ tests {
   
     expect(packageUrns).to.include.members([
       "urn:altinn:accesspackage:klientadministrator",
-      "urn:altinn:accesspackage:veitransport",
+      "urn:altinn:accesspackage:post-til-virksomheten-med-taushetsbelagt-innhold",
       "urn:altinn:accesspackage:regnskapsforer-lonn"
     ]);
     
@@ -77,7 +77,7 @@ tests {
     const resultByUrn = urn => data.find(p => p.package.urn === urn)?.result;
   
     expect(resultByUrn("urn:altinn:accesspackage:klientadministrator")).to.be.true;
-    expect(resultByUrn("urn:altinn:accesspackage:veitransport")).to.be.true;
+    expect(resultByUrn("urn:altinn:accesspackage:post-til-virksomheten-med-taushetsbelagt-innhold")).to.be.true;
     expect(resultByUrn("urn:altinn:accesspackage:regnskapsforer-lonn")).to.be.false;
     
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Package filter in delegation check query must not be applied before all user packages have been looked up. Otherwise assignable packages the user may have only through main administration package (like post-til-virksomheten-med-taushetsbelagt-innhold) will not he correctly found as assignable (unless hovedadministrator package also is part of the filtered packages).

## Related Issue(s)
- #1041

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
