### PR TITLE
Fixed one error when client relation is removed before the client del…

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnClientRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnClientRoleSyncService.cs
@@ -145,8 +145,8 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
 
         private Task<ImportClientDelegationRolePackageDto> CreateSystemDelegationRolePackageDtoForClientDelegation(string roleTypeCode, CancellationToken cancellationToken = default)
         {
-            string urn = string.Empty;
-            string clientRoleCode = string.Empty;
+            string urn;
+            string clientRoleCode;
             switch (roleTypeCode.ToUpper())
             {
                 case "A0237":
@@ -169,6 +169,8 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                     urn = "urn:altinn:accesspackage:regnskapsforer-lonn";
                     clientRoleCode = "regnskapsforer";
                     break;
+                default:
+                    throw new Exception($"Role type code '{roleTypeCode}' is not mapped to any access package");
             }
 
             ImportClientDelegationRolePackageDto accessPackage = new ImportClientDelegationRolePackageDto()

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
@@ -320,7 +320,13 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
             var clientRole = (await roleService.GetByCode(rp.Key)).First() ?? throw new Exception(string.Format("Role not found '{0}'", rp.Key));
 
             // Find ClientAssignment
-            var clientAssignment = await assignmentService.GetAssignment(client.Id, facilitator.Id, clientRole.Id, cancellationToken) ?? throw new Exception(string.Format("Could not find client assignment '{0}' - {1} - {2}", client.Name, clientRole.Code, facilitator.Name));
+            var clientAssignment = await assignmentService.GetAssignment(client.Id, facilitator.Id, clientRole.Id, cancellationToken);
+            if (clientAssignment == null)
+            {
+                // If client assignment does not exist none of the packages can be delegated this should happen if the client has lost the connection to the facilitator before the delegation is imported.
+                continue;
+            }
+
             var clientPackages = await assignmentService.GetPackagesForAssignment(clientAssignment.Id);
 
             Delegation delegation = null;


### PR DESCRIPTION
…egation is imported just ignore the delegation completly.

Also changed the handling of mapping between client roles in A2 to packages connected to client roles in A3 when som type exist in the value from the feed this can happen as sqlserver treats 'A0239' and 'A0239    ' the same but C3 does not and the rolecode is stored in a nchar(10) adding trailing spaces so if this is not trimmed in the database we will find values not posible to handle here, as this is an error in opperation i do not need to add trim() to all 16 000 000 that is ok for a few that is made in error. just let it be an error where it actualy belongs and not in a seperate stage later.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
