### PR TITLE
bug: quickfix add missing mapping of refid on get connections/resources

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperConnectionQuery.cs
@@ -224,6 +224,7 @@ public partial class DtoMapper : IDtoMapper
         {
             Id = resource.Id,
             Name = resource.Name,
+            RefId = resource.RefId
         };
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

