### PR TITLE
bug: fix app delegation in new connections/resources api

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/DelegationHelper.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/DelegationHelper.cs
@@ -327,8 +327,15 @@ namespace Altinn.AccessManagement.Core.Helpers
 
             if (resourceRegistryMatch != null && orgMatch == null && appMatch == null)
             {
-                resourceMatchType = ResourceAttributeMatchType.ResourceRegistry;
+                if (IsAppResourceId(resourceRegistryMatch.Value, out org, out app))
+                {
+                    resourceId = $"{org}/{app}";
+                    resourceMatchType = ResourceAttributeMatchType.AltinnAppId;
+                    return true;
+                }
+
                 resourceId = resourceRegistryMatch.Value;
+                resourceMatchType = ResourceAttributeMatchType.ResourceRegistry;
                 return true;
             }
 
@@ -350,6 +357,33 @@ namespace Altinn.AccessManagement.Core.Helpers
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Method to check if a resourceid is an app and decompose it into org/app values
+        /// </summary>
+        /// <param name="resourceId">the resourceid to check</param>
+        /// <param name="org">the org part of the resourceid if it is an app</param>
+        /// <param name="app">the app part of the resourceid if it is an app</param>
+        /// <returns>true if app false if not</returns>
+        public static bool IsAppResourceId(string resourceId, out string org, out string app)
+        {
+            org = null;
+            app = null;
+            bool isApp = false;
+
+            if (resourceId.StartsWith("app_"))
+            {
+                isApp = true;
+                string[] parts = resourceId.Split('_', 3);
+                if (parts.Length == 3)
+                {
+                    org = parts[1];
+                    app = parts[2];
+                }
+            }
+
+            return isApp;
         }
 
         /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
@@ -201,7 +201,15 @@ namespace Altinn.AccessManagement.Core.Services
                 }
                 else
                 {
-                    resourceList.Add(currentAttributeMatch);
+                    if (currentAttributeMatch.Id.Equals(AltinnXacmlConstants.MatchAttributeIdentifiers.ResourceRegistryAttribute, StringComparison.InvariantCultureIgnoreCase) && DelegationHelper.IsAppResourceId(currentAttributeMatch.Value, out string org, out string app))
+                    {
+                        resourceList.Add(new AttributeMatch { Id = AltinnXacmlConstants.MatchAttributeIdentifiers.OrgAttribute, Value = org });
+                        resourceList.Add(new AttributeMatch { Id = AltinnXacmlConstants.MatchAttributeIdentifiers.AppAttribute, Value = app });
+                    }
+                    else
+                    {
+                        resourceList.Add(currentAttributeMatch);
+                    }
                 }
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

SingleRightsService.SplitActionKey
- Fixed so rules are built with org and app attribute when resourceId is an an app-resourceId

DelegationHelper.TryGetResourceFromAttributeMatch
- Updated with support for app resourceIds to still be processed as ResourceAttributeMatchType.AltinnAppId

## Related Issue(s)
- #2291

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
