### PR TITLE
Allow empty metadata values for A2 consents

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
@@ -892,7 +892,7 @@ namespace Altinn.AccessManagement.Core.Services
 
                     if (string.IsNullOrEmpty(metaData.Value) && !fromAltinn2)
                     {
-                        problemsBuilder.Add(Problems.MissingMetadataValue.Create([new("key", metaData.Key.ToLower())]));
+                        problemsBuilder.Add(Problems.MissingMetadataValue.Create([new($"ConsentRight index: {rightIndex}, key", metaData.Key.ToLower())]));
                     }
                 }
             }


### PR DESCRIPTION
Allow empty metadata values for A2 consents

## Description
Allow empty metadata values for A2 consents
Also changed logging of empty Metadata values to log Key name instead of index.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
