### PR TITLE
Fixed the comparison to not use a string comparer as this crashes wit…

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AllAltinnRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AllAltinnRoleSyncService.cs
@@ -193,7 +193,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
             }
 
             var role = await dbContext.Roles.AsNoTracking()
-                .FirstOrDefaultAsync(r => string.Equals(r.Urn, roleIdentifier, StringComparison.InvariantCultureIgnoreCase), cancellationToken);
+                .FirstOrDefaultAsync(r => string.Equals(r.Urn.ToLower(), roleIdentifier), cancellationToken);
 
             if (role == null)
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AssignmentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AssignmentService.cs
@@ -23,7 +23,7 @@ public class AssignmentService(AppDbContext db) : IAssignmentService
     {
         var packageIds = await db.Packages
             .AsNoTracking()
-            .Where(p => packageUrns.Contains(p.Urn, StringComparer.InvariantCultureIgnoreCase))
+            .Where(p => packageUrns.Contains(p.Urn))
             .Select(p => p.Id)
             .ToListAsync(cancellationToken);
 
@@ -88,7 +88,7 @@ public class AssignmentService(AppDbContext db) : IAssignmentService
     {
         var packageIds = await db.Packages
             .AsNoTracking()
-            .Where(p => packageUrns.Contains(p.Urn, StringComparer.InvariantCultureIgnoreCase))
+            .Where(p => packageUrns.Contains(p.Urn))
             .Select(p => p.Id)
             .ToListAsync(cancellationToken);
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
@@ -189,7 +189,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
         try
         {
             // Find Agent Role
-            var agentRole = await db.Roles.AsNoTracking().FirstOrDefaultAsync(t => string.Equals(t.Code, request.AgentRole, StringComparison.InvariantCultureIgnoreCase), cancellationToken) ?? throw new Exception(string.Format("Role not found '{0}'", request.AgentRole));
+            var agentRole = await db.Roles.AsNoTracking().FirstOrDefaultAsync(t => string.Equals(t.Code.ToLower(), request.AgentRole.ToLower()), cancellationToken) ?? throw new Exception(string.Format("Role not found '{0}'", request.AgentRole));
 
             // Verify Delegation Packages
             Dictionary<string, List<PackageDto>> rolepacks = await VerifyDelegationPackages(request);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -100,7 +100,7 @@ public class PackageService : IPackageService
             urnValue = ":" + urnValue;
         }
 
-        var packages = await DbContext.Packages.AsNoTracking().Where(t => t.Urn.EndsWith(urnValue, StringComparison.InvariantCultureIgnoreCase)).Include(t => t.Area).ToListAsync(cancellationToken);
+        var packages = await DbContext.Packages.AsNoTracking().Where(t => t.Urn.ToLower().EndsWith(urnValue.ToLower())).Include(t => t.Area).ToListAsync(cancellationToken);
         if (packages == null || packages.Count() != 1)
         {
             return null;


### PR DESCRIPTION
…h EntityFramework not beeing able to translate it into sql.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
