### PR TITLE
perf: accesspackages pip api optimization

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
@@ -153,6 +153,31 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
         ct);
     }
 
+    /// <inheritdoc />
+    public async Task<List<ConnectionQueryExtendedRecord>> GetPipConnectionsFromOthers(
+        Guid toId,
+        AuthorizedPartiesFilters filters = null,
+        CancellationToken ct = default)
+    {
+        return await connectionQuery.GetPipConnectionPackagesAsync(
+        new ConnectionQueryFilter()
+        {
+            ToIds = [toId],
+            FromIds = filters?.PartyFilter?.Keys.ToList(),
+            PackageIds = null,
+            EnrichEntities = false,
+            IncludeSubConnections = true,
+            IncludeKeyRole = filters?.IncludePartiesViaKeyRoles ?? true,
+            IncludeMainUnitConnections = true,
+            IncludeDelegation = true,
+            IncludePackages = filters?.IncludeAccessPackages ?? true,
+            IncludeResource = false,
+            EnrichPackageResources = false,
+            ExcludeDeleted = false
+        },
+        ct);
+    }
+
     public async Task<Dictionary<string, Resource>> GetResourcesByProvider(string? providerCode = null, IEnumerable<string>? resourceIds = null, CancellationToken ct = default)
     {
         return await db.Resources

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IAuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IAuthorizedPartyRepoServiceEf.cs
@@ -100,6 +100,12 @@ public interface IAuthorizedPartyRepoServiceEf
     Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthers(Guid toId, AuthorizedPartiesFilters filters = null, CancellationToken ct = default);
 
     /// <summary>
+    /// Get list of packages the to party has access to, on behalf of the from party
+    /// </summary>
+    /// <returns>Enumerable of package permissions</returns>
+    Task<List<ConnectionQueryExtendedRecord>> GetPipConnectionsFromOthers(Guid toId, AuthorizedPartiesFilters filters = null, CancellationToken ct = default);
+
+    /// <summary>
     /// Get resources by provider code and/or resource ids
     /// </summary>
     /// <param name="providerCode">Provider code</param>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -22,7 +22,7 @@ public class ConnectionQuery(AppDbContext db)
 
     public async Task<List<ConnectionQueryExtendedRecord>> GetConnectionsToOthersAsync(ConnectionQueryFilter filter, bool useNewQuery = true, CancellationToken ct = default)
     {
-        return await GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers, useNewQuery, ct);
+        return await GetConnectionsAsync(filter, ConnectionQueryDirection.ToOthers, useNewQuery, ct);
     }
 
     /// <summary>
@@ -88,6 +88,29 @@ public class ConnectionQuery(AppDbContext db)
         catch (Exception ex)
         {
             throw new Exception($"Failed to get connections with filter: {JsonSerializer.Serialize(filter)}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Slightly optimized connection packages lookup for PIP API
+    /// </summary>
+    public async Task<List<ConnectionQueryExtendedRecord>> GetPipConnectionPackagesAsync(ConnectionQueryFilter filter, CancellationToken ct = default)
+    {
+        try
+        {
+            var baseQuery = BuildBaseQueryFromOthersNew(db, filter);
+            var queryString = baseQuery.ToQueryString();
+
+            var query = EnrichFromEntities(filter, baseQuery);
+            var data = await query.AsNoTracking().ToListAsync(ct);
+            var result = data.Select(ToDtoEmpty).ToList();
+
+            var pkgs = await LoadPackagesByKeyAsync(query, filter, ct);
+            return Attach(result, pkgs, p => p.Id, (dto, list) => dto.Packages = list);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Failed to get pip connection packages with filter: {JsonSerializer.Serialize(filter)}", ex);
         }
     }
 
@@ -699,6 +722,29 @@ public class ConnectionQuery(AppDbContext db)
                 Role = x.r,
                 Via = x.via,
                 ViaRole = x.viaRole,
+                Reason = x.c.Reason,
+            });
+
+        return query;
+    }
+
+    private IQueryable<ConnectionQueryRecord> EnrichFromEntities(ConnectionQueryFilter filter, IQueryable<ConnectionQueryBaseRecord> allKeys)
+    {
+        var entities = db.Entities.AsQueryable();
+
+        var query = allKeys
+            .Join(entities, c => c.FromId, e => e.Id, (c, f) => new { c, f })
+            .WhereIf(filter.ExcludeDeleted, x => !x.f.IsDeleted)
+            .Select(x => new ConnectionQueryRecord
+            {
+                FromId = x.c.FromId,
+                ToId = x.c.ToId,
+                RoleId = x.c.RoleId,
+                AssignmentId = x.c.AssignmentId,
+                DelegationId = x.c.DelegationId,
+                ViaId = x.c.ViaId,
+                ViaRoleId = x.c.ViaRoleId,
+                From = x.f,
                 Reason = x.c.Reason,
             });
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- introduce slightly optimized connection query variant of fromOthers query with only from-party enrichment (needed for rolepackage.variant check)
- use connectionquery response directly not through expensive PackagePermissionDto mapping

## Related Issue(s)
- #1836

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

