### PR TITLE
Authz | Delegation policy obligations caching issue

### DIFF
--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
@@ -118,29 +118,29 @@ namespace Altinn.Platform.Authorization.Controllers
                 {
                     return await AuthorizeXmlRequest(model, cancellationToken);
                 }
-                }
-                catch (Exception ex)
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "// DecisionController // Decision // Unexpected Exception");
+
+                XacmlContextResult result = new XacmlContextResult(XacmlContextDecision.Indeterminate)
                 {
-                    _logger.LogError(ex, "// DecisionController // Decision // Unexpected Exception");
+                    Status = new XacmlContextStatus(XacmlContextStatusCode.SyntaxError)
+                };
 
-                    XacmlContextResult result = new XacmlContextResult(XacmlContextDecision.Indeterminate)
-                    {
-                        Status = new XacmlContextStatus(XacmlContextStatusCode.SyntaxError)
-                    };
+                XacmlContextResponse xacmlContextResponse = new XacmlContextResponse(result);
 
-                    XacmlContextResponse xacmlContextResponse = new XacmlContextResponse(result);
-
-                    if (Request.ContentType.Contains("application/json"))
-                    {
-                        XacmlJsonResponse jsonResult = XacmlJsonXmlConverter.ConvertResponse(xacmlContextResponse);
-                        return Ok(jsonResult);
-                    }
-                    else
-                    {
-                        return CreateResponse(xacmlContextResponse);
-                    }
+                if (Request.ContentType.Contains("application/json"))
+                {
+                    XacmlJsonResponse jsonResult = XacmlJsonXmlConverter.ConvertResponse(xacmlContextResponse);
+                    return Ok(jsonResult);
+                }
+                else
+                {
+                    return CreateResponse(xacmlContextResponse);
                 }
             }
+        }
 
         /// <summary>
         /// External endpoint for autorization 
@@ -336,7 +336,7 @@ namespace Altinn.Platform.Authorization.Controllers
             {
                 await _eventLog.CreateAuthorizationEvent(_featureManager, decisionRequest, HttpContext, finalResponse, cancellationToken);
             }
-            
+
             return finalResponse;
         }
 
@@ -412,7 +412,7 @@ namespace Altinn.Platform.Authorization.Controllers
                     Status = new XacmlContextStatus(XacmlContextStatusCode.MissingAttribute) { StatusMessage = "Request not complete for authorization based on delegations." },
                 });
             }
-            
+
             // Look up delegations from (cached) AccessManagement PIP API
             IEnumerable<DelegationChangeExternal> delegations = new List<DelegationChangeExternal>();
             if (IsTypeApp(resourceAttributes))

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
@@ -118,29 +118,29 @@ namespace Altinn.Platform.Authorization.Controllers
                 {
                     return await AuthorizeXmlRequest(model, cancellationToken);
                 }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "// DecisionController // Decision // Unexpected Exception");
-
-                XacmlContextResult result = new XacmlContextResult(XacmlContextDecision.Indeterminate)
-                {
-                    Status = new XacmlContextStatus(XacmlContextStatusCode.SyntaxError)
-                };
-
-                XacmlContextResponse xacmlContextResponse = new XacmlContextResponse(result);
-
-                if (Request.ContentType.Contains("application/json"))
-                {
-                    XacmlJsonResponse jsonResult = XacmlJsonXmlConverter.ConvertResponse(xacmlContextResponse);
-                    return Ok(jsonResult);
                 }
-                else
+                catch (Exception ex)
                 {
-                    return CreateResponse(xacmlContextResponse);
+                    _logger.LogError(ex, "// DecisionController // Decision // Unexpected Exception");
+
+                    XacmlContextResult result = new XacmlContextResult(XacmlContextDecision.Indeterminate)
+                    {
+                        Status = new XacmlContextStatus(XacmlContextStatusCode.SyntaxError)
+                    };
+
+                    XacmlContextResponse xacmlContextResponse = new XacmlContextResponse(result);
+
+                    if (Request.ContentType.Contains("application/json"))
+                    {
+                        XacmlJsonResponse jsonResult = XacmlJsonXmlConverter.ConvertResponse(xacmlContextResponse);
+                        return Ok(jsonResult);
+                    }
+                    else
+                    {
+                        return CreateResponse(xacmlContextResponse);
+                    }
                 }
             }
-        }
 
         /// <summary>
         /// External endpoint for autorization 
@@ -150,32 +150,32 @@ namespace Altinn.Platform.Authorization.Controllers
         [Route("authorization/api/v1/authorize")]
         public async Task<ActionResult<XacmlJsonResponseExternal>> AuthorizeExternal([FromBody] XacmlJsonRequestRootExternal authorizationRequest, CancellationToken cancellationToken = default)
         {
-            ////try
-            ////{
+            try
+            {
                 XacmlJsonRequestRoot jsonRequest = _mapper.Map<XacmlJsonRequestRoot>(authorizationRequest);
                 XacmlJsonResponse xacmlResponse = await Authorize(jsonRequest.Request, true, cancellationToken);
                 return _mapper.Map<XacmlJsonResponseExternal>(xacmlResponse);
-            ////}
-            ////catch (Exception ex)
-            ////{
-            ////    _logger.LogError(ex, "// DecisionController // External Decision // Unexpected Exception");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "// DecisionController // External Decision // Unexpected Exception");
 
-            ////    XacmlContextStatus status = new XacmlContextStatus(XacmlContextStatusCode.SyntaxError);
-            ////    if (ex is ArgumentException)
-            ////    {
-            ////        status = new XacmlContextStatus(XacmlContextStatusCode.ProcessingError);
-            ////        status.StatusMessage = ex.Message;
-            ////    }
+                XacmlContextStatus status = new XacmlContextStatus(XacmlContextStatusCode.SyntaxError);
+                if (ex is ArgumentException)
+                {
+                    status = new XacmlContextStatus(XacmlContextStatusCode.ProcessingError);
+                    status.StatusMessage = ex.Message;
+                }
 
-            ////    XacmlContextResult result = new XacmlContextResult(XacmlContextDecision.Indeterminate)
-            ////    {
-            ////        Status = status
-            ////    };
+                XacmlContextResult result = new XacmlContextResult(XacmlContextDecision.Indeterminate)
+                {
+                    Status = status
+                };
 
-            ////    XacmlContextResponse xacmlContextResponse = new XacmlContextResponse(result);
-            ////    XacmlJsonResponse jsonResult = XacmlJsonXmlConverter.ConvertResponse(xacmlContextResponse);
-            ////    return _mapper.Map<XacmlJsonResponseExternal>(jsonResult);
-            ////}
+                XacmlContextResponse xacmlContextResponse = new XacmlContextResponse(result);
+                XacmlJsonResponse jsonResult = XacmlJsonXmlConverter.ConvertResponse(xacmlContextResponse);
+                return _mapper.Map<XacmlJsonResponseExternal>(jsonResult);
+            }
         }
 
         private async Task<XacmlJsonResponse> Authorize(XacmlJsonRequest decisionRequest, bool isExternalRequest = false, CancellationToken cancellationToken = default)
@@ -307,14 +307,14 @@ namespace Altinn.Platform.Authorization.Controllers
             XacmlContextResponse delegationContextResponse = null;
             if (roleResult.Decision.Equals(XacmlContextDecision.NotApplicable))
             {
-                ////try
-                ////{
+                try
+                {
                     delegationContextResponse = await AuthorizeUsingDelegations(decisionRequest, policy, cancellationToken);
-                ////}
-                ////catch (Exception ex)
-                ////{
-                ////    _logger.LogError(ex, "// DecisionController // Authorize // Delegation // Unexpected Exception");
-                ////}
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "// DecisionController // Authorize // Delegation // Unexpected Exception");
+                }
             }
 
             XacmlContextResponse finalResponse = delegationContextResponse ?? rolesContextResponse;
@@ -488,14 +488,17 @@ namespace Altinn.Platform.Authorization.Controllers
             return result;
         }
 
-        private async Task<XacmlContextResponse> ProcessDelegationResult(XacmlContextRequest decisionRequest, IEnumerable<DelegationChangeExternal> delegations, XacmlPolicy appPolicy, CancellationToken cancellationToken = default)
+        private async Task<XacmlContextResponse> ProcessDelegationResult(XacmlContextRequest decisionRequest, IEnumerable<DelegationChangeExternal> delegations, XacmlPolicy resourcePolicy, CancellationToken cancellationToken = default)
         {
             foreach (DelegationChangeExternal delegation in delegations.Where(d => d.DelegationChangeType != DelegationChangeType.RevokeLast))
             {
                 XacmlPolicy delegationPolicy = await _prp.GetPolicyVersionAsync(delegation.BlobStoragePolicyPath, delegation.BlobStorageVersionId, cancellationToken);
-                foreach (XacmlObligationExpression obligationExpression in appPolicy.ObligationExpressions)
+                if (delegationPolicy.ObligationExpressions.Count == 0)
                 {
-                    delegationPolicy.ObligationExpressions.Add(obligationExpression);
+                    foreach (XacmlObligationExpression obligationExpression in resourcePolicy.ObligationExpressions)
+                    {
+                        delegationPolicy.ObligationExpressions.Add(obligationExpression);
+                    }
                 }
 
                 XacmlContextResponse delegationContextResponse = _pdp.Authorize(decisionRequest, delegationPolicy);

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/PolicyRepository.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/PolicyRepository.cs
@@ -174,8 +174,8 @@ namespace Altinn.Platform.Authorization.Repositories
 
         private async Task<Stream> GetBlobStreamInternal(BlobClient blobClient, CancellationToken cancellationToken)
         {
-            ////try
-            ////{
+            try
+            {
                 Stream memoryStream = new MemoryStream();
 
                 if (await blobClient.ExistsAsync(cancellationToken))
@@ -187,12 +187,12 @@ namespace Altinn.Platform.Authorization.Repositories
                 }
 
                 return memoryStream;
-            ////}
-            ////catch (Exception ex)
-            ////{
-            ////    _logger.LogError(ex, "Failed to read policy file at {blobClient.Name}.", blobClient.Name);
-            ////    throw;
-            ////}
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to read policy file at {blobClient.Name}.", blobClient.Name);
+                throw;
+            }
         }
 
         private async Task<Response<BlobContentInfo>> WriteBlobStreamInternal(BlobClient blobClient, Stream fileStream, BlobUploadOptions blobUploadOptions = null, CancellationToken cancellationToken = default)

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/PolicyRepository.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/PolicyRepository.cs
@@ -190,7 +190,7 @@ namespace Altinn.Platform.Authorization.Repositories
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to read policy file at {blobClientName}.", blobClient.Name);
+                _logger.LogError(ex, "Failed to read policy file at {BlobClientName}.", blobClient.Name);
                 throw;
             }
         }
@@ -210,16 +210,16 @@ namespace Altinn.Platform.Authorization.Repositories
             {
                 if (ex.Status == (int)HttpStatusCode.PreconditionFailed)
                 {
-                    _logger.LogError(ex, "Failed to save policy file {blobClientName}. Precondition failed", blobClient.Name);
+                    _logger.LogError(ex, "Failed to save policy file {BlobClientName}. Precondition failed", blobClient.Name);
                     throw;
                 }
 
-                _logger.LogError(ex, "Failed to save policy file {blobClientName}. RequestFailedException", blobClient.Name);
+                _logger.LogError(ex, "Failed to save policy file {BlobClientName}. RequestFailedException", blobClient.Name);
                 throw;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to save policy file {blobClientName}. Unexpected exception", blobClient.Name);
+                _logger.LogError(ex, "Failed to save policy file {BlobClientName}. Unexpected exception", blobClient.Name);
                 throw;
             }
         }

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/PolicyRepository.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/PolicyRepository.cs
@@ -190,7 +190,7 @@ namespace Altinn.Platform.Authorization.Repositories
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to read policy file at {blobClient.Name}.", blobClient.Name);
+                _logger.LogError(ex, "Failed to read policy file at {blobClientName}.", blobClient.Name);
                 throw;
             }
         }
@@ -210,16 +210,16 @@ namespace Altinn.Platform.Authorization.Repositories
             {
                 if (ex.Status == (int)HttpStatusCode.PreconditionFailed)
                 {
-                    _logger.LogError(ex, "Failed to save policy file {blobClient.Name}. Precondition failed", blobClient.Name);
+                    _logger.LogError(ex, "Failed to save policy file {blobClientName}. Precondition failed", blobClient.Name);
                     throw;
                 }
 
-                _logger.LogError(ex, "Failed to save policy file {blobClient.Name}. RequestFailedException", blobClient.Name);
+                _logger.LogError(ex, "Failed to save policy file {blobClientName}. RequestFailedException", blobClient.Name);
                 throw;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to save policy file {blobClient.Name}. Unexpected exception", blobClient.Name);
+                _logger.LogError(ex, "Failed to save policy file {blobClientName}. Unexpected exception", blobClient.Name);
                 throw;
             }
         }

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ContextHandlerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ContextHandlerTest.cs
@@ -8,6 +8,7 @@ using Altinn.Platform.Authorization.Services.Implementation;
 using Altinn.Platform.Events.Tests.Mocks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using Moq;
@@ -26,6 +27,11 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
         public ContextHandlerTest()
         {
+            ServiceCollection services = new ServiceCollection();
+            services.AddMemoryCache();
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+            IMemoryCache memoryCache = serviceProvider.GetService<IMemoryCache>();
+
             Mock<IHttpContextAccessor> httpContextAccessorMock = new Mock<IHttpContextAccessor>();
             httpContextAccessorMock.Setup(h => h.HttpContext).Returns(_httpContext);
             _contextHandler = new ContextHandler(
@@ -37,7 +43,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
                 new MemoryCache(new MemoryCacheOptions()),
                 Options.Create(new GeneralSettings { RoleCacheTimeout = 5 }),
                 new RegisterServiceMock(),
-                new PolicyRetrievalPointMock(httpContextAccessorMock.Object, null),
+                new PolicyRetrievalPointMock(memoryCache, httpContextAccessorMock.Object, null),
                 new AccessManagementWrapperMock(httpContextAccessorMock.Object),
                 featureManageMock.Object);
         }

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/DelegationHelperTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/DelegationHelperTest.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Platform.Authorization.Constants;
 using Altinn.Platform.Authorization.Helpers;
@@ -8,9 +7,10 @@ using Altinn.Platform.Authorization.IntegrationTests.Util;
 using Altinn.Platform.Authorization.Models;
 using Altinn.Platform.Authorization.Services.Implementation;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
 
 namespace Altinn.Platform.Authorization.IntegrationTests
 {
@@ -19,10 +19,16 @@ namespace Altinn.Platform.Authorization.IntegrationTests
     /// </summary>
     public class DelegationHelperTest
     {
-        private PolicyRetrievalPointMock _prpMock = new PolicyRetrievalPointMock(new HttpContextAccessor(), new Mock<ILogger<PolicyRetrievalPointMock>>().Object);
+        private PolicyRetrievalPointMock _prpMock;
 
         public DelegationHelperTest()
         {
+            ServiceCollection services = new ServiceCollection();
+            services.AddMemoryCache();
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+            IMemoryCache memoryCache = serviceProvider.GetService<IMemoryCache>();
+
+            _prpMock = new PolicyRetrievalPointMock(memoryCache, new HttpContextAccessor(), new Mock<ILogger<PolicyRetrievalPointMock>>().Object);
         }
 
         /// <summary>

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExternalDecisionTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExternalDecisionTest.cs
@@ -309,32 +309,32 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             HttpRequestMessage httpRequestMessage = TestSetupUtil.CreateXacmlRequestExternal(testCase);
             XacmlJsonResponse expected = TestSetupUtil.ReadExpectedJsonProfileResponse(testCase);
 
-        ////    // Act
-        ////    XacmlJsonResponse contextResponse = await TestSetupUtil.GetXacmlJsonProfileContextResponseAsync(client, httpRequestMessage);
+            // Act
+            XacmlJsonResponse contextResponse = await TestSetupUtil.GetXacmlJsonProfileContextResponseAsync(client, httpRequestMessage);
 
-        ////    // Assert
-        ////    AssertionUtil.AssertEqual(expected, contextResponse);
-        ////}
+            // Assert
+            AssertionUtil.AssertEqual(expected, contextResponse);
+        }
 
-        /////// <summary>
-        /////// Scenario where systemuser has received delegation, but request includes multiple subjects as org and orgnumber. Should NOT give Permit. 
-        /////// </summary>
-        ////[Fact]
-        ////public async Task PDPExternal_Decision_SystemUserWithDelegation_TooManyRequestSubjects_Indeterminate()
-        ////{
-        ////    string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:authorization/authorize");
-        ////    string testCase = "ResourceRegistry_SystemUserWithDelegation_TooManyRequestSubjects_Indeterminate";
-        ////    HttpClient client = GetTestClient();
-        ////    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", token);
-        ////    HttpRequestMessage httpRequestMessage = TestSetupUtil.CreateXacmlRequestExternal(testCase);
-        ////    XacmlJsonResponse expected = TestSetupUtil.ReadExpectedJsonProfileResponse(testCase);
+        /// <summary>
+        /// Scenario where systemuser has received delegation, but request includes multiple subjects as org and orgnumber. Should NOT give Permit. 
+        /// </summary>
+        [Fact]
+        public async Task PDPExternal_Decision_SystemUserWithDelegation_TooManyRequestSubjects_Indeterminate()
+        {
+            string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:authorization/authorize");
+            string testCase = "ResourceRegistry_SystemUserWithDelegation_TooManyRequestSubjects_Indeterminate";
+            HttpClient client = GetTestClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", token);
+            HttpRequestMessage httpRequestMessage = TestSetupUtil.CreateXacmlRequestExternal(testCase);
+            XacmlJsonResponse expected = TestSetupUtil.ReadExpectedJsonProfileResponse(testCase);
 
-        ////    // Act
-        ////    XacmlJsonResponse contextResponse = await TestSetupUtil.GetXacmlJsonProfileContextResponseAsync(client, httpRequestMessage);
+            // Act
+            XacmlJsonResponse contextResponse = await TestSetupUtil.GetXacmlJsonProfileContextResponseAsync(client, httpRequestMessage);
 
-        ////    // Assert
-        ////    AssertionUtil.AssertEqual(expected, contextResponse);
-        ////}
+            // Assert
+            AssertionUtil.AssertEqual(expected, contextResponse);
+        }
 
         /// <summary>
         /// Scenario where systemuser has received delegation from the resource party for two resources. Multirequest should give Permit result for both.

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExternalDecisionTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExternalDecisionTest.cs
@@ -275,18 +275,39 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             AssertionUtil.AssertEqual(expected, contextResponse);
         }
 
-        /////// <summary>
-        /////// Multi request scenario for 3 authorization checks in one request
-        /////// </summary>
-        ////[Fact]
-        ////public async Task PDPExternal_Decision_AltinnResourceRegistryMulti0012()
-        ////{
-        ////    string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:authorization/authorize");
-        ////    string testCase = "AltinnResourceRegistryMulti0012";
-        ////    HttpClient client = GetTestClient();
-        ////    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", token);
-        ////    HttpRequestMessage httpRequestMessage = TestSetupUtil.CreateXacmlRequestExternal(testCase);
-        ////    XacmlJsonResponse expected = TestSetupUtil.ReadExpectedJsonProfileResponse(testCase);
+        /// <summary>
+        /// Scenario where systemuser has received delegation from the resource party for the resource. Should give Permit result.
+        /// </summary>
+        [Fact]
+        public async Task PDPExternal_Decision_SystemUserWithAppDelegation_MultipleObligationsBugFix_Permit()
+        {
+            string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:authorization/authorize");
+            string testCase = "AltinnApps_SystemUserWithDelegation_Permit";
+            HttpClient client = GetTestClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", token);
+            XacmlJsonResponse expected = TestSetupUtil.ReadExpectedJsonProfileResponse(testCase);
+
+            // Act multiple times to ensure obligations is not cached multiple times
+            XacmlJsonResponse contextResponse = await TestSetupUtil.GetXacmlJsonProfileContextResponseAsync(client, TestSetupUtil.CreateXacmlRequestExternal(testCase));
+            contextResponse = await TestSetupUtil.GetXacmlJsonProfileContextResponseAsync(client, TestSetupUtil.CreateXacmlRequestExternal(testCase));
+            contextResponse = await TestSetupUtil.GetXacmlJsonProfileContextResponseAsync(client, TestSetupUtil.CreateXacmlRequestExternal(testCase));
+
+            // Assert
+            Assert.True(contextResponse.Response[0].Obligations.Count() == 2, "Expected only the two instances of obligations from main app/resource policy in response");
+        }
+
+        /// <summary>
+        /// Multi request scenario for 3 authorization checks in one request
+        /// </summary>
+        [Fact]
+        public async Task PDPExternal_Decision_AltinnResourceRegistryMulti0012()
+        {
+            string token = PrincipalUtil.GetOrgToken("skd", "974761076", "altinn:authorization/authorize");
+            string testCase = "AltinnResourceRegistryMulti0012";
+            HttpClient client = GetTestClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", token);
+            HttpRequestMessage httpRequestMessage = TestSetupUtil.CreateXacmlRequestExternal(testCase);
+            XacmlJsonResponse expected = TestSetupUtil.ReadExpectedJsonProfileResponse(testCase);
 
         ////    // Act
         ////    XacmlJsonResponse contextResponse = await TestSetupUtil.GetXacmlJsonProfileContextResponseAsync(client, httpRequestMessage);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added integration test setup to reproduce the bug #150
- Added logic to avoid updating already cached delegation policy with duplicate obligations
- Reverted debug changes #1092

## Related Issue(s)
- #150
- #1092 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
