### PR TITLE
bug: DelegationMetadataEF support from and to party lookup when input only has uuid (e.g. systemuser)

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
@@ -1078,4 +1078,3 @@ namespace Altinn.AccessManagement.Core.Services
         }
     }
 }
-

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/DelegationMetadataEF.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/DelegationMetadataEF.cs
@@ -305,10 +305,15 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
             role = RoleConstants.Supplier;
         }
 
-        var from = await DbContext.Entities.AsNoTracking().SingleAsync(t => t.PartyId == delegationChange.OfferedByPartyId, cancellationToken);
-        var to = delegationChange.CoveredByUserId.HasValue ?
-            await DbContext.Entities.AsNoTracking().SingleAsync(t => t.UserId == delegationChange.CoveredByUserId, cancellationToken) :
-            await DbContext.Entities.AsNoTracking().SingleAsync(t => t.PartyId == delegationChange.CoveredByPartyId, cancellationToken);
+        var from = delegationChange.FromUuid.HasValue ?
+            await DbContext.Entities.AsNoTracking().SingleAsync(t => t.Id == delegationChange.FromUuid.Value, cancellationToken) :
+            await DbContext.Entities.AsNoTracking().SingleAsync(t => t.PartyId == delegationChange.OfferedByPartyId, cancellationToken);
+        var to = delegationChange.ToUuid.HasValue ?
+            await DbContext.Entities.AsNoTracking().SingleAsync(t => t.Id == delegationChange.ToUuid.Value, cancellationToken) :
+            (delegationChange.CoveredByUserId.HasValue ?
+                await DbContext.Entities.AsNoTracking().SingleAsync(t => t.UserId == delegationChange.CoveredByUserId, cancellationToken) :
+                await DbContext.Entities.AsNoTracking().SingleAsync(t => t.PartyId == delegationChange.CoveredByPartyId, cancellationToken)
+            );
 
         var assignment = await DbContext.Assignments.FirstOrDefaultAsync(t => t.FromId == from.Id && t.ToId == to.Id && t.RoleId == role.Id, cancellationToken);
         AssignmentResource assignmentResource = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #2374

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

