### PR TITLE
chore: add cancellation tokens to PEP package

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/PdpDenyMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/PdpDenyMock.cs
@@ -10,7 +10,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
     internal class PdpDenyMock : IPDP
     {
         /// <inheritdoc/>
-        public Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest)
+        public Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken = default)
         {
             var response = new XacmlJsonResponse
             {
@@ -21,7 +21,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
         }
 
         /// <inheritdoc/>
-        public Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user)
+        public Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(false);
         }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/PdpPermitMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/PdpPermitMock.cs
@@ -12,7 +12,7 @@ namespace Altinn.AccessManagement.Tests.Mocks;
 public class PdpPermitMock: IPDP
 {
     /// <inheritdoc/>
-    public Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest)
+    public Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken = default)
     {
         var response = new XacmlJsonResponse
         {
@@ -23,7 +23,7 @@ public class PdpPermitMock: IPDP
     }
 
     /// <inheritdoc/>
-    public Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user)
+    public Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user, CancellationToken cancellationToken = default)
     {
         return Task.FromResult(true);
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/PepWithPDPAuthorizationMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/PepWithPDPAuthorizationMock.cs
@@ -37,7 +37,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
         private const string PartyAttributeId = "urn:altinn:partyid";
 
         /// <inheritdoc />
-        public async Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest)
+        public async Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken = default)
         {
             return await Authorize(xacmlJsonRequest.Request);
         }
@@ -125,9 +125,9 @@ namespace Altinn.AccessManagement.Tests.Mocks
         }
 
         /// <inheritdoc/>
-        public async Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user)
+        public async Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user, CancellationToken cancellationToken = default)
         {
-            XacmlJsonResponse response = await GetDecisionForRequest(xacmlJsonRequest);
+            XacmlJsonResponse response = await GetDecisionForRequest(xacmlJsonRequest, cancellationToken);
             return DecisionHelper.ValidatePdpDecision(response.Response, user);
         }
 

--- a/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Authorization/AppAccessHandler.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Authorization/AppAccessHandler.cs
@@ -49,7 +49,7 @@ namespace Altinn.Common.PEP.Authorization
 
             XacmlJsonRequestRoot request = DecisionHelper.CreateDecisionRequest(context, requirement, _httpContextAccessor.HttpContext.GetRouteData());
 
-            XacmlJsonResponse response = await _pdp.GetDecisionForRequest(request);
+            XacmlJsonResponse response = await _pdp.GetDecisionForRequest(request, httpContext.RequestAborted);
 
             if (response?.Response == null)
             {

--- a/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Authorization/ResourceAccessHandler.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Authorization/ResourceAccessHandler.cs
@@ -51,7 +51,7 @@ namespace Altinn.Common.PEP.Authorization
 
             XacmlJsonRequestRoot request = DecisionHelper.CreateDecisionRequest(context, requirement, _httpContextAccessor.HttpContext.GetRouteData(), _httpContextAccessor.HttpContext.Request.Headers);
 
-            XacmlJsonResponse response = await _pdp.GetDecisionForRequest(request);
+            XacmlJsonResponse response = await _pdp.GetDecisionForRequest(request, httpContext.RequestAborted);
 
             if (response?.Response == null)
             {

--- a/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Clients/AuthorizationApiClient.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Clients/AuthorizationApiClient.cs
@@ -56,8 +56,9 @@ namespace Altinn.Common.PEP.Clients
         /// Method for performing authorization.
         /// </summary>
         /// <param name="xacmlJsonRequest">An authorization request.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The result of the authorization request.</returns>
-        public async Task<XacmlJsonResponse> AuthorizeRequest(XacmlJsonRequestRoot xacmlJsonRequest)
+        public async Task<XacmlJsonResponse> AuthorizeRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken = default)
         {
             XacmlJsonResponse xacmlJsonResponse = null;
             string apiUrl = $"decision";
@@ -66,19 +67,19 @@ namespace Altinn.Common.PEP.Clients
 
             Stopwatch stopWatch = new Stopwatch();
             stopWatch.Start();
-            HttpResponseMessage response = await _httpClient.PostAsync(apiUrl, httpContent);
+            HttpResponseMessage response = await _httpClient.PostAsync(apiUrl, httpContent, cancellationToken);
             stopWatch.Stop();
             TimeSpan ts = stopWatch.Elapsed;
             _logger.LogInformation("Authorization PDP time elapsed: " + ts.TotalMilliseconds);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                xacmlJsonResponse = await response.Content.ReadFromJsonAsync<XacmlJsonResponse>(jsonOptions);
+                xacmlJsonResponse = await response.Content.ReadFromJsonAsync<XacmlJsonResponse>(jsonOptions, cancellationToken);
             }
             else
             {
                 _logger.LogInformation($"// PDPAppSI // GetDecisionForRequest // Non-zero status code: {response.StatusCode}");
-                _logger.LogInformation($"// PDPAppSI // GetDecisionForRequest // Response: {await response.Content.ReadAsStringAsync()}");
+                _logger.LogInformation($"// PDPAppSI // GetDecisionForRequest // Response: {await response.Content.ReadAsStringAsync(cancellationToken)}");
             }
 
             return xacmlJsonResponse;

--- a/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Implementation/PDPAppSI.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Implementation/PDPAppSI.cs
@@ -28,13 +28,13 @@ namespace Altinn.Common.PEP.Implementation
         }
 
         /// <inheritdoc/>
-        public async Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest)
+        public async Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken = default)
         {
             XacmlJsonResponse xacmlJsonResponse = null;
 
             try
             {
-                xacmlJsonResponse = await _authorizationApiClient.AuthorizeRequest(xacmlJsonRequest);
+                xacmlJsonResponse = await _authorizationApiClient.AuthorizeRequest(xacmlJsonRequest, cancellationToken);
             }
             catch (Exception e)
             {
@@ -45,9 +45,9 @@ namespace Altinn.Common.PEP.Implementation
         }
 
         /// <inheritdoc/>
-        public async Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user)
+        public async Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user, CancellationToken cancellationToken = default)
         {
-            XacmlJsonResponse response = await GetDecisionForRequest(xacmlJsonRequest);
+            XacmlJsonResponse response = await GetDecisionForRequest(xacmlJsonRequest, cancellationToken);
 
             if (response?.Response == null)
             {

--- a/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Interfaces/IPDP.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Interfaces/IPDP.cs
@@ -14,15 +14,17 @@ namespace Altinn.Common.PEP.Interfaces
         /// Sends in a request and get response with result of the request
         /// </summary>
         /// <param name="xacmlJsonRequest">The Xacml Json Request</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The Xacml Json response contains the result of the request</returns>
-        Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest);
+        Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Change this to a better one???????
         /// </summary>
         /// <param name="xacmlJsonRequest">The Xacml Json Request</param>
         /// <param name="user">The claims principal</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Returns true if request is permitted and false if not</returns>
-        Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user);
+        Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user, CancellationToken cancellationToken = default);
     }
 }

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/AppAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/AppAccessHandlerTest.cs
@@ -41,7 +41,7 @@ namespace Altinn.Common.PEP.Authorization
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContext();
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext());
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _aah.HandleAsync(context);
@@ -62,7 +62,7 @@ namespace Altinn.Common.PEP.Authorization
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContext();
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext());
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Deny.ToString());
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _aah.HandleAsync(context);
@@ -86,7 +86,7 @@ namespace Altinn.Common.PEP.Authorization
 
             // Add extra result
             response.Response.Add(new XacmlJsonResult());
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _aah.HandleAsync(context);
@@ -108,7 +108,7 @@ namespace Altinn.Common.PEP.Authorization
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext());
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
             AddObligationWithMinAuthLv(response, "2");
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _aah.HandleAsync(context);
@@ -130,7 +130,7 @@ namespace Altinn.Common.PEP.Authorization
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext());
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
             AddObligationWithMinAuthLv(response, "3");
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _aah.HandleAsync(context);
@@ -151,7 +151,7 @@ namespace Altinn.Common.PEP.Authorization
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContext();
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext());
             XacmlJsonResponse response = null;
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act & Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => _aah.HandleAsync(context));
@@ -171,7 +171,7 @@ namespace Altinn.Common.PEP.Authorization
             // Create response with a result list that is null
             XacmlJsonResponse response = new XacmlJsonResponse();
             response.Response = null;
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act & Assert
             await Assert.ThrowsAsync<ArgumentNullException>(() => _aah.HandleAsync(context));
@@ -192,7 +192,7 @@ namespace Altinn.Common.PEP.Authorization
             AddObligationWithMinAuthLv(response, "2");
 
             // verify
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _aah.HandleAsync(context);
@@ -209,7 +209,7 @@ namespace Altinn.Common.PEP.Authorization
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContextSystemUser();
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext());
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _aah.HandleAsync(context);
@@ -230,7 +230,7 @@ namespace Altinn.Common.PEP.Authorization
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContextAppUser("app_skd_flyttemelding");
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext());
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _aah.HandleAsync(context);

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ResourceAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ResourceAccessHandlerTest.cs
@@ -44,7 +44,7 @@ namespace Altinn.Common.PEP.Authorization
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContext();
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext("23453546", null, null));
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _rah.HandleAsync(context);
@@ -65,7 +65,7 @@ namespace Altinn.Common.PEP.Authorization
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContext();
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext("organization", "991825827", null));
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _rah.HandleAsync(context);
@@ -91,7 +91,7 @@ namespace Altinn.Common.PEP.Authorization
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContext();
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext("organization", "991825827M", null));
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             Task Act() => _rah.HandleAsync(context);
@@ -113,7 +113,7 @@ namespace Altinn.Common.PEP.Authorization
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContext();
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext("person", null, "01014922047"));
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _rah.HandleAsync(context);
@@ -139,7 +139,7 @@ namespace Altinn.Common.PEP.Authorization
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContext();
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext("person", null, "a01014922047"));
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             Task Act() => _rah.HandleAsync(context);
@@ -162,7 +162,7 @@ namespace Altinn.Common.PEP.Authorization
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
 
             // Verify
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.Is<XacmlJsonRequestRoot>(xr => xr.Request.XForwardedForHeader == null))).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.Is<XacmlJsonRequestRoot>(xr => xr.Request.XForwardedForHeader == null), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _rah.HandleAsync(context);
@@ -182,7 +182,7 @@ namespace Altinn.Common.PEP.Authorization
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
 
             // verify
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _rah.HandleAsync(context);


### PR DESCRIPTION
## Description

- adds default cancellation token to PDP and AuthorizationApiClient
- threads the cancellation token from `HttpContext.RequestAborted`

Test  failures were a bit puzzling until I realized it's failing on main too...

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
