### PR TITLE
bug: added missing check for parent party already added

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -335,9 +335,13 @@ public class AuthorizedPartiesServiceEf(
             }
             else
             {
-                // Either person or top-level organization
-                allPartiesDict[party.Id] = BuildAuthorizedPartyFromEntity(party);
-                authorizedParties.Add(allPartiesDict[party.Id]);
+                // Either person or top-level organization.
+                // Still need to check whether already exists (may have been added as parent (with onlyHierarchyElement = true) through a subunit access). If exists, just continue.
+                if (!allPartiesDict.TryGetValue(party.Id, out AuthorizedParty _))
+                {
+                    allPartiesDict[party.Id] = BuildAuthorizedPartyFromEntity(party);
+                    authorizedParties.Add(allPartiesDict[party.Id]);
+                }
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When access exists both for a subunit and for parent, the parent is now added twice first as "onlyHierarchyElement" and then again when found in the list because of direct-access.

## Related Issue(s)
- #1580

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
