### PR TITLE
Bug/accmgmt rolesyncservice replaced paralleljob howie

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/RoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/RoleSyncService.cs
@@ -67,7 +67,7 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
             {
                 var assignment = MapToAssignment(item);
                 
-                // Fix #7: Improved duplicate detection logic
+                // Fix: Improved duplicate detection logic
                 if (ShouldSetParent(item))
                 {
                     // Track both parent role types before checking if flush is needed
@@ -165,7 +165,7 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
 
         var ids = removeParents.Concat(setParents.Keys).ToList();
 
-        // Fix #6: Validate that all expected entities were retrieved
+        // Fix: Validate that all expected entities were retrieved
         if (ids.Any())
         {
             var entities = await dbContext.Entities
@@ -195,7 +195,7 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
             }
         }
 
-        // Fix #5: Use shared helper method for removing assignments
+        // Fix: Use shared helper method for removing assignments
         if (removeAssignments.Any())
         {
             var assignmentsToRemove = await GetMatchingAssignments(dbContext, removeAssignments, cancellationToken);
@@ -205,7 +205,7 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
         return await dbContext.SaveChangesAsync(cancellationToken);
     }
 
-    // Fix #5: Extracted shared logic into helper method
+    // Fix: Extracted shared logic into helper method
     private static async Task<List<Assignment>> GetMatchingAssignments(
         AppDbContext dbContext, 
         List<Assignment> relations, 
@@ -234,7 +234,7 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
     {
         using var dbContext = dbContextFactory.CreateDbContext();
         
-        // Fix #5: Use shared helper method
+        // Fix: Use shared helper method
         var entities = await GetMatchingAssignments(dbContext, relations, cancellationToken);
 
         dbContext.RemoveRange(entities);
@@ -303,7 +303,7 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
     private bool ShouldSetParent(ExternalRoleAssignmentEvent item) =>
         item.RoleIdentifier == RoleConstants.HasAsRegistrationUnitBEDR.Entity.Code || item.RoleIdentifier == RoleConstants.HasAsRegistrationUnitAAFY.Entity.Code;
 
-    // Fix #8: Added validation for model properties
+    // Fix: Added validation for model properties
     private Assignment MapToAssignment(ExternalRoleAssignmentEvent model)
     {
         if (model == null)


### PR DESCRIPTION
Improve validation, duplicate detection, and refactor duplicated code

## Description
**Duplicate Logic Between Methods**
•	Extracted the common assignment matching logic into a new static helper method GetMatchingAssignments
•	Both RemoveAssignments and ProcessEntityAndAssignmentUpdates now use this shared method
•	Added .Distinct() to optimize the query for FromId values

**Missing Null Check After Database Query**
•	Added validation in ProcessEntityAndAssignmentUpdates to check if all expected entities were retrieved
•	Logs a warning with the count and IDs of missing entities (limited to first 10 for readability)
•	The code continues processing available entities but alerts about missing ones

**Inefficient Duplicate Detection Logic**
•	Changed the logic to add both BEDR and AAFY roles to the seen set first
•	Then checks if either failed (meaning it was already present)
•	This ensures both roles are properly tracked and prevents the issue where the first call fails and flushes before checking the second

**Missing Validation in MapToAssignment**
•	Added null check for the model parameter
•	Validates that FromParty and ToParty are not empty GUIDs
•	Validates that RoleIdentifier is not null or whitespace
•	Changed exception types to be more specific (ArgumentNullException, ArgumentException, InvalidOperationException)
•	Improved error messages to include contextual information

**Additional improvements:**
•	Renamed DoAllTheThings to ProcessEntityAndAssignmentUpdates (more descriptive)
•	Fixed typo: "proccessing" → "processing"
•	Made the helper method GetMatchingAssignments static since it doesn't use instance state