### PR TITLE
bug: party/from and to/changedby parameters flipped when calling GetAssignableAccessPackages

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
@@ -281,8 +281,8 @@ public partial class ConnectionService : IConnectionService
     {
         
         var assignablePackages = await DbContext.GetAssignableAccessPackages(
-            AuditAccessor.AuditValues.ChangedBy, 
             party,
+            AuditAccessor.AuditValues.ChangedBy, 
             packageIds,
             cancellationToken
         );


### PR DESCRIPTION

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

