### PR TITLE
bug: only reset OnlyHierarchyElementWithNoAccess on a3 party when a2 party has access

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -233,7 +233,11 @@ public class AuthorizedPartiesServiceEf(
             {
                 // Merge roles from Altinn 2 into existing Altinn 3 party
                 existingA3Party.AuthorizedRoles = a2Party.AuthorizedRoles;
-                existingA3Party.OnlyHierarchyElementWithNoAccess = false;
+                if (!a2Party.OnlyHierarchyElementWithNoAccess)
+                {
+                    // Only set to false if Altinn 2 party has actual access
+                    existingA3Party.OnlyHierarchyElementWithNoAccess = false;
+                }
 
                 foreach (AuthorizedParty a2SubUnit in a2Party.Subunits)
                 {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1737

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

