### PR TITLE
hotfix: authorizedparties | default include filters and fix wrong id used for package.id filtering

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -751,6 +751,9 @@ public class AuthorizedPartiesServiceEf(
         // Only build resource filters if providerCode or anyOfResourceIds filters are specified
         if (filter.ProviderCode != null || filter.AnyOfResourceIds?.Count() > 0)
         {
+            // Make sure all include filters are set to true, as we need all access info when filtering on provider/resources
+            filter.IncludeAltinn2 = filter.IncludeAltinn3 = filter.IncludeRoles = filter.IncludeAccessPackages = filter.IncludeResources = filter.IncludeInstances = true;
+
             List<Resource> resources = await repoService.GetResources(filter.ProviderCode, filter.AnyOfResourceIds, ct: cancellationToken);
 
             if (resources.Count == 0)
@@ -769,11 +772,11 @@ public class AuthorizedPartiesServiceEf(
 
             // Add packageIds from packageResources to filter.PackageFilter
             filter.PackageFilter ??= new SortedDictionary<Guid, Guid>();
-            foreach (var package in packageResources)
+            foreach (var packageResource in packageResources)
             {
-                if (!filter.PackageFilter.ContainsKey(package.Id))
+                if (!filter.PackageFilter.ContainsKey(packageResource.PackageId))
                 {
-                    filter.PackageFilter[package.Id] = package.Id;
+                    filter.PackageFilter[packageResource.PackageId] = packageResource.PackageId;
                 }
             }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
@@ -111,7 +111,7 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
             IncludeKeyRole = filters?.IncludePartiesViaKeyRoles == AuthorizedPartiesIncludeFilter.True ? true : false,
             IncludeMainUnitConnections = true,
             IncludeDelegation = true,
-            IncludePackages = filters?.IncludeAccessPackages ?? false,
+            IncludePackages = filters?.IncludeAccessPackages == true || filters?.PackageFilter?.Keys?.Count > 0,
             IncludeResource = false,
             EnrichPackageResources = false,
             ExcludeDeleted = false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- set needed include filter defaults to true when performing orgcode or anyOfResourceIds filtering
- fix error selecting packageResource.Id instead of packageResource.PackageId


## Related Issue(s)
- #2074

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

