### PR TITLE
Added logging when A2 consent is not stored to A3 DB

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
@@ -259,7 +259,7 @@ namespace Altinn.AccessManagement.Core.Services
                 else
                 {
                     logger.LogWarning(
-                        "Consent with id {consentRequestId} exist in Altinn2 but failed to migrate to Altinn3 with error {error}.",
+                        "Consent with id {ConsentRequestId} exist in Altinn2 but failed to migrate to Altinn3 with error {Error}.",
                         consentRequestId,
                         string.Join(Environment.NewLine, ((ValidationProblemInstance)result.Problem).Errors.Select(e => $"{e.ErrorCode}: {e.Detail}")));
                 }


### PR DESCRIPTION
Added logging when A2 consent is not stored to A3 DB

## Description
Problems during migration from A2 to A3 is logged as a warning.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
