### PR TITLE
bug: get connections/resources missing direction for connection query

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AssignmentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AssignmentService.cs
@@ -670,7 +670,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery)
             FromIds = [fromId],
             ToIds = [toId],
             ResourceIds = [resourceId],
-            IncludeResource = true,
+            IncludeResources = true,
         });
 
         return result.Any();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
@@ -112,7 +112,7 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
             IncludeMainUnitConnections = true,
             IncludeDelegation = true,
             IncludePackages = filters?.IncludeAccessPackages == true || filters?.PackageFilter?.Keys?.Count > 0,
-            IncludeResource = false,
+            IncludeResources = false,
             EnrichPackageResources = false,
             ExcludeDeleted = false
         },
@@ -139,7 +139,7 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
             IncludeMainUnitConnections = true,
             IncludeDelegation = true,
             IncludePackages = filters?.IncludeAccessPackages ?? true,
-            IncludeResource = false,
+            IncludeResources = false,
             EnrichPackageResources = false,
             ExcludeDeleted = false
         },

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IConnectionService.cs
@@ -70,7 +70,7 @@ public interface IConnectionService
     /// Get connection resources
     /// </summary>
     /// <returns></returns>
-    Task<Result<IEnumerable<ResourcePermissionDto>>> GetResources(Guid party, Guid? fromId, Guid? toId, Action<ConnectionOptions> configureConnections = null, CancellationToken cancellationToken = default);
+    Task<Result<IEnumerable<ResourcePermissionDto>>> GetResources(Guid party, Guid? fromId, Guid? toId, Guid? resourceId, Action<ConnectionOptions> configureConnections = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a resource to an assignment (by resource ID) based on the role between two entities.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryFilter.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryFilter.cs
@@ -61,7 +61,7 @@ public sealed class ConnectionQueryFilter
     /// <summary>
     /// Gets or sets a value indicating whether to include resources.
     /// </summary>
-    public bool IncludeResource { get; init; } = false;
+    public bool IncludeResources { get; init; } = false;
 
     /// <summary>
     /// Gets or sets a value indicating whether to include resources connected to packages.

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConnectionQueryTests.cs
@@ -257,7 +257,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
             IncludeDelegation = flags[0],
             IncludeKeyRole = flags[1],
             IncludePackages = flags[2],
-            IncludeResource = flags[3],
+            IncludeResources = flags[3],
             EnrichEntities = flags[4],
             EnrichPackageResources = flags[5],
             ExcludeDeleted = flags[6],

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/DelegationCheck/GET_Enduser_Conn_Resources_DelgCheck_Dagl.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/DelegationCheck/GET_Enduser_Conn_Resources_DelgCheck_Dagl.bru
@@ -1,18 +1,18 @@
 meta {
-  name: GET_Enduser_Conn_Resource_DelgCheck_Dagl
+  name: GET_Enduser_Conn_Resources_DelgCheck_Dagl
   type: http
-  seq: 11
+  seq: 1
 }
 
 get {
-  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources/delegationcheck?party={{party}}&resourceId={{resourceid}}
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources/delegationcheck?party={{party}}&resource={{resource}}
   body: json
   auth: inherit
 }
 
 params:query {
   party: {{party}}
-  resourceId: {{resourceid}}
+  resource: {{resource}}
 }
 
 headers {
@@ -23,10 +23,10 @@ script:pre-request {
   const sharedtestdata = require(`./testdata/sharedtestdata.js`);
   const testdata = require(`./testdata/resource-delegationcheck/${bru.getEnvVar("tokenEnv")}.js`);
   
-  bru.setVar("requestName", "GET_Enduser_Conn_ResourcePackage_DelgCheck_Dagl");
+  bru.setVar("requestName", "GET_Enduser_Conn_Resources_DelgCheck_Dagl");
   
   bru.setVar("party", testdata.VOKSENDE_FRYKTLØS_TIGER.partyUuid);
-  bru.setVar("resourceid", testdata.resources.packageResourceId);
+  bru.setVar("resource", testdata.resources.packageResourceId);
   
   var getTokenParameters = {
     auth_userId: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.userId,

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/DelegationCheck/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/DelegationCheck/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: DelegationCheck
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/FromOthers/GET_Enduser_Conn_Resources_FromOthers_Dagl_GetAll.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/FromOthers/GET_Enduser_Conn_Resources_FromOthers_Dagl_GetAll.bru
@@ -1,0 +1,59 @@
+meta {
+  name: GET_Enduser_Conn_Resources_FromOthers_Dagl_GetAll
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources?party={{party}}&to={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  to: {{party}}
+  ~resource: {{resource}}
+  ~from: {{party}}
+}
+
+headers {
+  Accept: application/json
+}
+
+script:pre-request {
+  const sharedtestdata = require(`./testdata/sharedtestdata.js`);
+  const testdata = require(`./testdata/resource-delegationcheck/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  bru.setVar("requestName", "GET_Enduser_Conn_Resources_FromOthers_Dagl_GetAll");
+  
+  bru.setVar("party", testdata.VOKSENDE_FRYKTLØS_TIGER.partyUuid);
+  bru.setVar("resource", testdata.resources.packageResourceId);
+  
+  var getTokenParameters = {
+    auth_userId: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.userId,
+    auth_partyId: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.partyId,
+    auth_partyUuid: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.partyUuid,
+    auth_ssn: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.pid,
+    auth_tokenType: sharedtestdata.authTokenType.personal,
+    auth_scopes: sharedtestdata.auth_scopes.portalEnduser
+  }
+  
+  
+  const testTokenGenerator = require(`./TestToolsTokenGenerator.js`);
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken", token);
+}
+
+tests {
+  
+  test(bru.getVar("requestName"), function() {
+    const body = res.getBody();
+    const data = body.data;
+    
+    expect(res.status).to.equal(200);
+    
+    // ToDo: Actual test asserts
+    
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/FromOthers/GET_Enduser_Conn_Resources_FromOthers_Dagl_GetResource.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/FromOthers/GET_Enduser_Conn_Resources_FromOthers_Dagl_GetResource.bru
@@ -1,0 +1,59 @@
+meta {
+  name: GET_Enduser_Conn_Resources_FromOthers_Dagl_GetResource
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources?party={{party}}&to={{party}}&resource={{resource}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  to: {{party}}
+  resource: {{resource}}
+  ~from: {{party}}
+}
+
+headers {
+  Accept: application/json
+}
+
+script:pre-request {
+  const sharedtestdata = require(`./testdata/sharedtestdata.js`);
+  const testdata = require(`./testdata/resource-delegationcheck/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  bru.setVar("requestName", "GET_Enduser_Conn_Resources_FromOthers_Dagl_GetResource");
+  
+  bru.setVar("party", testdata.VOKSENDE_FRYKTLØS_TIGER.partyUuid);
+  bru.setVar("resource", testdata.resources.packageResourceId);
+  
+  var getTokenParameters = {
+    auth_userId: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.userId,
+    auth_partyId: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.partyId,
+    auth_partyUuid: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.partyUuid,
+    auth_ssn: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.pid,
+    auth_tokenType: sharedtestdata.authTokenType.personal,
+    auth_scopes: sharedtestdata.auth_scopes.portalEnduser
+  }
+  
+  
+  const testTokenGenerator = require(`./TestToolsTokenGenerator.js`);
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken", token);
+}
+
+tests {
+  
+  test(bru.getVar("requestName"), function() {
+    const body = res.getBody();
+    const data = body.data;
+    
+    expect(res.status).to.equal(200);
+    
+    // ToDo: Actual test asserts
+    
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/FromOthers/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/FromOthers/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: FromOthers
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/ToOthers/GET_Enduser_Conn_Resources_ToOthers_Dagl_GetAll.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/ToOthers/GET_Enduser_Conn_Resources_ToOthers_Dagl_GetAll.bru
@@ -1,0 +1,59 @@
+meta {
+  name: GET_Enduser_Conn_Resources_ToOthers_Dagl_GetAll
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources?party={{party}}&from={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  from: {{party}}
+  ~resource: {{resource}}
+  ~to: {{party}}
+}
+
+headers {
+  Accept: application/json
+}
+
+script:pre-request {
+  const sharedtestdata = require(`./testdata/sharedtestdata.js`);
+  const testdata = require(`./testdata/resource-delegationcheck/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  bru.setVar("requestName", "GET_Enduser_Conn_Resources_ToOthers_Dagl_GetAll");
+  
+  bru.setVar("party", testdata.VOKSENDE_FRYKTLØS_TIGER.partyUuid);
+  bru.setVar("resource", testdata.resources.packageResourceId);
+  
+  var getTokenParameters = {
+    auth_userId: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.userId,
+    auth_partyId: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.partyId,
+    auth_partyUuid: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.partyUuid,
+    auth_ssn: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.pid,
+    auth_tokenType: sharedtestdata.authTokenType.personal,
+    auth_scopes: sharedtestdata.auth_scopes.portalEnduser
+  }
+  
+  
+  const testTokenGenerator = require(`./TestToolsTokenGenerator.js`);
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken", token);
+}
+
+tests {
+  
+  test(bru.getVar("requestName"), function() {
+    const body = res.getBody();
+    const data = body.data;
+    
+    expect(res.status).to.equal(200);
+    
+    // ToDo: Actual test asserts  
+    
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/ToOthers/GET_Enduser_Conn_Resources_ToOthers_Dagl_GetResource.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/ToOthers/GET_Enduser_Conn_Resources_ToOthers_Dagl_GetResource.bru
@@ -1,0 +1,59 @@
+meta {
+  name: GET_Enduser_Conn_Resources_ToOthers_Dagl_GetResource
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources?party={{party}}&from={{party}}&resource={{resource}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  from: {{party}}
+  resource: {{resource}}
+  ~to: {{party}}
+}
+
+headers {
+  Accept: application/json
+}
+
+script:pre-request {
+  const sharedtestdata = require(`./testdata/sharedtestdata.js`);
+  const testdata = require(`./testdata/resource-delegationcheck/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  bru.setVar("requestName", "GET_Enduser_Conn_Resources_ToOthers_Dagl_GetResource");
+  
+  bru.setVar("party", testdata.VOKSENDE_FRYKTLØS_TIGER.partyUuid);
+  bru.setVar("resource", testdata.resources.packageResourceId);
+  
+  var getTokenParameters = {
+    auth_userId: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.userId,
+    auth_partyId: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.partyId,
+    auth_partyUuid: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.partyUuid,
+    auth_ssn: testdata.VOKSENDE_FRYKTLØS_TIGER.dagligleder.pid,
+    auth_tokenType: sharedtestdata.authTokenType.personal,
+    auth_scopes: sharedtestdata.auth_scopes.portalEnduser
+  }
+  
+  
+  const testTokenGenerator = require(`./TestToolsTokenGenerator.js`);
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken", token);
+}
+
+tests {
+  
+  test(bru.getVar("requestName"), function() {
+    const body = res.getBody();
+    const data = body.data;
+    
+    expect(res.status).to.equal(200);
+    
+    // ToDo: Actual test asserts  
+    
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/ToOthers/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/ToOthers/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: ToOthers
+  seq: 3
+}
+
+auth {
+  mode: inherit
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/Resources/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Resources
+  seq: 8
+}
+
+auth {
+  mode: inherit
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/Meta/types/GET_organization_subtypes.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/Meta/types/GET_organization_subtypes.bru
@@ -1,0 +1,19 @@
+meta {
+  name: GET_organization_subtypes
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/meta/types/organization/subtypes
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("GET_roles", function() {
+    const data = res.getBody();  
+    expect(res.status).to.equal(200);
+  });
+  
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/Meta/types/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/Meta/types/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: types
+  seq: 3
+}
+
+auth {
+  mode: inherit
+}


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added missing implementation of "direction" of connection query based on whether party param is equal to either of the optional from- or to-params
- The resource lookup through connection query does too much
  - Removed RoleResource from resource enrichment
  - Removed DelegationResource from resource enrichment
  - Added filter for only getting AssignmentResources tied to Rettighetshaver-assignments
- Added missing resource param

## Related Issue(s)
- #2195

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

