### PR TITLE
bruno: tests for REVI/REGN access to Innehaver of deleted ENK

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/AuthorizedParties/AsAuthenticatedUser/GET_AuthorizedParties_Dagl_Regn.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/AuthorizedParties/AsAuthenticatedUser/GET_AuthorizedParties_Dagl_Regn.bru
@@ -41,7 +41,7 @@ script:pre-request {
 }
 
 tests {
-  const testdata = require(`./Testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.json`);
+  const testdata = require(`./Testdata/authorizedparties/${bru.getEnvVar("tokenEnv")}.json`);
   const body = res.getBody();
   const requestName = bru.getVar("requestName");
   
@@ -156,11 +156,19 @@ tests {
     // Test that the expected client party exists in the response with the expected packages
     
     const allParties = body.flatMap(party => [party, ...(party.subunits || [])]);
-    const targetParty = allParties.find(party => party.partyUuid === testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_HUMAN_TOPP_KATT_BIL.innehaver.partyUuid);
+    const innehaverOfActiveEnk = allParties.find(party => party.partyUuid === testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_HUMAN_TOPP_KATT_BIL.innehaver.partyUuid);
+    const innehaverOfDeletedEnkLessThanTwoYears = allParties.find(party => party.partyUuid === testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_DELETED_2025_11_27_InnehaverAccess.innehaver.partyUuid);
+    const innehaverOfDeletedEnkMoreThanTwoYears = allParties.find(party => party.partyUuid === testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_DELETED_2023_11_01_NoInnehaverAccess.innehaver.partyUuid);
   
-    assert.exists(targetParty, 'Expected Innehaver of Enk-ClientParty: '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_HUMAN_TOPP_KATT_BIL.innehaver.name+' to exist');
-    assert.includeMembers(targetParty.authorizedAccessPackages, ["regnskapsforer-lonn", "regnskapsforer-med-signeringsrettighet", "regnskapsforer-uten-signeringsrettighet"]);
-    expect(targetParty.authorizedAccessPackages.length, `authorizedAccessPackages for Client contains unexpected packages`).to.equal(3);
+    assert.exists(innehaverOfActiveEnk, 'Expected Innehaver of Enk-ClientParty: '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_HUMAN_TOPP_KATT_BIL.innehaver.name+' to exist');
+    assert.includeMembers(innehaverOfActiveEnk.authorizedAccessPackages, ["regnskapsforer-lonn", "regnskapsforer-med-signeringsrettighet", "regnskapsforer-uten-signeringsrettighet"]);
+    expect(innehaverOfActiveEnk.authorizedAccessPackages.length, `authorizedAccessPackages for Client contains unexpected packages`).to.equal(3);
+    
+    assert.exists(innehaverOfDeletedEnkLessThanTwoYears, 'Expected Innehaver of Enk-ClientParty: '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_DELETED_2025_11_27_InnehaverAccess.innehaver.name+' to exist');
+    assert.includeMembers(innehaverOfDeletedEnkLessThanTwoYears.authorizedAccessPackages, ["regnskapsforer-lonn", "regnskapsforer-med-signeringsrettighet", "regnskapsforer-uten-signeringsrettighet"]);
+    expect(innehaverOfDeletedEnkLessThanTwoYears.authorizedAccessPackages.length, `authorizedAccessPackages for Client contains unexpected packages`).to.equal(3);
+    
+    assert.strictEqual(innehaverOfDeletedEnkMoreThanTwoYears, undefined, 'Expected Innehaver of Enk-ClientParty: '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_DELETED_2023_11_01_NoInnehaverAccess.innehaver.name+' to NOT exist');
     
   });
   

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/AuthorizedParties/AsServiceOwner/POST_ResourceOwner_AuthorizedParties_Dagl_Regn.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Automatic Test Collection/AuthorizedParties/AsServiceOwner/POST_ResourceOwner_AuthorizedParties_Dagl_Regn.bru
@@ -47,7 +47,7 @@ script:pre-request {
 }
 
 tests {
-  const testdata = require(`./Testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.json`);
+  const testdata = require(`./Testdata/authorizedparties/${bru.getEnvVar("tokenEnv")}.json`);
   const body = res.getBody();
   const requestName = bru.getVar("requestName");
   
@@ -162,11 +162,19 @@ tests {
     // Test that the expected client party exists in the response with the expected packages
     
     const allParties = body.flatMap(party => [party, ...(party.subunits || [])]);
-    const targetParty = allParties.find(party => party.partyUuid === testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_HUMAN_TOPP_KATT_BIL.innehaver.partyUuid);
+    const innehaverOfActiveEnk = allParties.find(party => party.partyUuid === testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_HUMAN_TOPP_KATT_BIL.innehaver.partyUuid);
+    const innehaverOfDeletedEnkLessThanTwoYears = allParties.find(party => party.partyUuid === testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_DELETED_2025_11_27_InnehaverAccess.innehaver.partyUuid);
+    const innehaverOfDeletedEnkMoreThanTwoYears = allParties.find(party => party.partyUuid === testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_DELETED_2023_11_01_NoInnehaverAccess.innehaver.partyUuid);
   
-    assert.exists(targetParty, 'Expected Innehaver of Enk-ClientParty: '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_HUMAN_TOPP_KATT_BIL.innehaver.name+' to exist');
-    assert.includeMembers(targetParty.authorizedAccessPackages, ["regnskapsforer-lonn", "regnskapsforer-med-signeringsrettighet", "regnskapsforer-uten-signeringsrettighet"]);
-    expect(targetParty.authorizedAccessPackages.length, `authorizedAccessPackages for Client contains unexpected packages`).to.equal(3);
+    assert.exists(innehaverOfActiveEnk, 'Expected Innehaver of Enk-ClientParty: '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_HUMAN_TOPP_KATT_BIL.innehaver.name+' to exist');
+    assert.includeMembers(innehaverOfActiveEnk.authorizedAccessPackages, ["regnskapsforer-lonn", "regnskapsforer-med-signeringsrettighet", "regnskapsforer-uten-signeringsrettighet"]);
+    expect(innehaverOfActiveEnk.authorizedAccessPackages.length, `authorizedAccessPackages for Client contains unexpected packages`).to.equal(3);
+    
+    assert.exists(innehaverOfDeletedEnkLessThanTwoYears, 'Expected Innehaver of Enk-ClientParty: '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_DELETED_2025_11_27_InnehaverAccess.innehaver.name+' to exist');
+    assert.includeMembers(innehaverOfDeletedEnkLessThanTwoYears.authorizedAccessPackages, ["regnskapsforer-lonn", "regnskapsforer-med-signeringsrettighet", "regnskapsforer-uten-signeringsrettighet"]);
+    expect(innehaverOfDeletedEnkLessThanTwoYears.authorizedAccessPackages.length, `authorizedAccessPackages for Client contains unexpected packages`).to.equal(3);
+    
+    assert.strictEqual(innehaverOfDeletedEnkMoreThanTwoYears, undefined, 'Expected Innehaver of Enk-ClientParty: '+testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.client_ENK_DELETED_2023_11_01_NoInnehaverAccess.innehaver.name+' to NOT exist');
     
   });
   

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Testdata/authorizedparties/at22.json
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Testdata/authorizedparties/at22.json
@@ -97,6 +97,44 @@
       "directPackageToDelegate": "mobler-og-annen-industri",
       "directPackageToDelegate2": "revisorattesterer"
     },
+    "client_ENK_DELETED_2025_11_27_InnehaverAccess": {
+      "name": "SJELDEN REN KATT KONJAKK",
+      "orgno": "313744019",
+      "partyId": 51653406,
+      "partyUuid": "1fbd06a3-3654-460b-8917-d9f4f9664625",
+      "innehaver": {
+        "name": "PRATSOM SKOLE",
+        "pid": "19846999968",
+        "userId": 20820830,
+        "partyId": 51175128,
+        "partyUuid": "ab0e4f41-4dbe-4198-bc69-6429cbfb6989"
+      },
+      "subunit": {
+        "name": "SJELDEN REN KATT KONJAKK",
+        "orgno": "314964055",
+        "partyId": 51740562,
+        "partyUuid": "ce662cb7-f781-4771-bbd3-2cbb291e523f"
+      }
+    },
+    "client_ENK_DELETED_2023_11_01_NoInnehaverAccess": {
+      "name": "OMSORGSFULL KUL KATT SKATOLL",
+      "orgno": "312282054",
+      "partyId": 51545196,
+      "partyUuid": "2c3b1064-2289-4217-b5de-41038ea86158",
+      "innehaver": {
+        "name": "SYMPATISK LINJE",
+        "pid": "24887299168",
+        "userId": 20946709,
+        "partyId": 50218861,
+        "partyUuid": "c5950a52-d4b4-454d-8cdf-a9c78bda6ff8"
+      },
+      "subunit": {
+        "name": "OMSORGSFULL KUL KATT SKATOLL",
+        "orgno": "315252946",
+        "partyId": 51766826,
+        "partyUuid": "893c7aae-e228-4e64-9643-38116d67eb39"
+      }
+    },
     "a2_klientadministrator": {
       "name": "RUSTEN AKVARELL",
       "pid": "11860198721",

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Testdata/authorizedparties/tt02.json
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/Testdata/authorizedparties/tt02.json
@@ -97,6 +97,44 @@
             "directPackageToDelegate": "mobler-og-annen-industri",
             "directPackageToDelegate2": "revisorattesterer"
         },
+        "client_ENK_DELETED_2025_11_27_InnehaverAccess": {
+            "name": "SJELDEN REN KATT KONJAKK",
+            "orgno": "313744019",
+            "partyId": 51866777,
+            "partyUuid": "3dbea3e5-d16b-4d22-9638-9503aefc1215",
+            "innehaver": {
+                "name": "PRATSOM SKOLE",
+                "pid": "19846999968",
+                "userId": 2133481,
+                "partyId": 51423182,
+                "partyUuid": "9922cf65-eea3-4d1b-ac11-e390cf0229ee"
+            },
+            "subunit": {
+                "name": "SJELDEN REN KATT KONJAKK",
+                "orgno": "314964055",
+                "partyId": 51953923,
+                "partyUuid": "0f7a17ac-c37d-476e-b0d0-8e718bbcce41"
+            }
+        },
+        "client_ENK_DELETED_2023_11_01_NoInnehaverAccess": {
+            "name": "OMSORGSFULL KUL KATT SKATOLL",
+            "orgno": "312282054",
+            "partyId": 51758726,
+            "partyUuid": "8f74d6a1-146c-49ea-9d39-9a76dde61210",
+            "innehaver": {
+                "name": "SYMPATISK LINJE",
+                "pid": "24887299168",
+                "userId": 1781973,
+                "partyId": 50946032,
+                "partyUuid": "49c5cbd5-7a8f-4904-b575-c8d44bc116a6"
+            },
+            "subunit": {
+                "name": "OMSORGSFULL KUL KATT SKATOLL",
+                "orgno": "315252946",
+                "partyId": 51980185,
+                "partyUuid": "2454fd08-5726-43e9-81e3-9551d29868bf"
+            }
+        },
         "a2_klientadministrator": {
             "name": "RUSTEN AKVARELL",
             "pid": "11860198721",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- added Enk-client test data and tests for two year rule of access to Innehaver of a deleted Enkeltpersonforetak

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

