### PR TITLE
Remove deprecated pdf url from k6 config

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/K6/src/config.js
+++ b/src/apps/Altinn.AccessManagement/test/K6/src/config.js
@@ -57,11 +57,6 @@ export var platformAuthorization = {
   maskinPortenSchemaReceived: `https://platform.${baseUrl}/accessmanagement/api/v1/delegations/AddRules`,
 };
 
-//PDF
-export var platformPdf = {
-  generate: 'https://platform.' + baseUrl + '/pdf/api/v1/generate',
-};
-
 //Receipt
 export var platformReceipt = {
   receipt: 'https://platform.' + baseUrl + '/receipt/api/v1/instances',

--- a/src/apps/Altinn.Authorization/test/K6/src/config.js
+++ b/src/apps/Altinn.Authorization/test/K6/src/config.js
@@ -55,11 +55,6 @@ export var platformAuthorization = {
   deletePolicy: `https://platform.${baseUrl}/authorization/api/v1/delegations/DeletePolicy`,
 };
 
-//PDF
-export var platformPdf = {
-  generate: 'https://platform.' + baseUrl + '/pdf/api/v1/generate',
-};
-
 //Receipt
 export var platformReceipt = {
   receipt: 'https://platform.' + baseUrl + '/receipt/api/v1/instances',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove unused config to deprecated pdf service

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
