### PR TITLE
chore: backwards compatibility in case existing use of resource:instance-id urn is being used for app instances

### DIFF
--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
@@ -233,6 +233,10 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 requestResourceAttributes.Attributes.Add(GetStringAttribute(XacmlRequestAttribute.ResourceRegistryInstanceAttribute, resourceAttributes.AppInstanceIdValue));           
                 requestResourceAttributes.Attributes.Add(GetStringAttribute(XacmlRequestAttribute.ResourceRegistryInstanceAttribute, resourceAttributes.ResourceInstanceValue));
             }
+            else if (resourceAttributes.ResourceInstanceValue != null && !resourceAttributes.ResourceInstanceValue.StartsWith(XacmlRequestAttribute.InstanceAttribute) && resourceAttributes.OrgValue != null && resourceAttributes.AppValue != null && resourceAttributes.ResourcePartyValue != null)
+            {
+                requestResourceAttributes.Attributes.Add(GetStringAttribute(XacmlRequestAttribute.ResourceRegistryInstanceAttribute, $"{XacmlRequestAttribute.InstanceAttribute}:{resourceAttributes.ResourcePartyValue}/{resourceAttributes.ResourceInstanceValue}"));
+            }
 
             return requestResourceAttributes;
         }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ønsker egentlig ikke å ta inn denne endringen med mindre det viser seg at det er aktivt i bruk av noen (brukerstyrt signering?) allerede. I så fall må nok denne merges for å ikke knekke bakover kompatibilitet etter at vi aktiverer ny datamodell for instans-delegering.

## Related Issue(s)
- #2495

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

