### PR TITLE
Optimized LoadPackagesByKeyAsync

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -953,7 +953,7 @@ public class ConnectionQuery(AppDbContext db)
 
         var delegationIds = keys.Select(k => k.DelegationId).Where(id => id != null).Distinct().ToList();
         var delegationPackagesRaw = delegationIds.Count == 0 ? [] :
-            await db.DelegationPackages.Where(d => keys.Select(k => k.DelegationId).Distinct().ToList().Contains(d.DelegationId))
+            await db.DelegationPackages.Where(d => delegationIds.Contains(d.DelegationId))
             .WhereIf(packageSet is not null, p => packageSet!.Contains(p.PackageId))
             .Select(d => new { d.PackageId, d.DelegationId })
             .ToListAsync(ct);


### PR DESCRIPTION
## Description
- Postponed nesting of child  parties from BuildBaseQueryFromOthersNew to EnrichEntities
- Optimized LoadPackagesByKeyAsync

## Related Issue(s)
- #1953

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
