### PR TITLE
bug: add missing null check on ResourceFilter after ProcessProviderAndResourceFilters

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -48,7 +48,7 @@ public class AuthorizedPartiesServiceEf(
         {
             filter = await ProcessProviderAndResourceFilters(filter, cancellationToken);
 
-            if (filter.ResourceFilter?.Count() == 0)
+            if (filter.ResourceFilter == null || filter.ResourceFilter.Count() == 0)
             {
                 // ServiceOwner or Resource filter specified, but no resources found matching.
                 return new List<AuthorizedParty>();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #2032

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
