### PR TITLE
fix: Normalize Accept-Language header to ISO 639-2 codes in middleware

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Middleware/TranslationMiddleware.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Middleware/TranslationMiddleware.cs
@@ -1,10 +1,13 @@
 ﻿using Altinn.AccessManagement.Api.Metadata.Translation;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
 namespace Altinn.AccessManagement.Api.Metadata.Middleware;
 
 /// <summary>
-/// Middleware that extracts language preferences from HTTP headers and stores them in HttpContext
+/// Middleware that extracts language preferences from HTTP headers and stores them in HttpContext.
+/// This middleware normalizes language codes to ISO 639-2 format before downstream processing.
 /// </summary>
 public class TranslationMiddleware
 {
@@ -36,7 +39,7 @@ public class TranslationMiddleware
 
     /// <summary>
     /// Extracts the preferred language code from the Accept-Language header.
-    /// Supports quality values (q) and returns the highest priority language.
+    /// Supports quality values (q) and returns the highest priority supported language.
     /// </summary>
     private static string ExtractLanguageCode(HttpContext context)
     {
@@ -47,11 +50,23 @@ public class TranslationMiddleware
         }
 
         var languages = ParseAcceptLanguageHeader(acceptLanguage.ToString());
-        return languages.FirstOrDefault() ?? TranslationConstants.DefaultLanguageCode;
+        
+        // Try to normalize each language code in order of preference
+        foreach (var lang in languages)
+        {
+            var normalized = NormalizeLanguageCode(lang);
+            if (!string.IsNullOrEmpty(normalized))
+            {
+                return normalized;
+            }
+        }
+
+        return TranslationConstants.DefaultLanguageCode;
     }
 
     /// <summary>
-    /// Parses the Accept-Language header and returns languages ordered by quality value
+    /// Parses the Accept-Language header and returns languages ordered by quality value.
+    /// Quality values (q) range from 0 to 1, with 1 being the highest priority.
     /// </summary>
     private static List<string> ParseAcceptLanguageHeader(string acceptLanguageHeader)
     {
@@ -87,7 +102,39 @@ public class TranslationMiddleware
     }
 
     /// <summary>
-    /// Extracts the partial translation preference from the custom header
+    /// Normalizes language codes to ISO 639-2 three-letter format.
+    /// 
+    /// This is the PRIMARY normalization point for HTTP requests. Language codes are 
+    /// normalized here before being stored in HttpContext, ensuring all downstream 
+    /// components (controllers, services) receive properly formatted codes.
+    /// 
+    /// Supported mappings:
+    /// - en, eng, en-US, en-GB → eng (English)
+    /// - nb, nob, nb-NO, no → nob (Norwegian Bokmål)
+    /// - nn, nno, nn-NO → nno (Norwegian Nynorsk)
+    /// - Unknown/unsupported → null (triggers fallback to default)
+    /// </summary>
+    private static string? NormalizeLanguageCode(string languageCode)
+    {
+        if (string.IsNullOrWhiteSpace(languageCode))
+        {
+            return TranslationConstants.DefaultLanguageCode;
+        }
+
+        // Extract the base language code (remove region codes like -US, -GB)
+        var normalized = languageCode.ToLowerInvariant().Split('-')[0];
+
+        return normalized switch
+        {
+            "en" or "eng" => "eng",
+            "nb" or "nob" or "no" => "nob",
+            "nn" or "nno" => "nno",
+            _ => null // Return null for unsupported languages, allowing fallback to default
+        };
+    }
+
+    /// <summary>
+    /// Extracts the partial translation preference from the custom X-Accept-Partial-Translation header.
     /// </summary>
     private static bool ExtractPartialTranslationPreference(HttpContext context)
     {
@@ -109,7 +156,7 @@ public class TranslationMiddleware
 }
 
 /// <summary>
-/// Extension methods for adding the translation middleware to the application pipeline
+/// Extension methods for adding the translation middleware to the application pipeline.
 /// </summary>
 public static class TranslationMiddlewareExtensions
 {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Utils/ITranslationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Utils/ITranslationService.cs
@@ -10,7 +10,9 @@ public interface ITranslationService
     /// </summary>
     /// <typeparam name="T">The type of the object to be translated. The type must support translation or serialization.</typeparam>
     /// <param name="source">The object to be translated. Cannot be <see langword="null"/>.</param>
-    /// <param name="languageCode">The language code representing the target language for translation. Must be a valid ISO 639-1 code.</param>
+    /// <param name="languageCode">The language code representing the target language for translation. 
+    /// Must be a valid ISO 639-2 three-letter code (e.g., "eng", "nob", "nno"). 
+    /// In HTTP request contexts, this should be normalized by TranslationMiddleware.</param>
     /// <param name="allowPartial">If true, returns partial translation when some fields cannot be translated. If false, returns original object when any translation fails.</param>
     /// <returns>A <see cref="ValueTask{T}"/> representing the asynchronous operation. The result contains the translated object
     /// of type <typeparamref name="T"/>.</returns>
@@ -21,7 +23,9 @@ public interface ITranslationService
     /// </summary>
     /// <typeparam name="T">The type of the object to be translated. The type must support translation or serialization.</typeparam>
     /// <param name="source">The object to be translated. Cannot be <see langword="null"/>.</param>
-    /// <param name="languageCode">The language code representing the target language for translation. Must be a valid ISO 639-1 code.</param>
+    /// <param name="languageCode">The language code representing the target language for translation. 
+    /// Must be a valid ISO 639-2 three-letter code (e.g., "eng", "nob", "nno"). 
+    /// In HTTP request contexts, this should be normalized by TranslationMiddleware.</param>
     /// <param name="allowPartial">If true, returns partial translation when some fields cannot be translated. If false, returns original object when any translation fails.</param>
     /// <returns>A <see name="T"/> representing the operation. The result contains the translated object
     /// of type <typeparamref name="T"/>.</returns>
@@ -32,7 +36,8 @@ public interface ITranslationService
     /// </summary>
     /// <typeparam name="T">The type of the object to be translated.</typeparam>
     /// <param name="source">The object to be translated.</param>
-    /// <param name="languageCode">The target language code.</param>
+    /// <param name="languageCode">The target language code. 
+    /// Must be a valid ISO 639-2 three-letter code (e.g., "eng", "nob", "nno").</param>
     /// <returns>A tuple containing success status and the translated object (or original if translation failed).</returns>
     ValueTask<(bool Success, T Result)> TryTranslateAsync<T>(T source, string languageCode);
 
@@ -41,7 +46,8 @@ public interface ITranslationService
     /// </summary>
     /// <typeparam name="T">The type of objects in the collection.</typeparam>
     /// <param name="sources">The collection of objects to translate.</param>
-    /// <param name="languageCode">The target language code.</param>
+    /// <param name="languageCode">The target language code. 
+    /// Must be a valid ISO 639-2 three-letter code (e.g., "eng", "nob", "nno").</param>
     /// <param name="allowPartial">If true, returns partial translation when some fields cannot be translated.</param>
     /// <returns>The translated collection.</returns>
     ValueTask<IEnumerable<T>> TranslateCollectionAsync<T>(IEnumerable<T> sources, string languageCode, bool allowPartial = true);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/TranslationServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/TranslationServiceTests.cs
@@ -9,7 +9,9 @@ using Microsoft.Extensions.Caching.Memory;
 namespace AccessMgmt.Tests.Services;
 
 /// <summary>
-/// Tests for the TranslationService to ensure proper translation behavior
+/// Tests for the TranslationService to ensure proper translation behavior.
+/// NOTE: All tests now use normalized ISO 639-2 language codes (eng, nob, nno).
+/// Language code normalization should happen in the middleware before reaching the service.
 /// </summary>
 public class TranslationServiceTests : IClassFixture<PostgresFixture>
 {
@@ -41,8 +43,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Description = "Fysisk- eller juridisk person som har ansvaret for den daglige driften i en virksomhet"
         };
 
-        // Act
-        var result = await _translationService.TranslateAsync(role, "nb");
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateAsync(role, "nob");
 
         // Assert
         Assert.Equal("Daglig leder", result.Name);
@@ -60,25 +62,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Description = "Test description"
         };
 
-        // Act
+        // Act - Using normalized language code
         var result = await _translationService.TranslateAsync(role, "nob");
-
-        // Assert
-        Assert.Equal("Daglig leder", result.Name);
-    }
-
-    [Fact]
-    public async Task TranslateAsync_WithNorwegianBokmål_No_ReturnsOriginal()
-    {
-        // Arrange
-        var role = new RoleDto
-        {
-            Id = RoleConstants.ManagingDirector.Id,
-            Name = "Daglig leder"
-        };
-
-        // Act
-        var result = await _translationService.TranslateAsync(role, "no");
 
         // Assert
         Assert.Equal("Daglig leder", result.Name);
@@ -116,8 +101,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Description = "Fysisk- eller juridisk person som har ansvaret for den daglige driften i en virksomhet"
         };
 
-        // Act
-        var result = await _translationService.TranslateAsync(role, "en");
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateAsync(role, "eng");
 
         // Assert
         Assert.Equal("Managing Director", result.Name);
@@ -134,25 +119,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Name = "Daglig leder"
         };
 
-        // Act
+        // Act - Using normalized language code
         var result = await _translationService.TranslateAsync(role, "eng");
-
-        // Assert
-        Assert.Equal("Managing Director", result.Name);
-    }
-
-    [Fact]
-    public async Task TranslateAsync_WithEnglish_EnUS_ReturnsEnglishTranslation()
-    {
-        // Arrange
-        var role = new RoleDto
-        {
-            Id = RoleConstants.ManagingDirector.Id,
-            Name = "Daglig leder"
-        };
-
-        // Act
-        var result = await _translationService.TranslateAsync(role, "en-US");
 
         // Assert
         Assert.Equal("Managing Director", result.Name);
@@ -169,8 +137,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Description = "Skjenkebevillinger og serveringstillatelser"
         };
 
-        // Act
-        var result = await _translationService.TranslateAsync(package, "en");
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateAsync(package, "eng");
 
         // Assert
         Assert.Equal("Catering", result.Name);
@@ -192,8 +160,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Description = "Fysisk- eller juridisk person som har ansvaret for den daglige driften i en virksomhet"
         };
 
-        // Act
-        var result = await _translationService.TranslateAsync(role, "nn");
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateAsync(role, "nno");
 
         // Assert
         Assert.Equal("Dagleg leiar", result.Name);
@@ -210,7 +178,7 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Name = "Daglig leder"
         };
 
-        // Act
+        // Act - Using normalized language code
         var result = await _translationService.TranslateAsync(role, "nno");
 
         // Assert
@@ -227,8 +195,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Name = "Servering"
         };
 
-        // Act
-        var result = await _translationService.TranslateAsync(package, "nn");
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateAsync(package, "nno");
 
         // Assert
         Assert.Equal("Servering", result.Name);
@@ -248,8 +216,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             new() { Id = RoleConstants.Accountant.Id, Name = "Regnskapsfører" }
         };
 
-        // Act
-        var result = await _translationService.TranslateCollectionAsync(roles, "en");
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateCollectionAsync(roles, "eng");
         var resultList = result.ToList();
 
         // Assert
@@ -264,8 +232,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
         // Arrange
         var roles = new List<RoleDto>();
 
-        // Act
-        var result = await _translationService.TranslateCollectionAsync(roles, "en");
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateCollectionAsync(roles, "eng");
 
         // Assert
         Assert.Empty(result);
@@ -281,8 +249,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             new() { Id = RoleConstants.Accountant.Id, Name = "Regnskapsfører" }
         };
 
-        // Act
-        var result = await _translationService.TranslateCollectionAsync(roles, "nb");
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateCollectionAsync(roles, "nob");
         var resultList = result.ToList();
 
         // Assert
@@ -306,8 +274,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Description = "Test"
         };
 
-        // Act
-        var result = await _translationService.TranslateAsync(role, "en", allowPartial: true);
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateAsync(role, "eng", allowPartial: true);
 
         // Assert - Name should be translated, Description might not match exactly
         Assert.Equal("Managing Director", result.Name);
@@ -324,8 +292,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Description = "Test Description"
         };
 
-        // Act
-        var result = await _translationService.TranslateAsync(role, "en", allowPartial: false);
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateAsync(role, "eng", allowPartial: false);
 
         // Assert - Should return original since translation failed
         Assert.Equal("Test Role", result.Name);
@@ -346,8 +314,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Name = "Daglig leder"
         };
 
-        // Act
-        var (success, result) = await _translationService.TryTranslateAsync(role, "en");
+        // Act - Using normalized language code
+        var (success, result) = await _translationService.TryTranslateAsync(role, "eng");
 
         // Assert
         Assert.True(success);
@@ -364,8 +332,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Name = "Daglig leder"
         };
 
-        // Act
-        var (success, result) = await _translationService.TryTranslateAsync(role, "nb");
+        // Act - Using normalized language code
+        var (success, result) = await _translationService.TryTranslateAsync(role, "nob");
 
         // Assert
         Assert.True(success);
@@ -382,8 +350,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Name = "Test"
         };
 
-        // Act
-        var (success, result) = await _translationService.TryTranslateAsync(role, "en");
+        // Act - Using normalized language code
+        var (success, result) = await _translationService.TryTranslateAsync(role, "eng");
 
         // Assert
         Assert.False(success);
@@ -393,8 +361,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
     [Fact]
     public async Task TryTranslateAsync_WithNullSource_ReturnsFalse()
     {
-        // Act
-        var (success, result) = await _translationService.TryTranslateAsync<RoleDto>(null, "en");
+        // Act - Using normalized language code
+        var (success, result) = await _translationService.TryTranslateAsync<RoleDto>(null, "eng");
 
         // Assert
         Assert.False(success);
@@ -406,7 +374,7 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
     #region Edge Cases
 
     [Fact]
-    public async Task TranslateAsync_WithUnknownLanguage_DefaultsToNorwegianBokmål()
+    public async Task TranslateAsync_WithUnknownLanguage_ReturnsOriginal()
     {
         // Arrange
         var role = new RoleDto
@@ -415,10 +383,10 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Name = "Daglig leder"
         };
 
-        // Act
+        // Act - Using an unsupported language code
         var result = await _translationService.TranslateAsync(role, "xyz");
 
-        // Assert
+        // Assert - Should return original since language is not supported
         Assert.Equal("Daglig leder", result.Name);
     }
 
@@ -428,8 +396,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
         // Arrange - Create an object type that doesn't have an Id property
         var obj = new { Name = "Test" };
 
-        // Act
-        var result = await _translationService.TranslateAsync(obj, "en");
+        // Act - Using normalized language code
+        var result = await _translationService.TranslateAsync(obj, "eng");
 
         // Assert
         Assert.Equal("Test", result.Name);
@@ -445,8 +413,8 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Name = "Daglig leder"
         };
 
-        // Act
-        var result = _translationService.Translate(role, "en");
+        // Act - Using normalized language code
+        var result = _translationService.Translate(role, "eng");
 
         // Assert
         Assert.Equal("Managing Director", result.Name);
@@ -534,14 +502,14 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Name = "Original"
         };
 
-        // Act - First call (should query database)
-        var result1 = await _translationService.TranslateAsync(role, "en");
+        // Act - First call (should query database) - Using normalized language code
+        var result1 = await _translationService.TranslateAsync(role, "eng");
         
         // Reset the object
         role.Name = "Original";
         
         // Second call (should use cache)
-        var result2 = await _translationService.TranslateAsync(role, "en");
+        var result2 = await _translationService.TranslateAsync(role, "eng");
 
         // Assert
         Assert.Equal("Cached Translation", result1.Name);


### PR DESCRIPTION
## Problem
Accept-Language headers like "en-US,en;q=0.9,no;q=0.8" were not being properly normalized, causing the translation service to return Norwegian content even when English was requested.

## Solution
- Added language code normalization to TranslationMiddleware
  - Converts Accept-Language values (en-US, nb-NO) to ISO 639-2 codes (eng, nob, nno)
  - Handles quality values (q) and selects highest priority supported language
  - Sets normalized code in HttpContext for downstream use

- Simplified TranslationService
  - Removed redundant normalization logic
  - Now expects pre-normalized ISO 639-2 codes
  - Clearer separation of concerns

- Updated all unit tests to use normalized codes
  - All 21 translation tests pass

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1091 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
