### PR TITLE
bug: authorized parties mangler aktører via app-delegering ved orgCode eller anyOfResourceIds filter

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/DelegationMetadataEF.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/DelegationMetadataEF.cs
@@ -71,6 +71,42 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
         };
     }
 
+    private DelegationChange ConvertForAuthorizedParties(AssignmentResource assignmentResource)
+    {
+        return new DelegationChange()
+        {
+            DelegationChangeId = assignmentResource.Resource.Type.Name == "AltinnApp"
+            ? assignmentResource.DelegationChangeId
+            : 0,
+            ResourceRegistryDelegationChangeId = assignmentResource.Resource.Type.Name != "AltinnApp"
+            ? assignmentResource.DelegationChangeId
+            : 0,
+            Created = assignmentResource.Audit_ValidFrom.UtcDateTime,
+
+            ResourceId = assignmentResource.Resource.RefId,
+
+            ResourceType = assignmentResource.Resource.Type.Name,
+            BlobStoragePolicyPath = assignmentResource.PolicyPath,
+            BlobStorageVersionId = assignmentResource.PolicyVersion,
+
+            FromUuid = assignmentResource.Assignment.FromId,
+            FromUuidType = ConvertEntityTypeToUuidType(assignmentResource.Assignment.From.TypeId),
+            OfferedByPartyId = assignmentResource.Assignment.From.PartyId.Value,
+
+            PerformedByUuid = assignmentResource.Audit_ChangedBy.ToString(),
+            PerformedByPartyId = assignmentResource.ChangedBy.PartyId,
+            PerformedByUserId = assignmentResource.ChangedBy.UserId,
+            PerformedByUuidType = ConvertEntityTypeToUuidType(assignmentResource.ChangedBy.TypeId),
+
+            DelegationChangeType = DelegationChangeType.Grant,
+
+            ToUuid = assignmentResource.Assignment.ToId,
+            ToUuidType = ConvertEntityTypeToUuidType(assignmentResource.Assignment.To.TypeId),
+            CoveredByUserId = assignmentResource.Assignment.To.UserId,
+            CoveredByPartyId = assignmentResource.Assignment.To.UserId.HasValue ? null : assignmentResource.Assignment.To.PartyId, // If CoveredByUserId already has value skip setting CoveredByPartyId as old logic expects only one of these
+        };
+    }
+
     private InstanceDelegationChange Convert(AssignmentInstance assignmentInstance)
     {
         return new InstanceDelegationChange()
@@ -895,7 +931,7 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
           .Where(t => t.Assignment.RoleId == RoleConstants.Rightholder)
           .ToListAsync(cancellationToken);
 
-        return result.Select(Convert).ToList();
+        return result.Select(ConvertForAuthorizedParties).ToList();
     }
 
     Task<List<DelegationChange>> IDelegationMetadataRepository.GetNextPageAppDelegationChanges(long startFeedIndex, CancellationToken cancellationToken)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Buggen har oppstått i sammenheng med overgang til ny datamodell for ressurs-delegeringer, som gikk i Prod 11. Mars

Feilen oppstår pga. at oppslaget av app-delegeringer blir app ressurs id på formatet "app_org_appname" konvertert tilbake til gammelt format "org/appname" for bakoverkompatibilitet med annen eksisterende bruk av det gamle database interfacet IDelegationMetadataRepository.

Fiks:
- Ha egen modell mapping for oppslaget fra AuthorizedParties som er avhengig av å kunne mappe på app-ressursId formatet
 
## Related Issue(s)
- #2792

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
