### PR TITLE
Update PackageService.cs

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -66,9 +66,15 @@ public class PackageService : IPackageService
         var packages = await DbContext.Packages.AsNoTracking().ToListAsync(cancellationToken);
 
         var result = new List<PackageDto>();
+        var packageResources = await DbContext.PackageResources.AsNoTracking()
+            .Include(t => t.Resource)
+            .Include(t => t.Resource).ThenInclude(t => t.Provider)
+            .Include(t => t.Resource).ThenInclude(t => t.Type)
+            .ToListAsync(cancellationToken);
+
         foreach (var package in packages)
         {
-            result.Add(DtoMapper.Convert(package, areas.First(t => t.Id == package.AreaId), await GetDbPackageResources(package.Id, cancellationToken)));
+            result.Add(DtoMapper.Convert(package, areas.First(t => t.Id == package.AreaId), packageResources.Where(t => t.PackageId == package.Id).Select(t => t.Resource)));
         }
 
         return result;


### PR DESCRIPTION
## Description
Listing AccessPackages with empty search term is slow (3 sec in AT22).

> https://platform.at22.altinn.cloud/accessmanagement/api/v1/meta/info/accesspackages/search?term=

## Fix
- Removed heavy loop