### PR TITLE
Fix #2155: Prevent self-delegation in Connections API POST endpoints

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/ConnectionCombinationRules.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/ConnectionCombinationRules.cs
@@ -104,6 +104,34 @@ internal static class ConnectionCombinationRules
     };
 
     /// <summary>
+    /// Prevents self-delegation: from and to must be different parties.
+    /// Used in add/update scenarios to ensure a party cannot delegate to itself.
+    /// </summary>
+    internal static RuleExpression FromAndToMustBeDifferent(string from, string to) => () =>
+    {
+        if (!Guid.TryParse(from, out var fromId) || fromId == Guid.Empty)
+        {
+            return null;
+        }
+
+        if (!Guid.TryParse(to, out var toId) || toId == Guid.Empty)
+        {
+            return null;
+        }
+
+        if (fromId == toId)
+        {
+            return (ref ValidationErrorBuilder errors) =>
+            {
+                errors.Add(ValidationErrors.InvalidQueryParameter, "QUERY/from", [new("from", ValidationErrorMessageTexts.SelfDelegationNotAllowed)]);
+                errors.Add(ValidationErrors.InvalidQueryParameter, "QUERY/to", [new("to", ValidationErrorMessageTexts.SelfDelegationNotAllowed)]);
+            };
+        }
+
+        return null;
+    };
+
+    /// <summary>
     /// Package reference must be exactly one of (packageId, packageUrn). Reject empty Guid.
     /// </summary>
     internal static RuleExpression ExclusivePackageReference(Guid? packageId, string packageUrn, string idName = "packageId", string urnName = "package") => () =>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/ConnectionValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/ConnectionValidation.cs
@@ -24,7 +24,8 @@ internal static class ConnectionValidation
             ParameterValidation.Party(party),
             ParameterValidation.PartyFrom(from),
             ParameterValidation.PartyTo(to),
-            ConnectionCombinationRules.PartyEqualsFrom(party, from)
+            ConnectionCombinationRules.PartyEqualsFrom(party, from),
+            ConnectionCombinationRules.FromAndToMustBeDifferent(from, to)
         );
 
     /// <summary>
@@ -55,7 +56,8 @@ internal static class ConnectionValidation
             ParameterValidation.PartyFrom(from),
             ParameterValidation.PartyTo(to),
             ConnectionCombinationRules.ExclusivePackageReference(packageId, packageUrn),
-            ConnectionCombinationRules.PartyEqualsFrom(party, from)
+            ConnectionCombinationRules.PartyEqualsFrom(party, from),
+            ConnectionCombinationRules.FromAndToMustBeDifferent(from, to)
         );
 
     /// <summary>
@@ -101,7 +103,8 @@ internal static class ConnectionValidation
             ParameterValidation.Party(party),
             ParameterValidation.PartyFrom(from),
             ParameterValidation.PartyTo(to),
-            ConnectionCombinationRules.PartyEqualsFrom(party, from)
+            ConnectionCombinationRules.PartyEqualsFrom(party, from),
+            ConnectionCombinationRules.FromAndToMustBeDifferent(from, to)
         );
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/ValidationErrorMessageTexts.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/ValidationErrorMessageTexts.cs
@@ -19,4 +19,5 @@ internal static class ValidationErrorMessageTexts
     internal const string PersonIdentifierInvalid = "Invalid national identity number";
     internal const string LastNameRequired = "Required when providing PersonInput details";
     internal const string PersonIdentifierLastNameInvalid = "PersonInput details must match";
+    internal const string SelfDelegationNotAllowed = "Self-delegation not allowed. From and To cannot be the same party";
 }


### PR DESCRIPTION
Add validation to ensure 'from' and 'to' cannot be the same party when creating assignments, adding packages, or adding resources.

Fixes #2155

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #2155 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
