### PR TITLE
bug: makes subconnections gettable as to/from filter to GET Connections endpoint

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
@@ -57,15 +57,15 @@ public partial class ConnectionService(
                 IncludeResource = false,
                 EnrichPackageResources = false,
                 ExcludeDeleted = false,
-                OnlyUniqueResults = true,
+                OnlyUniqueResults = true
             },
             direction,
             cancellationToken
         );
 
         return direction == ConnectionQueryDirection.FromOthers
-            ? DtoMapper.ConvertFromOthers(connections)
-            : DtoMapper.ConvertToOthers(connections);
+            ? DtoMapper.ConvertFromOthers(connections, getSingle: fromId.HasValue)
+            : DtoMapper.ConvertToOthers(connections, getSingle: toId.HasValue);
     }
 
     public async Task<Result<AssignmentDto>> AddAssignment(Guid fromId, Guid toId, Action<ConnectionOptions> configureConnections = null, CancellationToken cancellationToken = default)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperConnectionQuery.cs
@@ -6,9 +6,9 @@ namespace Altinn.AccessMgmt.Core.Utils;
 /// <inheritdoc/>
 public partial class DtoMapper : IDtoMapper
 {
-    public static List<ConnectionDto> ConvertToOthers(IEnumerable<ConnectionQueryExtendedRecord> connections)
+    public static List<ConnectionDto> ConvertToOthers(IEnumerable<ConnectionQueryExtendedRecord> connections, bool getSingle = false)
     {
-        var result = connections.Where(t => t.Reason != ConnectionReason.KeyRole && t.Reason != ConnectionReason.Delegation).GroupBy(res => res.ToId).Select(c =>
+        var result = connections.Where(t => getSingle || (t.Reason != ConnectionReason.KeyRole && t.Reason != ConnectionReason.Delegation)).GroupBy(res => res.ToId).Select(c =>
         {
             var connection = c.First();
             var subconnections = connections.Where(c => c.ViaId == connection.ToId && (c.Reason == ConnectionReason.KeyRole || c.Reason == ConnectionReason.Delegation));
@@ -25,9 +25,9 @@ public partial class DtoMapper : IDtoMapper
         return result.ToList();
     }
 
-    public static List<ConnectionDto> ConvertFromOthers(IEnumerable<ConnectionQueryExtendedRecord> connections)
+    public static List<ConnectionDto> ConvertFromOthers(IEnumerable<ConnectionQueryExtendedRecord> connections, bool getSingle = false)
     {
-        var result = connections.Where(t => t.Reason != ConnectionReason.Hierarchy).GroupBy(res => res.FromId).Select(c =>
+        var result = connections.Where(t => getSingle || (t.Reason != ConnectionReason.Hierarchy)).GroupBy(res => res.FromId).Select(c =>
         {
             var connection = c.First();
             var subconnections = connections.Where(c => c.ViaId == connection.FromId && c.Reason == ConnectionReason.Hierarchy);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1689

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

