### PR TITLE
Changed AreaDto.Icon to AreaDto.IconUrl

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperRolePackage.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperRolePackage.cs
@@ -93,7 +93,7 @@ public partial class DtoMapper : IDtoMapper
             Name = area.Name,
             Urn = area.Urn,
             Description = area.Description,
-            Icon = area.IconUrl,
+            IconUrl = area.IconUrl,
             Packages = new List<PackageDto>()
         };
 
@@ -105,7 +105,7 @@ public partial class DtoMapper : IDtoMapper
             Name = area.Name,
             Urn = area.Urn,
             Description = area.Description,
-            Icon = area.IconUrl,
+            IconUrl = area.IconUrl,
             Packages = packages?.Select(p => Convert(p)!).ToList() ?? new()
         };
 

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/AreaDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/AreaDto.cs
@@ -28,7 +28,7 @@ public class AreaDto
     /// <summary>
     /// Gets or sets the icon representing the area.
     /// </summary>
-    public string Icon { get; set; }
+    public string IconUrl { get; set; }
 
     /// <summary>
     /// Gets or sets the list of packages available in this area.


### PR DESCRIPTION
## Description
- EF Dto used AreaDto.Icon - changed back to AreaDto.IconUrl to match actual Area model.
