### PR TITLE
bug: set OnlyHierarchyElementWithNoAccess to false if parent with access have been added previously

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/AuthorizedParties/AsAuthenticatedUser/GET_AuthorizedParties_RightholderWithPackages_WithoutAccessInfo.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/AuthorizedParties/AsAuthenticatedUser/GET_AuthorizedParties_RightholderWithPackages_WithoutAccessInfo.bru
@@ -78,6 +78,7 @@ tests {
   
     assert.exists(targetParty, 'Expected MainUnit Party: '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.name+' to exist');
     assert.exists(targetSubUnit, 'Expected SubUnit Party: '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.subunit.name+' to exist');
+    assert.isNotOk(targetParty.onlyHierarchyElementWithNoAccess, 'Expected MainUnit '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.name+' to have onlyHierarchyElementWithNoAccess false');
   
   });
   


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This was a tricky one to debug as it is dependent on the order of the parties are found.

If subunit is found first, then the parent is added with OnlyHierarchyElementWithNoAccess = true When parent then exists with a direct access the flag is not reset to false.

## Related Issue(s)
- #1791

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

