### PR TITLE
Fix: add consent expired event consent request is expired when requesting a single consent request

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
@@ -25,7 +25,7 @@ namespace Altinn.AccessManagement.Core.Services
     /// <remarks>
     /// Service responsible for consent functionality
     /// </remarks>
-    public class ConsentService(IConsentRepository consentRepository, IPartiesClient partiesClient, ISingleRightsService singleRightsService, 
+    public class ConsentService(IConsentRepository consentRepository, IPartiesClient partiesClient, ISingleRightsService singleRightsService,
         IResourceRegistryClient resourceRegistryClient, IAMPartyService ampartyService, IMemoryCache memoryCache, IProfileClient profileClient, TimeProvider timeProvider, IOptions<GeneralSettings> generalSettings) : IConsent
     {
         private readonly IConsentRepository _consentRepository = consentRepository;
@@ -57,8 +57,8 @@ namespace Altinn.AccessManagement.Core.Services
             {
                 // Need to verify if it is null because of duplicate
                 ConsentRequestDetails consentRequestDetails = await _consentRepository.GetRequest(consentRequest.Id, cancellationToken);
-                if (consentRequestDetails != null 
-                    && consentRequest.Id == consentRequestDetails.Id 
+                if (consentRequestDetails != null
+                    && consentRequest.Id == consentRequestDetails.Id
                     && consentRequest.From == consentRequestDetails.From
                     && consentRequest.To == consentRequestDetails.To)
                 {
@@ -88,7 +88,7 @@ namespace Altinn.AccessManagement.Core.Services
 
                 return Problems.ConsentWithIdAlreadyExist.Create([new("requestId", consentRequest.Id.ToString())]);
             }
-            
+
             requestDetails.From = await MapToExternalIdentity(requestDetails.From, cancellationToken);
             requestDetails.To = await MapToExternalIdentity(requestDetails.To, cancellationToken);
             if (requestDetails.HandledBy != null)
@@ -146,7 +146,7 @@ namespace Altinn.AccessManagement.Core.Services
 
                 if (details.ConsentRequestStatus != ConsentRequestStatusType.Created)
                 {
-                   return Problems.ConsentCantBeRejected;
+                    return Problems.ConsentCantBeRejected;
                 }
 
                 throw;
@@ -168,7 +168,7 @@ namespace Altinn.AccessManagement.Core.Services
 
             if (consentRequest == null)
             {
-                return Problems.ConsentNotFound;    
+                return Problems.ConsentNotFound;
             }
             else
             {
@@ -290,7 +290,7 @@ namespace Altinn.AccessManagement.Core.Services
                     consentRequestEvent.PerformedBy = await MapToExternalIdentity(consentRequestEvent.PerformedBy, cancellationToken);
                 }
             }
- 
+
             if (performedByParty.IsOrganizationId(out OrganizationNumber organizationNumber))
             {
                 if (details.To.IsOrganizationId(out OrganizationNumber toOrganizationNumber))
@@ -315,6 +315,8 @@ namespace Altinn.AccessManagement.Core.Services
             }
 
             details.ViewUri = GetConsentViewUri(details.Id);
+
+            AddExpiredEventIfConsentIsExpired(details);
 
             return details;
         }
@@ -820,7 +822,7 @@ namespace Altinn.AccessManagement.Core.Services
                     return Problems.InvalidPersonIdentifier.Create([new("fnumber", consentPartyUrn.ToString())]);
                 }
             }
-            
+
             return to;
         }
 
@@ -849,22 +851,27 @@ namespace Altinn.AccessManagement.Core.Services
             Result<List<ConsentRequestDetails>> requests = await _consentRepository.GetRequestsForParty(coveredByParty, cancellationToken);
 
             if (requests.Value != null)
-            { 
+            {
                 foreach (var req in requests.Value)
                 {
-                    if (req.ValidTo < _timeProvider.GetUtcNow() && !req.ConsentRequestEvents.Exists(r => r.EventType.Equals(ConsentRequestEventType.Expired)))
-                    {
-                        req.ConsentRequestEvents.Add(new ConsentRequestEvent
-                        {
-                            EventType = ConsentRequestEventType.Expired,
-                            Created = req.ValidTo,
-                            PerformedBy = req.To
-                        });
-                    }
+                    AddExpiredEventIfConsentIsExpired(req);
                 }
             }
 
             return requests;
+        }
+
+        private static void AddExpiredEventIfConsentIsExpired(ConsentRequestDetails consentRequest)
+        {
+            if (consentRequest.ValidTo < _timeProvider.GetUtcNow() && !consentRequest.ConsentRequestEvents.Exists(r => r.EventType.Equals(ConsentRequestEventType.Expired)))
+            {
+                consentRequest.ConsentRequestEvents.Add(new ConsentRequestEvent
+                {
+                    EventType = ConsentRequestEventType.Expired,
+                    Created = consentRequest.ValidTo,
+                    PerformedBy = consentRequest.To
+                });
+            }
         }
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
@@ -861,7 +861,7 @@ namespace Altinn.AccessManagement.Core.Services
             return requests;
         }
 
-        private static void AddExpiredEventIfConsentIsExpired(ConsentRequestDetails consentRequest)
+        private void AddExpiredEventIfConsentIsExpired(ConsentRequestDetails consentRequest)
         {
             if (consentRequest.ValidTo < _timeProvider.GetUtcNow() && !consentRequest.ConsentRequestEvents.Exists(r => r.EventType.Equals(ConsentRequestEventType.Expired)))
             {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
@@ -77,6 +77,28 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Assert.Equal("urn:altinn:resource", consentRequest.ConsentRights[0].Resource[0].Type);
         }
 
+        /// <summary>
+        /// Test case: Get consent request with expired event
+        /// Scenario: User is authenticated and is the same person that has been request to accept the request
+        /// User is authorized for all rights in the consent request
+        /// </summary>
+        [Fact]
+        public async Task GetConsentRequest_WithExpiredEvent()
+        {
+            Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
+
+            IConsentRepository repositgo = Fixture.Services.GetRequiredService<IConsentRepository>();
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(-1)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            HttpClient client = GetTestClient();
+            string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}");
+            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestEventType.Created, consentRequest.ConsentRequestEvents[0].EventType);
+            Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestEventType.Expired, consentRequest.ConsentRequestEvents[1].EventType);
+        }
+
         [Fact]
         public async Task GetConsentRequestWithoutMessagehandledby()
         {


### PR DESCRIPTION
## Description
The `Expired` event is already added to `ConsentRequestEvents` for expired consentRequests when requesting a list of consent requests (accessmanagement/api/v1/bff/consentrequests/list/<party>). `Expired` should also be added to `ConsentRequestEvents` when requesting a single consentRequest (accessmanagement/api/v1/bff/consentrequests/<id>)

## Related Issue(s)
- this PR

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
