### PR TITLE
Bugfix: Instance delegation not showing with EF feature flag enabled

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -7,6 +7,7 @@ using Altinn.AccessManagement.Core.Enums;
 using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Repositories.Interfaces;
 using Altinn.AccessManagement.Core.Services.Interfaces;
+using Altinn.AccessMgmt.Core;
 using Altinn.AccessMgmt.Core.Services.Contracts;
 using Altinn.AccessMgmt.Core.Utils.Helper;
 using Altinn.AccessMgmt.PersistenceEF.Constants;
@@ -27,7 +28,6 @@ public class AuthorizedPartiesServiceEf(
     Microsoft.FeatureManagement.IFeatureManager featureManager) : IAuthorizedPartiesService
 {
     private static readonly MemoryCacheEntryOptions _cacheEntryOptions = new() { AbsoluteExpirationRelativeToNow = new TimeSpan(0, 5, 0) };
-    private const string InstanceDelegationEfFeatureFlag = "AccessManagement.InstanceDelegation.EF";
 
     /// <inheritdoc/>
     public async Task<List<AuthorizedParty>> GetAuthorizedParties(BaseAttribute subjectAttribute, AuthorizedPartiesFilters filter, CancellationToken cancellationToken = default) => subjectAttribute.Type switch
@@ -643,7 +643,7 @@ public class AuthorizedPartiesServiceEf(
             return;
         }
 
-        bool useEF = await featureManager.IsEnabledAsync(InstanceDelegationEfFeatureFlag);
+        bool useEF = await featureManager.IsEnabledAsync(AccessMgmtFeatureFlags.InstanceDbEf);
 
         foreach (DelegationChange delegation in resourceDelegations)
         {


### PR DESCRIPTION
This fixes a bug where free dialogs with resources borrowed from an app were not showing correctly for delegation recipients when using the new EF data model.

## Description

Only add instance URN prefix when using the old data model (EF feature
flag disabled). When the InstanceDelegation.EF feature flag is enabled,
the instanceRef should be used as-is without modification.

Changes:
- Add IFeatureManager dependency to AuthorizedPartiesServiceEf
- Add feature flag check in EnrichWithResourceAndInstanceParties
- Change else to else if (!useEF) to conditionally add prefix
- Make EnrichWithResourceAndInstanceParties async to support feature check

## Related Issue(s)
#2652

https://github.com/Altinn/altinn-tests/issues/420
En fri dialog med ressurs "lånt" fra en app vil ved intstansdelegering ikke vises for den det delegeres til.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
