### PR TITLE
Set Migrationstatus to success on already existing consent

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
@@ -256,7 +256,7 @@ namespace Altinn.AccessManagement.Core.Services
                 ConsentRequest mappedConsentFromA2 = await MapA2ConsentToA3Consent(altinn2ConsentRequest, cancellationToken);
                 Result<ConsentRequestDetailsWrapper> result = await CreateRequest(mappedConsentFromA2, mappedConsentFromA2.From, true, cancellationToken);
 
-                await _altinn2ConsentClient.UpdateAltinn2ConsentMigrateStatus(consentRequestId.ToString(), result.IsProblem ? 2 : 1, cancellationToken);
+                await _altinn2ConsentClient.UpdateAltinn2ConsentMigrateStatus(consentRequestId.ToString(), (result.IsProblem && result.Problem != Problems.ConsentWithIdAlreadyExist) ? 2 : 1, cancellationToken);
 
                 if (!result.IsProblem)
                 {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
@@ -1,0 +1,314 @@
+﻿using Altinn.AccessManagement.Core.Clients.Interfaces;
+using Altinn.AccessManagement.Core.Configuration;
+using Altinn.AccessManagement.Core.Errors;
+using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.Core.Models.Consent;
+using Altinn.AccessManagement.Core.Models.Party;
+using Altinn.AccessManagement.Core.Models.ResourceRegistry;
+using Altinn.AccessManagement.Core.Repositories.Interfaces;
+using Altinn.AccessManagement.Core.Services;
+using Altinn.AccessManagement.Core.Services.Interfaces;
+using Altinn.Authorization.Api.Contracts.Register;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace AccessMgmt.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ConsentService"/>
+/// </summary>
+public class ConsentServiceTests
+{
+    private readonly Mock<ILogger<ConsentService>> _loggerMock;
+    private readonly Mock<IConsentRepository> _consentRepositoryMock;
+    private readonly Mock<IAltinn2ConsentClient> _altinn2ConsentClientMock;
+    private readonly Mock<IPartiesClient> _partiesClientMock;
+    private readonly Mock<ISingleRightsService> _singleRightsServiceMock;
+    private readonly Mock<IResourceRegistryClient> _resourceRegistryClientMock;
+    private readonly Mock<IAMPartyService> _amPartyServiceMock;
+    private readonly Mock<IMemoryCache> _memoryCacheMock;
+    private readonly Mock<IProfileClient> _profileClientMock;
+    private readonly TimeProvider _timeProvider;
+    private readonly Mock<IOptions<GeneralSettings>> _generalSettingsMock;
+
+    public ConsentServiceTests()
+    {
+        _loggerMock = new Mock<ILogger<ConsentService>>();
+        _consentRepositoryMock = new Mock<IConsentRepository>();
+        _altinn2ConsentClientMock = new Mock<IAltinn2ConsentClient>();
+        _partiesClientMock = new Mock<IPartiesClient>();
+        _singleRightsServiceMock = new Mock<ISingleRightsService>();
+        _resourceRegistryClientMock = new Mock<IResourceRegistryClient>();
+        _amPartyServiceMock = new Mock<IAMPartyService>();
+        _memoryCacheMock = new Mock<IMemoryCache>();
+        _profileClientMock = new Mock<IProfileClient>();
+        _timeProvider = TimeProvider.System;
+        _generalSettingsMock = new Mock<IOptions<GeneralSettings>>();
+
+        _generalSettingsMock.Setup(x => x.Value).Returns(new GeneralSettings { Hostname = "localhost" });
+        SetupMemoryCache();
+    }
+
+    [Fact]
+    public async Task GetAndStoreAltinn2Consent_DuplicateFound_SetsMigrateStatusTo1()
+    {
+        // Arrange
+        var consentRequestId = Guid.NewGuid();
+        var fromPartyUuid = Guid.NewGuid();
+        var toPartyUuid = Guid.NewGuid();
+
+        var altinn2ConsentRequest = CreateAltinn2ConsentRequest(consentRequestId, fromPartyUuid, toPartyUuid);
+        var existingRequestDetails = CreateConsentRequestDetails(consentRequestId, fromPartyUuid, toPartyUuid);
+
+        _altinn2ConsentClientMock
+            .Setup(x => x.GetAltinn2Consent(consentRequestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(altinn2ConsentRequest);
+
+        SetupValidationMocks(fromPartyUuid, toPartyUuid);
+
+        // Simulate duplicate: CreateRequest returns null
+        _consentRepositoryMock
+            .Setup(x => x.CreateRequest(It.IsAny<ConsentRequest>(), It.IsAny<ConsentPartyUrn>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConsentRequestDetails)null);
+
+        // GetRequest returns existing consent with matching parties (duplicate scenario)
+        _consentRepositoryMock
+            .Setup(x => x.GetRequest(consentRequestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRequestDetails);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsProblem);
+        Assert.NotNull(result.Value);
+
+        // Verify migration status was set to 1 (success) for duplicate
+        _altinn2ConsentClientMock.Verify(
+            x => x.UpdateAltinn2ConsentMigrateStatus(consentRequestId.ToString(), 1, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAndStoreAltinn2Consent_InvalidResource_SetsMigrateStatusTo2()
+    {
+        // Arrange
+        var consentRequestId = Guid.NewGuid();
+        var fromPartyUuid = Guid.NewGuid();
+        var toPartyUuid = Guid.NewGuid();
+
+        var altinn2ConsentRequest = CreateAltinn2ConsentRequest(consentRequestId, fromPartyUuid, toPartyUuid);
+
+        _altinn2ConsentClientMock
+            .Setup(x => x.GetAltinn2Consent(consentRequestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(altinn2ConsentRequest);
+
+        SetupValidationMocks(fromPartyUuid, toPartyUuid);
+
+        // Make resource validation fail (return null for resource)
+        _resourceRegistryClientMock
+            .Setup(x => x.GetResource(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ServiceResource)null);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsProblem || result.Value == null);
+
+        // Verify migration status was set to 2 (failure) for validation error
+        _altinn2ConsentClientMock.Verify(
+            x => x.UpdateAltinn2ConsentMigrateStatus(consentRequestId.ToString(), 2, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAndStoreAltinn2Consent_Success_SetsMigrateStatusTo1()
+    {
+        // Arrange
+        var consentRequestId = Guid.NewGuid();
+        var fromPartyUuid = Guid.NewGuid();
+        var toPartyUuid = Guid.NewGuid();
+
+        var altinn2ConsentRequest = CreateAltinn2ConsentRequest(consentRequestId, fromPartyUuid, toPartyUuid);
+        var createdRequestDetails = CreateConsentRequestDetails(consentRequestId, fromPartyUuid, toPartyUuid);
+
+        _altinn2ConsentClientMock
+            .Setup(x => x.GetAltinn2Consent(consentRequestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(altinn2ConsentRequest);
+
+        SetupValidationMocks(fromPartyUuid, toPartyUuid);
+
+        // Successful creation
+        _consentRepositoryMock
+            .Setup(x => x.CreateRequest(It.IsAny<ConsentRequest>(), It.IsAny<ConsentPartyUrn>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdRequestDetails);
+
+        _consentRepositoryMock
+            .Setup(x => x.GetRequest(consentRequestId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdRequestDetails);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsProblem);
+        Assert.NotNull(result.Value);
+
+        // Verify migration status was set to 1 (success)
+        _altinn2ConsentClientMock.Verify(
+            x => x.UpdateAltinn2ConsentMigrateStatus(consentRequestId.ToString(), 1, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private ConsentService CreateService()
+    {
+        return new ConsentService(
+            _loggerMock.Object,
+            _consentRepositoryMock.Object,
+            _altinn2ConsentClientMock.Object,
+            _partiesClientMock.Object,
+            _singleRightsServiceMock.Object,
+            _resourceRegistryClientMock.Object,
+            _amPartyServiceMock.Object,
+            _memoryCacheMock.Object,
+            _profileClientMock.Object,
+            _timeProvider,
+            _generalSettingsMock.Object);
+    }
+
+    private Altinn2ConsentRequest CreateAltinn2ConsentRequest(Guid id, Guid fromPartyUuid, Guid toPartyUuid)
+    {
+        return new Altinn2ConsentRequest
+        {
+            ConsentGuid = id,
+            OfferedByPartyUUID = fromPartyUuid,
+            CoveredByPartyUUID = toPartyUuid,
+            ValidTo = DateTimeOffset.UtcNow.AddDays(30),
+            ConsentRequestStatus = "Created",
+            CreatedTime = DateTimeOffset.UtcNow,
+            RequestResources = new List<AuthorizationRequestResourceBE>
+            {
+                new AuthorizationRequestResourceBE
+                {
+                    ServiceCode = "test",
+                    ServiceEditionCode = 1,
+                    ServiceEditionVersionID = 1,
+                    Operations = new List<string> { "read" }
+                }
+            },
+            ConsentHistoryEvents = new List<Altinn2ConsentRequestEvent>(),
+            RedirectUrl = "https://redirect.url",
+            TemplateId = "test-template"
+        };
+    }
+
+    private ConsentRequestDetails CreateConsentRequestDetails(Guid id, Guid fromPartyUuid, Guid toPartyUuid)
+    {
+        return new ConsentRequestDetails
+        {
+            Id = id,
+            From = ConsentPartyUrn.PartyUuid.Create(fromPartyUuid),
+            To = ConsentPartyUrn.PartyUuid.Create(toPartyUuid),
+            ValidTo = DateTimeOffset.UtcNow.AddDays(30),
+            Consented = DateTimeOffset.UtcNow,
+            RedirectUrl = "https://redirect.url",
+            ConsentRights = new List<ConsentRight>
+            {
+                new ConsentRight
+                {
+                    Action = new List<string> { "read" },
+                    Resource = new List<ConsentResourceAttribute>
+                    {
+                        new ConsentResourceAttribute
+                        {
+                            Type = "urn:altinn:resource",
+                            Value = "test-resource"
+                        }
+                    }
+                }
+            },
+            ConsentRequestEvents = new List<ConsentRequestEvent>()
+        };
+    }
+
+    private void SetupValidationMocks(Guid fromPartyUuid, Guid toPartyUuid)
+    {
+        // Mock party lookups with required PersonId or OrganizationId
+        _amPartyServiceMock
+            .Setup(x => x.GetByUid(fromPartyUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MinimalParty
+            {
+                PartyUuid = fromPartyUuid,
+                Name = "FromParty",
+                PersonId = "01025161013" // Add PersonId for external identity mapping
+            });
+
+        _amPartyServiceMock
+            .Setup(x => x.GetByUid(toPartyUuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MinimalParty
+            {
+                PartyUuid = toPartyUuid,
+                Name = "ToParty",
+                OrganizationId = "810419512" // Add OrganizationId for external identity mapping
+            });
+
+        // Mock resource registry for validation
+        _resourceRegistryClientMock
+            .Setup(x => x.GetResources(It.IsAny<CancellationToken>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<ServiceResource>
+            {
+            new ServiceResource
+            {
+                Identifier = "test-resource",
+                ResourceType = ResourceType.Consent,
+                ConsentTemplate = "test-template",
+                VersionId = 1
+            }
+            });
+
+        _resourceRegistryClientMock
+            .Setup(x => x.GetResource(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ServiceResource
+            {
+                Identifier = "test-resource",
+                ResourceType = ResourceType.Consent,
+                ConsentTemplate = "test-template",
+                VersionId = 1
+            });
+
+        _resourceRegistryClientMock
+            .Setup(x => x.GetConsentTemplate(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsentTemplate
+            {
+                Id = "test-template",
+                Version = 1,
+                Texts = new ConsentTemplateTexts()
+            });
+    }
+
+    private void SetupMemoryCache()
+    {
+        // Mock TryGetValue to return false (cache miss)
+        _memoryCacheMock
+            .Setup(x => x.TryGetValue(It.IsAny<object>(), out It.Ref<object>.IsAny))
+            .Returns(false);
+
+        // Mock CreateEntry for Set operations
+        var mockCacheEntry = new Mock<ICacheEntry>();
+        mockCacheEntry.SetupProperty(x => x.Value);
+        mockCacheEntry.SetupProperty(x => x.AbsoluteExpirationRelativeToNow);
+
+        _memoryCacheMock
+            .Setup(x => x.CreateEntry(It.IsAny<object>()))
+            .Returns(mockCacheEntry.Object);
+    }
+}


### PR DESCRIPTION
add condition to set migration status to success if the id already existed

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
