### PR TITLE
bruno: fix two failing bruno tests

### DIFF
--- a/src/apps/Altinn.Authorization/test/Bruno/Altinn.Authorization/test/Authorize/AppInstanceDelegation/Instance_O2O_AC7_DaglOfFrom_NotApplicable.bru
+++ b/src/apps/Altinn.Authorization/test/Bruno/Altinn.Authorization/test/Authorize/AppInstanceDelegation/Instance_O2O_AC7_DaglOfFrom_NotApplicable.bru
@@ -34,7 +34,7 @@ body:json {
                   "Attribute": [
                       {
                           "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
-                          "Value": "read"
+                          "Value": "sign"
                       }
                   ]
               }

--- a/src/apps/Altinn.Authorization/test/Bruno/Altinn.Authorization/test/Authorize/MultiReqApp_BothOrgAppAndResourceAttr_Delegations.bru
+++ b/src/apps/Altinn.Authorization/test/Bruno/Altinn.Authorization/test/Authorize/MultiReqApp_BothOrgAppAndResourceAttr_Delegations.bru
@@ -188,8 +188,8 @@ tests {
     expect(res.status).to.equal(200);
     expect(data.response[0]).to.have.property('decision', "Permit");
     expect(data.response[1]).to.have.property('decision', "Permit");
+    expect(data.response[2]).to.have.property('decision', "Permit");
     expect(data.response[3]).to.have.property('decision', "Permit");
-    expect(data.response[4]).to.have.property('decision', "Permit");
   });
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- MultiReqApp_BothOrgAppAndResourceAttr_Delegations: I can't count.. 0, 1, 3, 4 -> 0, 1, 2, 3
- Instance_O2O_AC7_DaglOfFrom_NotApplicable: Dagl of From party has access to `read` action through app-policy. Test need to check for access to `sign` in order to test for missing instance-delegation

## Related Issue(s)
- #1907 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

