### PR TITLE
Added a new DecisionHelper that ignoeres obligation check. It is not …

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
@@ -137,7 +137,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
                 throw new InvalidOperationException("response");
             }
 
-            if (!DecisionHelper.ValidatePdpDecision(response.Response, claimsPrincipal))
+            if (!DecisionHelper.ValidatePdpDecisionWithoutObligationCheck(response.Response, claimsPrincipal))
             {
                 return false;
             }

--- a/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Helpers/DecisionHelper.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Helpers/DecisionHelper.cs
@@ -499,6 +499,27 @@ namespace Altinn.Common.PEP.Helpers
             return ValidateDecisionResult(results.First(), user);
         }
 
+
+        /// <summary>
+        /// Validate the response from PDP but do not check obligations like authentication level. Use with casution.
+        /// </summary>
+        /// <param name="results">The response to validate</param>
+        /// <param name="user">The <see cref="ClaimsPrincipal"/></param>
+        /// <returns>true or false, valid or not</returns>
+        public static bool ValidatePdpDecisionWithoutObligationCheck(List<XacmlJsonResult> results, ClaimsPrincipal user)
+        {
+            ArgumentNullException.ThrowIfNull(results, nameof(results));
+            ArgumentNullException.ThrowIfNull(user, nameof(user));
+
+            // We request one thing and then only want one result
+            if (results.Count != 1)
+            {
+                return false;
+            }
+
+            return ValidateDecisionResultWithoutObligationsCheck(results.First(), user);
+        }
+
         /// <summary>
         /// Validate the response from PDP
         /// </summary>
@@ -563,6 +584,23 @@ namespace Altinn.Common.PEP.Helpers
                         return false;
                     }
                 }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Validate the response from PDP
+        /// </summary>
+        /// <param name="result">The response to validate</param>
+        /// <param name="user">The <see cref="ClaimsPrincipal"/></param>
+        /// <returns>true or false, valid or not</returns>
+        public static bool ValidateDecisionResultWithoutObligationsCheck(XacmlJsonResult result, ClaimsPrincipal user)
+        {
+            // Checks that the result is nothing else than "permit"
+            if (!result.Decision.Equals(XacmlContextDecision.Permit.ToString()))
+            {
+                return false;
             }
 
             return true;


### PR DESCRIPTION
…relevant on this endpoint since it is only maskinporten endpoint and always "3" But that claims is missing from maskinporten since it is not defined

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
