### PR TITLE
bug: added missing check for subunit party already added

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -348,7 +348,7 @@ public class AuthorizedPartiesServiceEf(
         // Add all subunits to their top-level organization and to the dictionary
         foreach (var subunit in subunits)
         {
-            // Need to check whether subunit already exists (may have been added through a direct ubunit access). If exists, just continue.
+            // Need to check whether subunit already exists (may have been added through a direct subunit access). If exists, just continue.
             if (!allPartiesDict.TryGetValue(subunit.Id, out AuthorizedParty _))
             {
                 var subunitAuthParty = BuildAuthorizedPartyFromEntity(subunit);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When access exists both for a subunit and for parent, the subunit is now added twice, first as child of parent with "onlyHierarchyElement" and then again when found in the list because of direct-access to the parent.


## Related Issue(s)
- #1580

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

