### PR TITLE
feat: add /received/count and /sent/count endpoints

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/RequestController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/RequestController.cs
@@ -40,6 +40,8 @@ public class RequestController(
     IPDP Pdp
     ) : ControllerBase
 {
+    private static readonly RequestStatus[] DefaultStatusFilter = [RequestStatus.Draft, RequestStatus.Pending, RequestStatus.Approved, RequestStatus.Rejected, RequestStatus.Withdrawn];
+
     private Action<ConnectionOptions> ConfigureConnections { get; } = options =>
     {
         options.AllowedWriteFromEntityTypes = [EntityTypeConstants.Organization, EntityTypeConstants.Person];
@@ -68,8 +70,8 @@ public class RequestController(
         )
     {
         var statusFilter = status == null || !status.Any()
-            ? new List<RequestStatus>() { RequestStatus.Draft, RequestStatus.Pending, RequestStatus.Approved, RequestStatus.Rejected, RequestStatus.Withdrawn }
-            : status.ToList();
+            ? DefaultStatusFilter
+            : status;
 
         var result = await requestService.GetSentRequests(party, to, statusFilter, type, ct);
 
@@ -94,8 +96,8 @@ public class RequestController(
         )
     {
         var statusFilter = status == null || !status.Any()
-            ? new List<RequestStatus>() { RequestStatus.Draft, RequestStatus.Pending, RequestStatus.Approved, RequestStatus.Rejected, RequestStatus.Withdrawn }
-            : status.ToList();
+            ? DefaultStatusFilter
+            : status;
 
         var result = await requestService.GetReceivedRequests(party, from, statusFilter, type, ct);
         return result.IsSuccess ? Ok(PaginatedResult.Create(result.Value, null)) : result.Problem.ToActionResult();
@@ -118,8 +120,8 @@ public class RequestController(
         )
     {
         var statusFilter = status == null || !status.Any()
-            ? new List<RequestStatus>() { RequestStatus.Draft, RequestStatus.Pending, RequestStatus.Approved, RequestStatus.Rejected, RequestStatus.Withdrawn }
-            : status.ToList();
+            ? DefaultStatusFilter
+            : status;
 
         var result = await requestService.GetSentRequestsCount(party, to, statusFilter, type, ct);
 
@@ -143,8 +145,8 @@ public class RequestController(
         )
     {
         var statusFilter = status == null || !status.Any()
-            ? new List<RequestStatus>() { RequestStatus.Draft, RequestStatus.Pending, RequestStatus.Approved, RequestStatus.Rejected, RequestStatus.Withdrawn }
-            : status.ToList();
+            ? DefaultStatusFilter
+            : status;
 
         var result = await requestService.GetReceivedRequestsCount(party, from, statusFilter, type, ct);
         return result.IsSuccess ? Ok(result.Value) : result.Problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IRequestService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IRequestService.cs
@@ -14,22 +14,22 @@ public interface IRequestService
     Task<Result<RequestDto>> GetRequest(Guid requestId, CancellationToken ct = default);
 
     /// <summary>
-    /// Get requests created for party
+    /// Get requests sent by the party
     /// </summary>
     Task<Result<IEnumerable<RequestDto>>> GetSentRequests(Guid partyId, Guid? toId, IEnumerable<RequestStatus> status, string? type, CancellationToken ct = default);
-    
+
     /// <summary>
-    /// Get requests created at party
+    /// Get requests received by the party
     /// </summary>
     Task<Result<IEnumerable<RequestDto>>> GetReceivedRequests(Guid partyId, Guid? fromId, IEnumerable<RequestStatus> status, string? type, CancellationToken ct = default);
 
     /// <summary>
-    /// Get count of requests created for party
+    /// Get count of requests sent by the party
     /// </summary>
     Task<Result<int>> GetSentRequestsCount(Guid partyId, Guid? toId, IEnumerable<RequestStatus> status, string? type, CancellationToken ct = default);
 
     /// <summary>
-    /// Get count of requests created at party
+    /// Get count of requests received by the party
     /// </summary>
     Task<Result<int>> GetReceivedRequestsCount(Guid partyId, Guid? fromId, IEnumerable<RequestStatus> status, string? type, CancellationToken ct = default);
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/RequestService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/RequestService.cs
@@ -400,66 +400,62 @@ public class RequestService(AppDbContext db) : IRequestService
 
     private async Task<IEnumerable<RequestAssignmentResource>> GetRequestAssignmentResource(RequestFilter filter, IEnumerable<RequestStatus> status, CancellationToken ct)
     {
-        if (!filter.FromId.HasValue && !filter.ToId.HasValue)
-        {
-            throw new ArgumentException("At least one of fromId, toId or requestedBy must be provided");
-        }
+        ValidateFilter(filter);
 
-        return await db.RequestAssignmentResources
+        return await BuildRequestAssignmentResourceQuery(filter, status)
             .Include(r => r.Assignment).ThenInclude(a => a.From)
             .Include(r => r.Assignment).ThenInclude(a => a.To)
             .Include(r => r.Assignment).ThenInclude(a => a.Role)
             .Include(r => r.Resource)
-            .WhereIf(filter.FromId.HasValue, r => r.Assignment.FromId == filter.FromId.Value)
-            .WhereIf(filter.ToId.HasValue, r => r.Assignment.ToId == filter.ToId.Value)
-            .WhereIf(status?.Any() == true, r => status.Contains(r.Status))
             .ToListAsync(cancellationToken: ct);
     }
 
     private async Task<IEnumerable<RequestAssignmentPackage>> GetRequestAssignmentPackage(RequestFilter filter, IEnumerable<RequestStatus> status, CancellationToken ct)
     {
-        if (!filter.FromId.HasValue && !filter.ToId.HasValue)
-        {
-            throw new ArgumentException("At least one of fromId, toId or requestedBy must be provided");
-        }
+        ValidateFilter(filter);
 
-        return await db.RequestAssignmentPackages
+        return await BuildRequestAssignmentPackageQuery(filter, status)
             .Include(r => r.Assignment).ThenInclude(a => a.From)
             .Include(r => r.Assignment).ThenInclude(a => a.To)
             .Include(r => r.Assignment).ThenInclude(a => a.Role)
             .Include(r => r.Package)
-            .WhereIf(filter.FromId.HasValue, r => r.Assignment.FromId == filter.FromId.Value)
-            .WhereIf(filter.ToId.HasValue, r => r.Assignment.ToId == filter.ToId.Value)
-            .WhereIf(status?.Any() == true, r => status.Contains(r.Status))
             .ToListAsync(cancellationToken: ct);
     }
 
     private async Task<int> GetRequestAssignmentResourceCount(RequestFilter filter, IEnumerable<RequestStatus> status, CancellationToken ct)
     {
-        if (!filter.FromId.HasValue && !filter.ToId.HasValue)
-        {
-            throw new ArgumentException("At least one of fromId, toId or requestedBy must be provided");
-        }
-
-        return await db.RequestAssignmentResources
-            .WhereIf(filter.FromId.HasValue, r => r.Assignment.FromId == filter.FromId.Value)
-            .WhereIf(filter.ToId.HasValue, r => r.Assignment.ToId == filter.ToId.Value)
-            .WhereIf(status?.Any() == true, r => status.Contains(r.Status))
-            .CountAsync(cancellationToken: ct);
+        ValidateFilter(filter);
+        return await BuildRequestAssignmentResourceQuery(filter, status).CountAsync(cancellationToken: ct);
     }
 
     private async Task<int> GetRequestAssignmentPackageCount(RequestFilter filter, IEnumerable<RequestStatus> status, CancellationToken ct)
     {
-        if (!filter.FromId.HasValue && !filter.ToId.HasValue)
-        {
-            throw new ArgumentException("At least one of fromId, toId or requestedBy must be provided");
-        }
+        ValidateFilter(filter);
+        return await BuildRequestAssignmentPackageQuery(filter, status).CountAsync(cancellationToken: ct);
+    }
 
-        return await db.RequestAssignmentPackages
+    private IQueryable<RequestAssignmentResource> BuildRequestAssignmentResourceQuery(RequestFilter filter, IEnumerable<RequestStatus> status)
+    {
+        return db.RequestAssignmentResources
             .WhereIf(filter.FromId.HasValue, r => r.Assignment.FromId == filter.FromId.Value)
             .WhereIf(filter.ToId.HasValue, r => r.Assignment.ToId == filter.ToId.Value)
-            .WhereIf(status?.Any() == true, r => status.Contains(r.Status))
-            .CountAsync(cancellationToken: ct);
+            .WhereIf(status?.Any() == true, r => status.Contains(r.Status));
+    }
+
+    private IQueryable<RequestAssignmentPackage> BuildRequestAssignmentPackageQuery(RequestFilter filter, IEnumerable<RequestStatus> status)
+    {
+        return db.RequestAssignmentPackages
+            .WhereIf(filter.FromId.HasValue, r => r.Assignment.FromId == filter.FromId.Value)
+            .WhereIf(filter.ToId.HasValue, r => r.Assignment.ToId == filter.ToId.Value)
+            .WhereIf(status?.Any() == true, r => status.Contains(r.Status));
+    }
+
+    private static void ValidateFilter(RequestFilter filter)
+    {
+        if (!filter.FromId.HasValue && !filter.ToId.HasValue)
+        {
+            throw new ArgumentException("At least one of fromId or toId must be provided");
+        }
     }
 
     private async Task<Result<RequestAssignment>> GetOrCreateRequestAssignment(Guid fromId, Guid toId, Guid roleId, CancellationToken ct = default)


### PR DESCRIPTION
Lightweight endpoints in RequestController to retrieve request counts for notification badges without fetching full request data

## Description

**New Endpoints:**

**1. GET /accessmanagement/api/v1/enduser/request/received/count**
Returns the count of received requests for a party with a simple integer count

Parameters:
-   Party (required): The party ID to get counts for
-   From(AccessListAuthorizationRequest) (optional): Filter by sender
-   Status (optional): Filter by request status (e.g., ?status=pending)
-   Type (optional): Filter by type ("resource" or "package")

**2. GET /accessmanagement/api/v1/enduser/request/sent/count**
Returns the count of sent requests for a party with a simple integer count

Parameters:
- Party (required): The party ID to get counts for
- to (optional): Filter by recipient
- Status (optional): Filter by request status
- Type (optional): Filter by type ("resource" or "package")

## Implementation Details:

Service Layer (IRequestService & RequestService):
- Added GetSentRequestsCount() method
- Added GetReceivedRequestsCount() method
- GetRequestAssignmentResourceCount() - Uses CountAsync() for efficient counting
- GetRequestAssignmentPackageCount() - Uses CountAsync() for efficient counting

Controller Layer (RequestController):
- Both endpoints follow the same patterns as existing endpoints
- Same authorization, feature gates, and audit logging
- No pagination needed since they only return counts
- Much more lightweight than the full list endpoints

## Minor Refactors:

- Extract DefaultStatusFilter constant
- Refactor query building to shared methods
- Improve XML docs and fix error messages

## Related Issue(s)
- #2628

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
