### PR TITLE
Maskinporten API for supplier and consumer

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenConsumersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenConsumersController.cs
@@ -73,7 +73,7 @@ public class MaskinportenConsumersController(
     public async Task<IActionResult> RemoveConsumer(
         [Required][FromQuery(Name = "party")] Guid party,
         [Required][FromQuery(Name = "consumer")] string consumer,
-        [FromQuery(Name = "cascade")] bool cascade = true,
+        [FromQuery(Name = "cascade")] bool cascade = false,
         CancellationToken cancellationToken = default)
     {
         var consumerEntity = await maskinportenSupplierService.GetEntity(consumer, cancellationToken);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenConsumersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenConsumersController.cs
@@ -1,0 +1,191 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Net.Mime;
+using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessMgmt.Core.Audit;
+using Altinn.AccessMgmt.Core.Extensions;
+using Altinn.AccessMgmt.Core.Models;
+using Altinn.AccessMgmt.Core.Services;
+using Altinn.AccessMgmt.Core.Services.Contracts;
+using Altinn.AccessMgmt.PersistenceEF.Constants;
+using Altinn.AccessMgmt.PersistenceEF.Utils;
+using Altinn.Authorization.Api.Contracts.AccessManagement;
+using Altinn.Authorization.ProblemDetails;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.AccessManagement.Api.Enduser.Controllers;
+
+/// <summary>
+/// Controller for managing Maskinporten consumer connections (from supplier perspective)
+/// </summary>
+[ApiController]
+[Route("accessmanagement/api/v1/enduser/maskinportenconsumers")]
+public class MaskinportenConsumersController(
+    IMaskinportenSupplierService maskinportenSupplierService
+    ) : ControllerBase
+{
+    private Action<ConnectionOptions> ConfigureConnections { get; } = options =>
+    {
+        // Maskinporten supplier delegations are restricted to organization-to-organization only
+        options.AllowedWriteFromEntityTypes = [EntityTypeConstants.Organization];
+        options.AllowedWriteToEntityTypes = [EntityTypeConstants.Organization];
+        options.AllowedReadFromEntityTypes = [EntityTypeConstants.Organization];
+        options.AllowedReadToEntityTypes = [EntityTypeConstants.Organization];
+        options.FilterFromEntityTypes = [];
+        options.FilterToEntityTypes = [];
+    };
+    /// <summary>
+    /// Gets all consumers for the authenticated supplier
+    /// </summary>
+    [HttpGet]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ)]
+    [ProducesResponseType<IEnumerable<ConnectionDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetConsumers(
+        [Required][FromQuery(Name = "party")] Guid party,
+        [FromQuery(Name = "consumer")] string? consumer = null,
+        CancellationToken cancellationToken = default)
+    {
+        Guid? consumerEntityId = null;
+
+        if (!string.IsNullOrWhiteSpace(consumer))
+        {
+            var consumerEntity = await maskinportenSupplierService.GetEntity(consumer, cancellationToken);
+            if (consumerEntity.IsProblem)
+            {
+                return consumerEntity.Problem.ToActionResult();
+            }
+
+            consumerEntityId = consumerEntity.Value.Id;
+        }
+
+        var result = await maskinportenSupplierService.GetConsumers(party, consumerEntityId, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Removes a consumer connection (supplier relinquishes their access)
+    /// </summary>
+    [HttpDelete]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> RemoveConsumer(
+        [Required][FromQuery(Name = "party")] Guid party,
+        [Required][FromQuery(Name = "consumer")] string consumer,
+        [FromQuery(Name = "cascade")] bool cascade = true,
+        CancellationToken cancellationToken = default)
+    {
+        var consumerEntity = await maskinportenSupplierService.GetEntity(consumer, cancellationToken);
+        if (consumerEntity.IsProblem)
+        {
+            return consumerEntity.Problem.ToActionResult();
+        }
+
+        // Note: From supplier perspective, they are removing themselves (party) from consumer
+        // So the fromId is consumer, toId is supplier (party)
+        var problem = await maskinportenSupplierService.RemoveSupplier(consumerEntity.Value.Id, party, cascade, cancellationToken);
+        if (problem is { })
+        {
+            return problem.ToActionResult();
+        }
+
+        return NoContent();
+    }
+
+    #region Resources
+
+    /// <summary>
+    /// Gets MaskinportenSchema resources delegated from consumers
+    /// </summary>
+    [HttpGet("resources")]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ)]
+    [ProducesResponseType<IEnumerable<ResourcePermissionDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetResources(
+        [Required][FromQuery(Name = "party")] Guid party,
+        [FromQuery(Name = "consumer")] string? consumer = null,
+        [FromQuery(Name = "resource")] string? resource = null,
+        [FromQuery(Name = "scope")] string? scope = null,
+        CancellationToken cancellationToken = default)
+    {
+        Guid? consumerEntityId = null;
+        Guid? resourceId = null;
+
+        if (!string.IsNullOrWhiteSpace(consumer))
+        {
+            var consumerEntity = await maskinportenSupplierService.GetEntity(consumer, cancellationToken);
+            if (consumerEntity.IsProblem)
+            {
+                return consumerEntity.Problem.ToActionResult();
+            }
+
+            consumerEntityId = consumerEntity.Value.Id;
+        }
+
+        if (!string.IsNullOrWhiteSpace(resource))
+        {
+            var resourceEntity = await maskinportenSupplierService.GetResourceByRefId(resource, cancellationToken);
+            if (resourceEntity.IsProblem)
+            {
+                return resourceEntity.Problem.ToActionResult();
+            }
+
+            resourceId = resourceEntity.Value.Id;
+        }
+
+        var result = await maskinportenSupplierService.GetConsumerResources(party, consumerEntityId, resourceId, scope, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Removes a MaskinportenSchema resource delegation (supplier relinquishes access to a specific resource)
+    /// </summary>
+    [HttpDelete("resources")]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> RemoveResource(
+        [Required][FromQuery(Name = "party")] Guid party,
+        [Required][FromQuery(Name = "consumer")] string consumer,
+        [Required][FromQuery(Name = "resource")] string resource,
+        CancellationToken cancellationToken = default)
+    {
+        var consumerEntity = await maskinportenSupplierService.GetEntity(consumer, cancellationToken);
+        if (consumerEntity.IsProblem)
+        {
+            return consumerEntity.Problem.ToActionResult();
+        }
+
+        // From supplier perspective: consumer is fromId, supplier (party) is toId
+        var problem = await maskinportenSupplierService.RemoveResource(consumerEntity.Value.Id, party, resource, cancellationToken);
+        if (problem is { })
+        {
+            return problem.ToActionResult();
+        }
+
+        return NoContent();
+    }
+
+    #endregion
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenConsumersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenConsumersController.cs
@@ -28,7 +28,7 @@ public class MaskinportenConsumersController(
     /// Gets all consumers for the authenticated supplier
     /// </summary>
     [HttpGet]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ)]
     [ProducesResponseType<IEnumerable<ConnectionDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -64,7 +64,7 @@ public class MaskinportenConsumersController(
     /// Removes a consumer connection (supplier relinquishes their access)
     /// </summary>
     [HttpDelete]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
@@ -99,7 +99,7 @@ public class MaskinportenConsumersController(
     /// Gets MaskinportenSchema resources delegated from consumers
     /// </summary>
     [HttpGet("resources")]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ)]
     [ProducesResponseType<IEnumerable<ResourcePermissionDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -149,7 +149,7 @@ public class MaskinportenConsumersController(
     /// Removes a MaskinportenSchema resource delegation (supplier relinquishes access to a specific resource)
     /// </summary>
     [HttpDelete("resources")]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenConsumersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenConsumersController.cs
@@ -24,16 +24,6 @@ public class MaskinportenConsumersController(
     IMaskinportenSupplierService maskinportenSupplierService
     ) : ControllerBase
 {
-    private Action<ConnectionOptions> ConfigureConnections { get; } = options =>
-    {
-        // Maskinporten supplier delegations are restricted to organization-to-organization only
-        options.AllowedWriteFromEntityTypes = [EntityTypeConstants.Organization];
-        options.AllowedWriteToEntityTypes = [EntityTypeConstants.Organization];
-        options.AllowedReadFromEntityTypes = [EntityTypeConstants.Organization];
-        options.AllowedReadToEntityTypes = [EntityTypeConstants.Organization];
-        options.FilterFromEntityTypes = [];
-        options.FilterToEntityTypes = [];
-    };
     /// <summary>
     /// Gets all consumers for the authenticated supplier
     /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenConsumersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenConsumersController.cs
@@ -108,7 +108,6 @@ public class MaskinportenConsumersController(
         [Required][FromQuery(Name = "party")] Guid party,
         [FromQuery(Name = "consumer")] string? consumer = null,
         [FromQuery(Name = "resource")] string? resource = null,
-        [FromQuery(Name = "scope")] string? scope = null,
         CancellationToken cancellationToken = default)
     {
         Guid? consumerEntityId = null;
@@ -136,7 +135,7 @@ public class MaskinportenConsumersController(
             resourceId = resourceEntity.Value.Id;
         }
 
-        var result = await maskinportenSupplierService.GetConsumerResources(party, consumerEntityId, resourceId, scope, cancellationToken);
+        var result = await maskinportenSupplierService.GetConsumerResources(party, consumerEntityId, resourceId, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
@@ -29,7 +29,7 @@ public class MaskinportenSuppliersController(
     /// Adds a supplier assignment to allow an organization to receive Maskinporten scope delegations
     /// </summary>
     [HttpPost]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
     [ProducesResponseType<AssignmentDto>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
@@ -60,7 +60,7 @@ public class MaskinportenSuppliersController(
     /// Gets all suppliers for the authenticated party
     /// </summary>
     [HttpGet]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ)]
     [ProducesResponseType<IEnumerable<ConnectionDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -82,7 +82,7 @@ public class MaskinportenSuppliersController(
     /// Removes a supplier assignment
     /// </summary>
     [HttpDelete]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
@@ -115,7 +115,7 @@ public class MaskinportenSuppliersController(
     /// Performs a delegation check for a MaskinportenSchema resource
     /// </summary>
     [HttpGet("resources/delegationcheck")]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ)]
     [ProducesResponseType<ResourceCheckDto>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -140,7 +140,7 @@ public class MaskinportenSuppliersController(
     /// Delegates a MaskinportenSchema resource to a supplier
     /// </summary>
     [HttpPost("resources")]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
     [ProducesResponseType<bool>(StatusCodes.Status200OK)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
@@ -171,7 +171,7 @@ public class MaskinportenSuppliersController(
     /// Gets delegated MaskinportenSchema resources for suppliers
     /// </summary>
     [HttpGet("resources")]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ)]
     [ProducesResponseType<IEnumerable<ResourcePermissionDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -221,7 +221,7 @@ public class MaskinportenSuppliersController(
     /// Removes a MaskinportenSchema resource delegation from a supplier
     /// </summary>
     [HttpDelete("resources")]
-    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
@@ -67,9 +67,23 @@ public class MaskinportenSuppliersController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetSuppliers(
         [Required][FromQuery(Name = "party")] Guid party,
+        [FromQuery(Name = "supplier")] string? supplier = null,
         CancellationToken cancellationToken = default)
     {
-        var result = await maskinportenSupplierService.GetSuppliers(party, supplierId: null, cancellationToken);
+        Guid? supplierEntityId = null;
+
+        if (!string.IsNullOrWhiteSpace(supplier))
+        {
+            var supplierEntity = await maskinportenSupplierService.GetEntity(supplier, cancellationToken);
+            if (supplierEntity.IsProblem)
+            {
+                return supplierEntity.Problem.ToActionResult();
+            }
+
+            supplierEntityId = supplierEntity.Value.Id;
+        }
+
+        var result = await maskinportenSupplierService.GetSuppliers(party, supplierEntityId, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -125,7 +139,7 @@ public class MaskinportenSuppliersController(
         [Required][FromQuery(Name = "resource")] string resource,
         CancellationToken cancellationToken = default)
     {
-        Guid authenticatedUserUuid = AuthenticationHelper.GetPartyUuid(HttpContext);
+        Guid authenticatedUserUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
 
         var result = await maskinportenSupplierService.ResourceDelegationCheck(authenticatedUserUuid, party, resource, cancellationToken: cancellationToken);
         if (result.IsProblem)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Net.Mime;
 using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessManagement.Core.Helpers;
 using Altinn.AccessMgmt.Core.Audit;
 using Altinn.AccessMgmt.Core.Extensions;
 using Altinn.AccessMgmt.Core.Models;
@@ -24,16 +25,6 @@ public class MaskinportenSuppliersController(
     IMaskinportenSupplierService maskinportenSupplierService
     ) : ControllerBase
 {
-    private Action<ConnectionOptions> ConfigureConnections { get; } = options =>
-    {
-        // Maskinporten supplier delegations are restricted to organization-to-organization only
-        options.AllowedWriteFromEntityTypes = [EntityTypeConstants.Organization];
-        options.AllowedWriteToEntityTypes = [EntityTypeConstants.Organization];
-        options.AllowedReadFromEntityTypes = [EntityTypeConstants.Organization];
-        options.AllowedReadToEntityTypes = [EntityTypeConstants.Organization];
-        options.FilterFromEntityTypes = [];
-        options.FilterToEntityTypes = [];
-    };
     /// <summary>
     /// Adds a supplier assignment to allow an organization to receive Maskinporten scope delegations
     /// </summary>
@@ -134,7 +125,9 @@ public class MaskinportenSuppliersController(
         [Required][FromQuery(Name = "resource")] string resource,
         CancellationToken cancellationToken = default)
     {
-        var result = await maskinportenSupplierService.ResourceDelegationCheck(party, resource, cancellationToken: cancellationToken);
+        Guid authenticatedUserUuid = AuthenticationHelper.GetPartyUuid(HttpContext);
+
+        var result = await maskinportenSupplierService.ResourceDelegationCheck(authenticatedUserUuid, party, resource, cancellationToken: cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
@@ -140,8 +140,9 @@ public class MaskinportenSuppliersController(
         CancellationToken cancellationToken = default)
     {
         Guid authenticatedUserUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
+        string languageCode = this.GetLanguageCode();
 
-        var result = await maskinportenSupplierService.ResourceDelegationCheck(authenticatedUserUuid, party, resource, cancellationToken: cancellationToken);
+        var result = await maskinportenSupplierService.ResourceDelegationCheck(authenticatedUserUuid, party, resource, languageCode: languageCode, cancellationToken: cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
@@ -1,0 +1,259 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Net.Mime;
+using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessMgmt.Core.Audit;
+using Altinn.AccessMgmt.Core.Extensions;
+using Altinn.AccessMgmt.Core.Models;
+using Altinn.AccessMgmt.Core.Services;
+using Altinn.AccessMgmt.Core.Services.Contracts;
+using Altinn.AccessMgmt.PersistenceEF.Constants;
+using Altinn.AccessMgmt.PersistenceEF.Utils;
+using Altinn.Authorization.Api.Contracts.AccessManagement;
+using Altinn.Authorization.ProblemDetails;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.AccessManagement.Api.Enduser.Controllers;
+
+/// <summary>
+/// Controller for managing Maskinporten supplier assignments and scope delegations
+/// </summary>
+[ApiController]
+[Route("accessmanagement/api/v1/enduser/maskinportensuppliers")]
+public class MaskinportenSuppliersController(
+    IMaskinportenSupplierService maskinportenSupplierService
+    ) : ControllerBase
+{
+    private Action<ConnectionOptions> ConfigureConnections { get; } = options =>
+    {
+        // Maskinporten supplier delegations are restricted to organization-to-organization only
+        options.AllowedWriteFromEntityTypes = [EntityTypeConstants.Organization];
+        options.AllowedWriteToEntityTypes = [EntityTypeConstants.Organization];
+        options.AllowedReadFromEntityTypes = [EntityTypeConstants.Organization];
+        options.AllowedReadToEntityTypes = [EntityTypeConstants.Organization];
+        options.FilterFromEntityTypes = [];
+        options.FilterToEntityTypes = [];
+    };
+    /// <summary>
+    /// Adds a supplier assignment to allow an organization to receive Maskinporten scope delegations
+    /// </summary>
+    [HttpPost]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType<AssignmentDto>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> AddSupplier(
+        [Required][FromQuery(Name = "party")] Guid party,
+        [Required][FromQuery(Name = "supplier")] string supplier,
+        CancellationToken cancellationToken = default)
+    {
+        // Look up supplier entity by organization number
+        var supplierEntity = await maskinportenSupplierService.GetEntity(supplier, cancellationToken);
+        if (supplierEntity.IsProblem)
+        {
+            return supplierEntity.Problem.ToActionResult();
+        }
+
+        var result = await maskinportenSupplierService.AddSupplier(party, supplierEntity.Value.Id, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Gets all suppliers for the authenticated party
+    /// </summary>
+    [HttpGet]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ)]
+    [ProducesResponseType<IEnumerable<ConnectionDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetSuppliers(
+        [Required][FromQuery(Name = "party")] Guid party,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await maskinportenSupplierService.GetSuppliers(party, supplierId: null, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Removes a supplier assignment
+    /// </summary>
+    [HttpDelete]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> RemoveSupplier(
+        [Required][FromQuery(Name = "party")] Guid party,
+        [Required][FromQuery(Name = "supplier")] string supplier,
+        [FromQuery(Name = "cascade")] bool cascade = false,
+        CancellationToken cancellationToken = default)
+    {
+        var supplierEntity = await maskinportenSupplierService.GetEntity(supplier, cancellationToken);
+        if (supplierEntity.IsProblem)
+        {
+            return supplierEntity.Problem.ToActionResult();
+        }
+
+        var problem = await maskinportenSupplierService.RemoveSupplier(party, supplierEntity.Value.Id, cascade, cancellationToken);
+        if (problem is { })
+        {
+            return problem.ToActionResult();
+        }
+
+        return NoContent();
+    }
+
+    #region Resources
+
+    /// <summary>
+    /// Performs a delegation check for a MaskinportenSchema resource
+    /// </summary>
+    [HttpGet("resources/delegationcheck")]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ)]
+    [ProducesResponseType<ResourceCheckDto>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DelegationCheck(
+        [Required][FromQuery(Name = "party")] Guid party,
+        [Required][FromQuery(Name = "resource")] string resource,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await maskinportenSupplierService.ResourceDelegationCheck(party, resource, cancellationToken: cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Delegates a MaskinportenSchema resource to a supplier
+    /// </summary>
+    [HttpPost("resources")]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType<bool>(StatusCodes.Status200OK)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> AddResource(
+        [Required][FromQuery(Name = "party")] Guid party,
+        [Required][FromQuery(Name = "supplier")] string supplier,
+        [Required][FromQuery(Name = "resource")] string resource,
+        CancellationToken cancellationToken = default)
+    {
+        var supplierEntity = await maskinportenSupplierService.GetEntity(supplier, cancellationToken);
+        if (supplierEntity.IsProblem)
+        {
+            return supplierEntity.Problem.ToActionResult();
+        }
+
+        var result = await maskinportenSupplierService.AddResource(party, supplierEntity.Value.Id, resource, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Gets delegated MaskinportenSchema resources for suppliers
+    /// </summary>
+    [HttpGet("resources")]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ)]
+    [ProducesResponseType<IEnumerable<ResourcePermissionDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetResources(
+        [Required][FromQuery(Name = "party")] Guid party,
+        [FromQuery(Name = "supplier")] string? supplier = null,
+        [FromQuery(Name = "resource")] string? resource = null,
+        [FromQuery(Name = "scope")] string? scope = null,
+        CancellationToken cancellationToken = default)
+    {
+        Guid? supplierEntityId = null;
+        Guid? resourceId = null;
+
+        if (!string.IsNullOrWhiteSpace(supplier))
+        {
+            var supplierEntity = await maskinportenSupplierService.GetEntity(supplier, cancellationToken);
+            if (supplierEntity.IsProblem)
+            {
+                return supplierEntity.Problem.ToActionResult();
+            }
+
+            supplierEntityId = supplierEntity.Value.Id;
+        }
+
+        if (!string.IsNullOrWhiteSpace(resource))
+        {
+            var resourceEntity = await maskinportenSupplierService.GetResourceByRefId(resource, cancellationToken);
+            if (resourceEntity.IsProblem)
+            {
+                return resourceEntity.Problem.ToActionResult();
+            }
+
+            resourceId = resourceEntity.Value.Id;
+        }
+
+        var result = await maskinportenSupplierService.GetSupplierResources(party, supplierEntityId, resourceId, scope, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Removes a MaskinportenSchema resource delegation from a supplier
+    /// </summary>
+    [HttpDelete("resources")]
+    [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> RemoveResource(
+        [Required][FromQuery(Name = "party")] Guid party,
+        [Required][FromQuery(Name = "supplier")] string supplier,
+        [Required][FromQuery(Name = "resource")] string resource,
+        CancellationToken cancellationToken = default)
+    {
+        var supplierEntity = await maskinportenSupplierService.GetEntity(supplier, cancellationToken);
+        if (supplierEntity.IsProblem)
+        {
+            return supplierEntity.Problem.ToActionResult();
+        }
+
+        var problem = await maskinportenSupplierService.RemoveResource(party, supplierEntity.Value.Id, resource, cancellationToken);
+        if (problem is { })
+        {
+            return problem.ToActionResult();
+        }
+
+        return NoContent();
+    }
+
+    #endregion
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/MaskinportenSuppliersController.cs
@@ -194,7 +194,6 @@ public class MaskinportenSuppliersController(
         [Required][FromQuery(Name = "party")] Guid party,
         [FromQuery(Name = "supplier")] string? supplier = null,
         [FromQuery(Name = "resource")] string? resource = null,
-        [FromQuery(Name = "scope")] string? scope = null,
         CancellationToken cancellationToken = default)
     {
         Guid? supplierEntityId = null;
@@ -222,7 +221,7 @@ public class MaskinportenSuppliersController(
             resourceId = resourceEntity.Value.Id;
         }
 
-        var result = await maskinportenSupplierService.GetSupplierResources(party, supplierEntityId, resourceId, scope, cancellationToken);
+        var result = await maskinportenSupplierService.GetSupplierResources(party, supplierEntityId, resourceId, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Constants/AuthzConstants.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Constants/AuthzConstants.cs
@@ -29,7 +29,7 @@
         /// Policy tag for reading an maskinporten delegation
         /// </summary>
         public const string POLICY_MASKINPORTEN_DELEGATION_READ = "MaskinportenDelegationRead";
-        
+
         /// <summary>
         /// Policy tag for writing an maskinporten delegation
         /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Constants/AuthzConstants.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Constants/AuthzConstants.cs
@@ -36,6 +36,16 @@
         public const string POLICY_MASKINPORTEN_DELEGATION_WRITE = "MaskinportenDelegationWrite";
 
         /// <summary>
+        /// Policy tag for reading maskinporten delegation for end users
+        /// </summary>
+        public const string POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ = "MaskinportenDelegationEndUserRead";
+
+        /// <summary>
+        /// Policy tag for writing maskinporten delegation for end users
+        /// </summary>
+        public const string POLICY_MASKINPORTEN_DELEGATION_ENDUSER_WRITE = "MaskinportenDelegationEndUserWrite";
+
+        /// <summary>
         /// Policy tag for reading access management information
         /// </summary>
         public const string POLICY_ACCESS_MANAGEMENT_READ = "AccessManagementRead";

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
@@ -314,6 +314,8 @@ internal static partial class AccessManagementHost
             .AddPolicy(AuthzConstants.INTERNAL_AUTHORIZATION, policy => policy.Requirements.Add(new ClaimAccessRequirement("urn:altinn:app", "internal.authorization")))
             .AddPolicy(AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ, policy => policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_maskinporten_scope_delegation")))
             .AddPolicy(AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE, policy => policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_maskinporten_scope_delegation")))
+            .AddPolicy(AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ, policy => policy.Requirements.Add(new EndUserResourceAccessRequirement("read", "altinn_maskinporten_scope_delegation", false)))
+            .AddPolicy(AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_ENDUSER_WRITE, policy => policy.Requirements.Add(new EndUserResourceAccessRequirement("write", "altinn_maskinporten_scope_delegation", false)))
             .AddPolicy(AuthzConstants.POLICY_MASKINPORTEN_DELEGATIONS_PROXY, policy => policy.Requirements.Add(new ScopeAccessRequirement(["altinn:maskinporten/delegations", "altinn:maskinporten/delegations.admin"])))
             .AddPolicy(AuthzConstants.POLICY_MASKINPORTEN_CONSENT_READ, policy => policy.Requirements.Add(new ScopeAccessRequirement(["altinn:maskinporten/consent.read"])))
             .AddPolicy(AuthzConstants.POLICY_ACCESS_MANAGEMENT_READ, policy => policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_access_management")))

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Extensions/ServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<RegisterHostedService>();
         services.AddScoped<IIngestService, IngestService>();
         services.AddScoped<IConnectionService, ConnectionService>();
+        services.AddScoped<IMaskinportenSupplierService, MaskinportenSupplierService>();
         services.AddScoped<IPartyService, PartyService>();
         services.AddScoped<IPackageService, PackageService>();
         services.AddScoped<IRoleService, RoleService>();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
@@ -892,7 +892,7 @@ public partial class ConnectionService(
     }
 
     /// <inheritdoc />
-    public async Task<Result<ResourceCheckDto>> ResourceDelegationCheck(Guid authenticatedUserUuid, Guid party, string resource, Action<ConnectionOptions> configureConnection = null, string languageCode = "nb", bool ignoreDelegableFlag = false, CancellationToken cancellationToken = default)
+    public async Task<Result<ResourceCheckDto>> ResourceDelegationCheck(Guid authenticatedUserUuid, Guid party, string resource, Action<ConnectionOptions> configureConnection = null, string languageCode = "nb", bool ignoreDelegableFlag = false, bool allowMaskinportenSchema = false, CancellationToken cancellationToken = default)
     {
         // Get fromParty
         MinimalParty fromParty = await partyService.GetByUid(party, cancellationToken);
@@ -935,7 +935,7 @@ public partial class ConnectionService(
         }        
 
         ResourceAccessListMode accessListMode = resourceMetadata.AccessListMode;
-        bool isResourceDelegable = ignoreDelegableFlag || resourceMetadata.Delegable;
+        bool isResourceDelegable = ignoreDelegableFlag || resourceMetadata.Delegable || (allowMaskinportenSchema && isMaskinPortenSchema);
 
         // Decompose policy into resource/tasks
         List<Models.Right> rights = DelegationCheckHelper.DecomposePolicy(policy, resource);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
@@ -899,7 +899,7 @@ public partial class ConnectionService(
 
         ResourceDto resourceDto;
         XacmlPolicy policy;
-        bool isMaskinPortenSchema = false;
+        bool isMaskinPortenSchemaResource = false;
 
         try
         {
@@ -916,8 +916,12 @@ public partial class ConnectionService(
 
         if (resourceDto.Type.Name.Equals("MaskinportenSchema", StringComparison.InvariantCultureIgnoreCase))
         {
-            isMaskinPortenSchema = true;
+            isMaskinPortenSchemaResource = true;
         }
+
+        // When allowMaskinportenSchema is true, we don't want to deny delegation for MaskinportenSchema resources
+        // isMaskinPortenSchema is used later to add denial reasons, so we only set it when we want to deny
+        bool isMaskinPortenSchema = isMaskinPortenSchemaResource && !allowMaskinportenSchema;
 
         // Fetch Resourcemetadata
         ServiceResource resourceMetadata = await contextRetrievalService.GetResource(resource, cancellationToken);
@@ -935,7 +939,7 @@ public partial class ConnectionService(
         }        
 
         ResourceAccessListMode accessListMode = resourceMetadata.AccessListMode;
-        bool isResourceDelegable = ignoreDelegableFlag || resourceMetadata.Delegable || (allowMaskinportenSchema && isMaskinPortenSchema);
+        bool isResourceDelegable = ignoreDelegableFlag || resourceMetadata.Delegable || (allowMaskinportenSchema && isMaskinPortenSchemaResource);
 
         // Decompose policy into resource/tasks
         List<Models.Right> rights = DelegationCheckHelper.DecomposePolicy(policy, resource);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IConnectionService.cs
@@ -191,9 +191,10 @@ public interface IConnectionService
     /// <param name="configureConnection">ConnectionOptions</param>
     /// <param name="languageCode">the requested language code fallback "nb"</param>
     /// <param name="ignoreDelegableFlag">When true, the resource's Delegable flag is ignored and only the user's access is checked. Used for consent scenarios where re-delegation should not be allowed but access verification is still needed.</param>
+    /// <param name="allowMaskinportenSchema">When true, allows delegation of MaskinportenSchema resources even if delegable=false, but still requires valid access rights. Used for Maskinporten scope delegation scenarios.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The result on all the resource/action that is delegable on the resource and a reason behind if the user can or can not delegate a given action</returns>
-    Task<Result<ResourceCheckDto>> ResourceDelegationCheck(Guid authenticatedUserUuid, Guid party, string resource, Action<ConnectionOptions> configureConnection = null, string languageCode = "nb", bool ignoreDelegableFlag = false, CancellationToken cancellationToken = default);
+    Task<Result<ResourceCheckDto>> ResourceDelegationCheck(Guid authenticatedUserUuid, Guid party, string resource, Action<ConnectionOptions> configureConnection = null, string languageCode = "nb", bool ignoreDelegableFlag = false, bool allowMaskinportenSchema = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Method to check if a resource instance is delegable by an authenticated user on behalf of a party

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IEntityService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IEntityService.cs
@@ -19,6 +19,14 @@ public interface IEntityService
     Task<Entity> GetByOrgNo(string orgNo, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Get Entity based on OrgNo with Type navigation property included
+    /// </summary>
+    /// <param name="orgNo">Organization No</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns></returns>
+    Task<Entity> GetByOrgNoWithType(string orgNo, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get Entity based on PersNo
     /// </summary>
     /// <param name="persNo">persNo</param>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IMaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IMaskinportenSupplierService.cs
@@ -1,0 +1,139 @@
+﻿using Altinn.AccessMgmt.Core.Models;
+using Altinn.AccessMgmt.PersistenceEF.Models;
+using Altinn.Authorization.Api.Contracts.AccessManagement;
+using Altinn.Authorization.ProblemDetails;
+
+namespace Altinn.AccessMgmt.Core.Services.Contracts;
+
+/// <summary>
+/// Interface for managing Maskinporten supplier relationships and scope delegations
+/// </summary>
+public interface IMaskinportenSupplierService
+{
+    /// <summary>
+    /// Adds a supplier assignment between two organizations for MaskinportenSchema resources
+    /// </summary>
+    /// <param name="consumerId">The organization granting access (consumer)</param>
+    /// <param name="supplierId">The organization receiving access (supplier)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The created assignment</returns>
+    Task<Result<AssignmentDto>> AddSupplier(Guid consumerId, Guid supplierId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a supplier assignment
+    /// </summary>
+    /// <param name="consumerId">The consumer organization ID</param>
+    /// <param name="supplierId">The supplier organization ID</param>
+    /// <param name="cascade">Whether to cascade delete related delegations</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Validation problem if any</returns>
+    Task<ValidationProblemInstance> RemoveSupplier(Guid consumerId, Guid supplierId, bool cascade = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all suppliers for a consumer organization
+    /// </summary>
+    /// <param name="consumerId">The consumer organization ID</param>
+    /// <param name="supplierId">Optional supplier filter</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of suppliers</returns>
+    Task<Result<IEnumerable<ConnectionDto>>> GetSuppliers(Guid consumerId, Guid? supplierId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all consumers for a supplier organization
+    /// </summary>
+    /// <param name="supplierId">The supplier organization ID</param>
+    /// <param name="consumerId">Optional consumer filter</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of consumers</returns>
+    Task<Result<IEnumerable<ConnectionDto>>> GetConsumers(Guid supplierId, Guid? consumerId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets MaskinportenSchema resources delegated to suppliers
+    /// </summary>
+    /// <param name="consumerId">The consumer organization ID</param>
+    /// <param name="supplierId">Optional supplier filter</param>
+    /// <param name="resourceId">Optional resource filter</param>
+    /// <param name="scope">Optional Maskinporten scope filter</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of resource permissions</returns>
+    Task<Result<IEnumerable<ResourcePermissionDto>>> GetSupplierResources(
+        Guid consumerId,
+        Guid? supplierId = null,
+        Guid? resourceId = null,
+        string? scope = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets MaskinportenSchema resources delegated from consumers
+    /// </summary>
+    /// <param name="supplierId">The supplier organization ID</param>
+    /// <param name="consumerId">Optional consumer filter</param>
+    /// <param name="resourceId">Optional resource filter</param>
+    /// <param name="scope">Optional Maskinporten scope filter</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of resource permissions</returns>
+    Task<Result<IEnumerable<ResourcePermissionDto>>> GetConsumerResources(
+        Guid supplierId,
+        Guid? consumerId = null,
+        Guid? resourceId = null,
+        string? scope = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Performs a delegation check for a MaskinportenSchema resource
+    /// </summary>
+    /// <param name="consumerId">The consumer organization ID</param>
+    /// <param name="resource">The resource identifier</param>
+    /// <param name="languageCode">Language code for translations</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Resource check result</returns>
+    Task<Result<ResourceCheckDto>> ResourceDelegationCheck(
+        Guid consumerId,
+        string resource,
+        string languageCode = "nb",
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a MaskinportenSchema resource delegation to a supplier
+    /// </summary>
+    /// <param name="consumerId">The consumer organization ID</param>
+    /// <param name="supplierId">The supplier organization ID</param>
+    /// <param name="resource">The resource identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Success result</returns>
+    Task<Result<bool>> AddResource(
+        Guid consumerId,
+        Guid supplierId,
+        string resource,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a MaskinportenSchema resource delegation from a supplier
+    /// </summary>
+    /// <param name="consumerId">The consumer organization ID</param>
+    /// <param name="supplierId">The supplier organization ID</param>
+    /// <param name="resource">The resource identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Validation problem if any</returns>
+    Task<ValidationProblemInstance> RemoveResource(
+        Guid consumerId,
+        Guid supplierId,
+        string resource,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets an entity by organization number
+    /// </summary>
+    /// <param name="organizationNumber">The organization number</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The entity</returns>
+    Task<Result<Entity>> GetEntity(string organizationNumber, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a resource by RefId
+    /// </summary>
+    /// <param name="resourceRefId">The resource RefId</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The resource</returns>
+    Task<Result<Resource>> GetResourceByRefId(string resourceRefId, CancellationToken cancellationToken = default);
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IMaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IMaskinportenSupplierService.cs
@@ -53,14 +53,12 @@ public interface IMaskinportenSupplierService
     /// <param name="consumerId">The consumer organization ID</param>
     /// <param name="supplierId">Optional supplier filter</param>
     /// <param name="resourceId">Optional resource filter</param>
-    /// <param name="scope">Optional Maskinporten scope filter</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>List of resource permissions</returns>
     Task<Result<IEnumerable<ResourcePermissionDto>>> GetSupplierResources(
         Guid consumerId,
         Guid? supplierId = null,
         Guid? resourceId = null,
-        string? scope = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -69,14 +67,12 @@ public interface IMaskinportenSupplierService
     /// <param name="supplierId">The supplier organization ID</param>
     /// <param name="consumerId">Optional consumer filter</param>
     /// <param name="resourceId">Optional resource filter</param>
-    /// <param name="scope">Optional Maskinporten scope filter</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>List of resource permissions</returns>
     Task<Result<IEnumerable<ResourcePermissionDto>>> GetConsumerResources(
         Guid supplierId,
         Guid? consumerId = null,
         Guid? resourceId = null,
-        string? scope = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IMaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IMaskinportenSupplierService.cs
@@ -82,12 +82,14 @@ public interface IMaskinportenSupplierService
     /// <summary>
     /// Performs a delegation check for a MaskinportenSchema resource
     /// </summary>
+    /// <param name="authenticatedUserUuid">UUID of the authenticated user performing the check</param>
     /// <param name="consumerId">The consumer organization ID</param>
     /// <param name="resource">The resource identifier</param>
     /// <param name="languageCode">Language code for translations</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Resource check result</returns>
     Task<Result<ResourceCheckDto>> ResourceDelegationCheck(
+        Guid authenticatedUserUuid,
         Guid consumerId,
         string resource,
         string languageCode = "nb",

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/EntityService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/EntityService.cs
@@ -80,6 +80,14 @@ public class EntityService : IEntityService
             .FirstOrDefaultAsync(cancellationToken);
 
     /// <inheritdoc/>
+    public async Task<Entity> GetByOrgNoWithType(string orgNo, CancellationToken cancellationToken = default) => await
+        Db.Entities
+            .AsNoTracking()
+            .Include(e => e.Type)
+            .Where(e => e.OrganizationIdentifier == orgNo)
+            .FirstOrDefaultAsync(cancellationToken);
+
+    /// <inheritdoc/>
     public async Task<Entity> GetByPersNo(string persNo, CancellationToken cancellationToken = default) => await 
         Db.Entities
             .AsNoTracking()

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -116,6 +116,11 @@ public class MaskinportenSupplierService(
             return consumer.Problem;
         }
 
+        if (!IsOrganization(consumer.Value))
+        {
+            return Problems.PartyNotFound;
+        }
+
         var connections = await connectionQuery.GetConnectionsAsync(
             new ConnectionQueryFilter()
             {
@@ -141,6 +146,11 @@ public class MaskinportenSupplierService(
         if (supplier.IsProblem)
         {
             return supplier.Problem;
+        }
+
+        if (!IsOrganization(supplier.Value))
+        {
+            return Problems.PartyNotFound;
         }
 
         var connections = await connectionQuery.GetConnectionsAsync(
@@ -173,6 +183,11 @@ public class MaskinportenSupplierService(
         if (consumer.IsProblem)
         {
             return consumer.Problem;
+        }
+
+        if (!IsOrganization(consumer.Value))
+        {
+            return Problems.PartyNotFound;
         }
 
         // Build resource filter (by ID or scope)
@@ -226,6 +241,11 @@ public class MaskinportenSupplierService(
             return supplier.Problem;
         }
 
+        if (!IsOrganization(supplier.Value))
+        {
+            return Problems.PartyNotFound;
+        }
+
         // Build resource filter (by ID or scope)
         List<Guid>? resourceIds = null;
         if (resourceId.HasValue)
@@ -237,7 +257,7 @@ public class MaskinportenSupplierService(
             resourceIds = await GetResourceIdsByScope(scope, cancellationToken);
             if (resourceIds.Count == 0)
             {
-                return new List<ResourcePermissionDto>();
+                return new List<ResourcePermissionDto>(); // No matching resources
             }
         }
 
@@ -265,6 +285,7 @@ public class MaskinportenSupplierService(
 
     /// <inheritdoc />
     public async Task<Result<ResourceCheckDto>> ResourceDelegationCheck(
+        Guid authenticatedUserUuid,
         Guid consumerId,
         string resource,
         string languageCode = "nb",
@@ -292,13 +313,10 @@ public class MaskinportenSupplierService(
             return Problems.InvalidResource;
         }
 
-        // Use authenticated user from audit context
-        var authenticatedUserId = auditAccessor.AuditValues.ChangedBy;
-
         // Delegate to ConnectionService with allowMaskinportenSchema = true for MaskinportenSchema resources
         // This allows delegation even if delegable=false, but still requires valid access rights
         return await connectionService.ResourceDelegationCheck(
-            authenticatedUserId,
+            authenticatedUserUuid,
             consumerId,
             resource,
             configureConnection: null,
@@ -339,15 +357,14 @@ public class MaskinportenSupplierService(
             return Problems.InvalidResource;
         }
 
-        // Get authenticated user
+        // Perform delegation check
         var by = await GetEntity(auditAccessor.AuditValues.ChangedBy, cancellationToken);
         if (by.IsProblem)
         {
             return by.Problem;
         }
 
-        // Perform delegation check
-        var delegationCheck = await ResourceDelegationCheck(consumerId, resource, cancellationToken: cancellationToken);
+        var delegationCheck = await ResourceDelegationCheck(by.Value.Id, consumerId, resource, cancellationToken: cancellationToken);
         if (delegationCheck.IsProblem)
         {
             return delegationCheck.Problem;
@@ -508,12 +525,13 @@ public class MaskinportenSupplierService(
 
     private async Task<List<Guid>> GetResourceIdsByScope(string scope, CancellationToken cancellationToken)
     {
-        // Query resources by scope claim (this assumes resources have scope metadata stored)
-        // For now, we'll use RefId matching - adjust based on actual schema
+        // Fallback: Use exact RefId matching until authoritative scope metadata is available.
+        // This assumes RefId matches the Maskinporten scope claim (may not always be true).
+        // Future implementation should use proper scope claim storage and Resource Registry lookup.
         var resources = await dbContext.Resources
             .Include(r => r.Type)
             .Where(r => r.Type.Name == MaskinportenSchemaTypeName)
-            .Where(r => r.RefId.Contains(scope)) // Simplified - adjust based on actual scope storage
+            .Where(r => r.RefId == scope) // Exact match only - no substring matching
             .Select(r => r.Id)
             .ToListAsync(cancellationToken);
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -582,6 +582,7 @@ public class MaskinportenSupplierService(
         var problem = ValidationComposer.Validate(
             EntityValidation.FromExists(consumer),
             EntityValidation.ToExists(supplier),
+            EntityValidation.FromIsNotTo(consumerId, supplierId, "party", "supplier"),
             EntityTypeValidation.FromIsOfType(consumer?.TypeId ?? Guid.Empty, [EntityTypeConstants.Organization.Id]),
             EntityTypeValidation.ToIsOfType(supplier?.TypeId ?? Guid.Empty, [EntityTypeConstants.Organization.Id])
         );

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -438,16 +438,61 @@ public class MaskinportenSupplierService(
             );
         }
 
-        return await connectionService.RemoveResource(
+        return await RemoveSupplierResource(
             consumerId,
             supplierId,
             resourceObj.Id,
-            configureConnection: null,
-            cancellationToken: cancellationToken);
+            cancellationToken);
     }
 
     #region Private Helper Methods
 
+    private async Task<ValidationProblemInstance> RemoveSupplierResource(
+        Guid consumerId,
+        Guid supplierId,
+        Guid resourceId,
+        CancellationToken cancellationToken)
+    {
+        var assignment = await dbContext.Assignments
+            .Include(a => a.Role)
+            .Include(a => a.AssignmentResources)
+            .FirstOrDefaultAsync(
+                a =>
+                    a.FromEntityId == supplierId
+                    && a.ToEntityId == consumerId
+                    && a.Role.Name == RoleConstants.Supplier,
+                cancellationToken);
+
+        if (assignment == null)
+        {
+            return null;
+        }
+
+        var assignmentResource = assignment.AssignmentResources
+            .FirstOrDefault(ar => ar.ResourceId == resourceId);
+
+        if (assignmentResource == null)
+        {
+            return null;
+        }
+
+        var delegationPolicyRules = await dbContext.DelegationChangePolicyRules
+            .Where(
+                rule =>
+                    rule.AssignmentId == assignment.Id
+                    && rule.ResourceId == resourceId)
+            .ToListAsync(cancellationToken);
+
+        if (delegationPolicyRules.Count > 0)
+        {
+            dbContext.DelegationChangePolicyRules.RemoveRange(delegationPolicyRules);
+        }
+
+        dbContext.AssignmentResources.Remove(assignmentResource);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return null;
+    }
     private async Task<Result<Entity>> GetEntity(Guid entityId, CancellationToken cancellationToken)
     {
         var entity = await dbContext.Entities

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -98,7 +98,7 @@ public class MaskinportenSupplierService(
             {
                 // Resources exist and cascade not requested - fail with validation error
                 return ValidationComposer.Validate(
-                    ResourceValidation.HasAssignedResources(true)
+                    ResourceValidation.HasAssignedResources(assignedResources)
                 );
             }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -113,6 +113,14 @@ public class MaskinportenSupplierService(
                     assignmentResource.PolicyVersion,
                     cancellationToken);
 
+                if (newVersion is null)
+                {
+                    // Policy clear failed - abort the entire cascade operation
+                    return ValidationComposer.Validate(
+                        ResourceValidation.PolicyCascadeClearSucceeded(newVersion)
+                    );
+                }
+
                 // Update version to track the clear operation
                 assignmentResource.PolicyVersion = newVersion;
 
@@ -500,6 +508,14 @@ public class MaskinportenSupplierService(
             existingAssignmentResource.PolicyPath,
             existingAssignmentResource.PolicyVersion,
             cancellationToken);
+
+        if (newVersion is null)
+        {
+            // Policy clear failed - do not delete DB record to maintain consistency
+            return ValidationComposer.Validate(
+                ResourceValidation.PolicyClearSucceeded(newVersion, resource)
+            );
+        }
 
         existingAssignmentResource.PolicyVersion = newVersion;
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -102,9 +102,11 @@ public class MaskinportenSupplierService(
                 );
             }
 
-            // Cascade: Revoke each delegated resource by clearing policy rules directly
+            // Cascade: Clear all policy rules first (all-or-nothing)
             // Cannot use ConnectionService.RemoveResource because it looks for RoleConstants.Rightholder,
             // but supplier delegations use RoleConstants.Supplier
+            var clearedVersions = new List<(AssignmentResource Resource, string NewVersion)>();
+
             foreach (var assignmentResource in assignedResources)
             {
                 // Clear delegation policy rules for this resource
@@ -116,16 +118,24 @@ public class MaskinportenSupplierService(
                 if (newVersion is null)
                 {
                     // Policy clear failed - abort the entire cascade operation
+                    // All previously cleared policies remain cleared (no rollback mechanism)
+                    // But database records are NOT deleted, maintaining partial consistency
                     return ValidationComposer.Validate(
                         ResourceValidation.PolicyCascadeClearSucceeded(newVersion)
                     );
                 }
 
+                clearedVersions.Add((assignmentResource, newVersion));
+            }
+
+            // All policy clears succeeded - now safe to delete database records
+            foreach (var (resource, newVersion) in clearedVersions)
+            {
                 // Update version to track the clear operation
-                assignmentResource.PolicyVersion = newVersion;
+                resource.PolicyVersion = newVersion;
 
                 // Remove the assignment resource record
-                dbContext.Remove(assignmentResource);
+                dbContext.Remove(resource);
             }
         }
 
@@ -435,7 +445,7 @@ public class MaskinportenSupplierService(
             ignoreExistingPolicy: false,
             cancellationToken: cancellationToken);
 
-        if (!result.All(r => r.CreatedSuccessfully))
+        if (!result.Any() || !result.All(r => r.CreatedSuccessfully))
         {
             return Problems.DelegationPolicyRuleWriteFailed;
         }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -86,13 +86,13 @@ public class MaskinportenSupplierService(
 
         if (!cascade)
         {
-            var assignedResources = await dbContext.AssignmentResources
+            var hasAssignedResources = await dbContext.AssignmentResources
                 .AsNoTracking()
                 .Where(p => p.AssignmentId == existingAssignment.Id)
-                .ToListAsync(cancellationToken);
+                .AnyAsync(cancellationToken);
 
             var problem = ValidationComposer.Validate(
-                ResourceValidation.HasAssignedResources(assignedResources)
+                ResourceValidation.HasAssignedResources(hasAssignedResources)
             );
 
             if (problem is { })
@@ -314,7 +314,11 @@ public class MaskinportenSupplierService(
         }
 
         // Delegate to ConnectionService with allowMaskinportenSchema = true for MaskinportenSchema resources
-        // This allows delegation even if delegable=false, but still requires valid access rights
+        // This allows delegation even if delegable=false in Resource Registry, but still requires valid access rights.
+        // 
+        // Technical note: allowMaskinportenSchema bypasses the MaskinportenSchema denial logic in 
+        // ConnectionService.MapFromInternalToExternalRight, allowing rights to have Result=true
+        // when the caller has proper authorization. This enables AddResource to succeed with delegable rights.
         return await connectionService.ResourceDelegationCheck(
             authenticatedUserUuid,
             consumerId,
@@ -354,7 +358,9 @@ public class MaskinportenSupplierService(
 
         if (!resourceObj.Type.Name.Equals(MaskinportenSchemaTypeName, StringComparison.InvariantCultureIgnoreCase))
         {
-            return Problems.InvalidResource;
+            return ValidationComposer.Validate(
+                ResourceValidation.ResourceTypeIs(resourceObj, MaskinportenSchemaTypeName)
+            );
         }
 
         // Perform delegation check

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -120,7 +120,7 @@ public class MaskinportenSupplierService(
                     // All previously cleared policies remain cleared (no rollback mechanism)
                     // But database records are NOT deleted, maintaining partial consistency
                     return ValidationComposer.Validate(
-                        ResourceValidation.PolicyCascadeClearSucceeded(newVersion)
+                        ResourceValidation.PolicyCascadeClearFailed(newVersion)
                     );
                 }
 
@@ -518,7 +518,7 @@ public class MaskinportenSupplierService(
         {
             // Policy clear failed - do not delete DB record to maintain consistency
             return ValidationComposer.Validate(
-                ResourceValidation.PolicyClearSucceeded(newVersion, resource)
+                ResourceValidation.PolicyClearFailed(newVersion, resource)
             );
         }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -218,7 +218,6 @@ public class MaskinportenSupplierService(
         Guid consumerId,
         Guid? supplierId = null,
         Guid? resourceId = null,
-        string? scope = null,
         CancellationToken cancellationToken = default)
     {
         var consumer = await GetEntity(consumerId, cancellationToken);
@@ -230,15 +229,6 @@ public class MaskinportenSupplierService(
         if (!IsOrganization(consumer.Value))
         {
             return Problems.PartyNotFound;
-        }
-
-        // Scope filtering not yet implemented - requires Resource Registry integration
-        var problem = ValidationComposer.Validate(
-            ResourceValidation.ScopeFilterNotImplemented(scope)
-        );
-        if (problem is { })
-        {
-            return problem;
         }
 
         // Direct EF query for delegated resources
@@ -281,7 +271,6 @@ public class MaskinportenSupplierService(
         Guid supplierId,
         Guid? consumerId = null,
         Guid? resourceId = null,
-        string? scope = null,
         CancellationToken cancellationToken = default)
     {
         var supplier = await GetEntity(supplierId, cancellationToken);
@@ -293,15 +282,6 @@ public class MaskinportenSupplierService(
         if (!IsOrganization(supplier.Value))
         {
             return Problems.PartyNotFound;
-        }
-
-        // Scope filtering not yet implemented - requires Resource Registry integration
-        var problem = ValidationComposer.Validate(
-            ResourceValidation.ScopeFilterNotImplemented(scope)
-        );
-        if (problem is { })
-        {
-            return problem;
         }
 
         // Direct EF query for delegated resources

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Altinn.AccessManagement.Core.Errors;
+using Altinn.AccessManagement.Core.Services.Interfaces;
 using Altinn.AccessMgmt.Core.Models;
 using Altinn.AccessMgmt.Core.Services.Contracts;
 using Altinn.AccessMgmt.Core.Utils;
@@ -23,17 +24,18 @@ public class MaskinportenSupplierService(
     AppDbContext dbContext,
     ConnectionQuery connectionQuery,
     IAuditAccessor auditAccessor,
-    IConnectionService connectionService) : IMaskinportenSupplierService
+    IConnectionService connectionService,
+    ISingleRightsService singleRightsService) : IMaskinportenSupplierService
 {
     private const string MaskinportenSchemaTypeName = "MaskinportenSchema";
 
     /// <inheritdoc />
     public async Task<Result<AssignmentDto>> AddSupplier(Guid consumerId, Guid supplierId, CancellationToken cancellationToken = default)
     {
-        var (consumer, supplier) = await GetAndValidateOrganizations(consumerId, supplierId, cancellationToken);
-        if (consumer.IsProblem)
+        var (validation, _) = await GetAndValidateOrganizations(consumerId, supplierId, cancellationToken);
+        if (validation.IsProblem)
         {
-            return consumer.Problem;
+            return validation.Problem;
         }
 
         // Check if assignment already exists
@@ -84,23 +86,42 @@ public class MaskinportenSupplierService(
             return null;
         }
 
-        if (!cascade)
+        // Get all delegated resources for this supplier assignment
+        var assignedResources = await dbContext.AssignmentResources
+            .AsTracking()
+            .Where(p => p.AssignmentId == existingAssignment.Id)
+            .ToListAsync(cancellationToken);
+
+        if (assignedResources.Any())
         {
-            var hasAssignedResources = await dbContext.AssignmentResources
-                .AsNoTracking()
-                .Where(p => p.AssignmentId == existingAssignment.Id)
-                .AnyAsync(cancellationToken);
-
-            var problem = ValidationComposer.Validate(
-                ResourceValidation.HasAssignedResources(hasAssignedResources)
-            );
-
-            if (problem is { })
+            if (!cascade)
             {
-                return problem;
+                // Resources exist and cascade not requested - fail with validation error
+                return ValidationComposer.Validate(
+                    ResourceValidation.HasAssignedResources(true)
+                );
+            }
+
+            // Cascade: Revoke each delegated resource by clearing policy rules directly
+            // Cannot use ConnectionService.RemoveResource because it looks for RoleConstants.Rightholder,
+            // but supplier delegations use RoleConstants.Supplier
+            foreach (var assignmentResource in assignedResources)
+            {
+                // Clear delegation policy rules for this resource
+                var newVersion = await singleRightsService.ClearPolicyRules(
+                    assignmentResource.PolicyPath,
+                    assignmentResource.PolicyVersion,
+                    cancellationToken);
+
+                // Update version to track the clear operation
+                assignmentResource.PolicyVersion = newVersion;
+
+                // Remove the assignment resource record
+                dbContext.Remove(assignmentResource);
             }
         }
 
+        // All resources revoked (or none existed) - safe to delete the assignment
         dbContext.Remove(existingAssignment);
         await dbContext.SaveChangesAsync(cancellationToken);
 
@@ -394,15 +415,24 @@ public class MaskinportenSupplierService(
             return Problems.MissingConnection;
         }
 
-        // Delegate all available rights
-        return await connectionService.AddResource(
+        // Write delegation policy rules directly to avoid double delegation check
+        // Cannot use ConnectionService.AddResource because it performs ResourceDelegationCheck
+        // without allowMaskinportenSchema=true, which would deny all MaskinportenSchema rights
+        var result = await singleRightsService.TryWriteDelegationPolicyRules(
             entities.Consumer,
             entities.Supplier,
             resourceObj,
-            new RightKeyListDto { DirectRightKeys = delegableRightKeys },
+            delegableRightKeys,
             by.Value,
-            configureConnection: null,
+            ignoreExistingPolicy: false,
             cancellationToken: cancellationToken);
+
+        if (!result.All(r => r.CreatedSuccessfully))
+        {
+            return Problems.DelegationPolicyRuleWriteFailed;
+        }
+
+        return true;
     }
 
     /// <inheritdoc />
@@ -438,12 +468,46 @@ public class MaskinportenSupplierService(
             );
         }
 
-        return await connectionService.RemoveResource(
-            consumerId,
-            supplierId,
-            resourceObj.Id,
-            configureConnection: null,
-            cancellationToken: cancellationToken);
+        // Find the supplier assignment (not rightholder)
+        var assignment = await dbContext.Assignments
+            .AsNoTracking()
+            .Include(a => a.From)
+            .Include(a => a.To)
+            .Where(a => a.FromId == consumerId)
+            .Where(a => a.ToId == supplierId)
+            .Where(a => a.RoleId == RoleConstants.Supplier.Id)  // Supplier, not Rightholder!
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (assignment is null)
+        {
+            return null;  // No supplier assignment exists
+        }
+
+        // Find the assignment resource for this specific resource
+        var existingAssignmentResource = await dbContext.AssignmentResources
+            .AsTracking()
+            .Where(a => a.AssignmentId == assignment.Id)
+            .Where(a => a.ResourceId == resourceObj.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (existingAssignmentResource is null)
+        {
+            return null;  // Resource not delegated to this supplier
+        }
+
+        // Clear delegation policy rules
+        var newVersion = await singleRightsService.ClearPolicyRules(
+            existingAssignmentResource.PolicyPath,
+            existingAssignmentResource.PolicyVersion,
+            cancellationToken);
+
+        existingAssignmentResource.PolicyVersion = newVersion;
+
+        // Remove the assignment resource
+        dbContext.Remove(existingAssignmentResource);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return null;
     }
 
     #region Private Helper Methods

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -8,9 +8,8 @@ using Altinn.AccessMgmt.Core.Validation;
 using Altinn.AccessMgmt.PersistenceEF.Audit;
 using Altinn.AccessMgmt.PersistenceEF.Constants;
 using Altinn.AccessMgmt.PersistenceEF.Contexts;
+using Altinn.AccessMgmt.PersistenceEF.Extensions;
 using Altinn.AccessMgmt.PersistenceEF.Models;
-using Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
-using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
 using Altinn.Authorization.Api.Contracts.AccessManagement;
 using Altinn.Authorization.ProblemDetails;
 using Microsoft.EntityFrameworkCore;
@@ -22,10 +21,10 @@ namespace Altinn.AccessMgmt.Core.Services;
 /// </summary>
 public class MaskinportenSupplierService(
     AppDbContext dbContext,
-    ConnectionQuery connectionQuery,
     IAuditAccessor auditAccessor,
     IConnectionService connectionService,
-    ISingleRightsService singleRightsService) : IMaskinportenSupplierService
+    ISingleRightsService singleRightsService,
+    IEntityService entityService) : IMaskinportenSupplierService
 {
     private const string MaskinportenSchemaTypeName = "MaskinportenSchema";
 
@@ -160,22 +159,24 @@ public class MaskinportenSupplierService(
             return Problems.PartyNotFound;
         }
 
-        var connections = await connectionQuery.GetConnectionsAsync(
-            new ConnectionQueryFilter()
-            {
-                FromIds = [consumerId],
-                ToIds = supplierId.HasValue ? [supplierId.Value] : null,
-                RoleIds = [RoleConstants.Supplier.Id],
-                EnrichEntities = true,
-                IncludeKeyRole = true,
-                ExcludeDeleted = false,
-            },
-            ConnectionQueryDirection.ToOthers,
-            true,
-            cancellationToken
-        );
+        // Direct EF query for supplier assignments
+        var assignments = await dbContext.Assignments
+            .AsNoTracking()
+            .Include(a => a.To)
+            .ThenInclude(e => e.Type)
+            .Include(a => a.Role)
+            .Where(a => a.FromId == consumerId)
+            .Where(a => a.RoleId == RoleConstants.Supplier.Id)
+            .WhereIf(supplierId.HasValue, a => a.ToId == supplierId.Value)
+            .ToListAsync(cancellationToken);
 
-        return DtoMapper.ConvertToOthers(connections, getSingle: supplierId.HasValue);
+        var suppliers = assignments.Select(a => new ConnectionDto
+        {
+            Party = DtoMapper.Convert(a.To),
+            Roles = new List<CompactRoleDto> { DtoMapper.ConvertCompactRole(a.Role) }
+        }).ToList();
+
+        return suppliers;
     }
 
     /// <inheritdoc />
@@ -192,22 +193,24 @@ public class MaskinportenSupplierService(
             return Problems.PartyNotFound;
         }
 
-        var connections = await connectionQuery.GetConnectionsAsync(
-            new ConnectionQueryFilter()
-            {
-                FromIds = consumerId.HasValue ? [consumerId.Value] : null,
-                ToIds = [supplierId],
-                RoleIds = [RoleConstants.Supplier.Id],
-                EnrichEntities = true,
-                IncludeKeyRole = true,
-                ExcludeDeleted = false,
-            },
-            ConnectionQueryDirection.FromOthers,
-            true,
-            cancellationToken
-        );
+        // Direct EF query for consumer assignments
+        var assignments = await dbContext.Assignments
+            .AsNoTracking()
+            .Include(a => a.From)
+            .ThenInclude(e => e.Type)
+            .Include(a => a.Role)
+            .Where(a => a.ToId == supplierId)
+            .Where(a => a.RoleId == RoleConstants.Supplier.Id)
+            .WhereIf(consumerId.HasValue, a => a.FromId == consumerId.Value)
+            .ToListAsync(cancellationToken);
 
-        return DtoMapper.ConvertFromOthers(connections, getSingle: consumerId.HasValue);
+        var consumers = assignments.Select(a => new ConnectionDto
+        {
+            Party = DtoMapper.Convert(a.From),
+            Roles = new List<CompactRoleDto> { DtoMapper.ConvertCompactRole(a.Role) }
+        }).ToList();
+
+        return consumers;
     }
 
     /// <inheritdoc />
@@ -229,41 +232,48 @@ public class MaskinportenSupplierService(
             return Problems.PartyNotFound;
         }
 
-        // Build resource filter (by ID or scope)
-        List<Guid>? resourceIds = null;
-        if (resourceId.HasValue)
-        {
-            resourceIds = [resourceId.Value];
-        }
-        else if (!string.IsNullOrWhiteSpace(scope))
-        {
-            resourceIds = await GetResourceIdsByScope(scope, cancellationToken);
-            if (resourceIds.Count == 0)
-            {
-                return new List<ResourcePermissionDto>(); // No matching resources
-            }
-        }
-
-        var connections = await connectionQuery.GetConnectionsAsync(
-            new ConnectionQueryFilter()
-            {
-                FromIds = [consumerId],
-                ToIds = supplierId.HasValue ? [supplierId.Value] : null,
-                RoleIds = [RoleConstants.Supplier.Id],
-                ResourceIds = resourceIds,
-                IncludeResources = true,
-                IncludeKeyRole = true,
-                EnrichEntities = true,
-            },
-            ConnectionQueryDirection.ToOthers,
-            true,
-            cancellationToken
+        // Scope filtering not yet implemented - requires Resource Registry integration
+        var problem = ValidationComposer.Validate(
+            ResourceValidation.ScopeFilterNotImplemented(scope)
         );
+        if (problem is { })
+        {
+            return problem;
+        }
 
-        var resources = DtoMapper.ConvertResources(connections);
+        // Direct EF query for delegated resources
+        var delegatedResources = await dbContext.AssignmentResources
+            .AsNoTracking()
+            .Include(ar => ar.Assignment)
+            .ThenInclude(a => a.To)
+            .ThenInclude(e => e.Type)
+            .Include(ar => ar.Assignment)
+            .ThenInclude(a => a.Role)
+            .Include(ar => ar.Resource)
+            .ThenInclude(r => r.Type)
+            .Where(ar => ar.Assignment.FromId == consumerId)
+            .Where(ar => ar.Assignment.RoleId == RoleConstants.Supplier.Id)
+            .Where(ar => ar.Resource.Type.Name == MaskinportenSchemaTypeName)
+            .WhereIf(supplierId.HasValue, ar => ar.Assignment.ToId == supplierId.Value)
+            .WhereIf(resourceId.HasValue, ar => ar.ResourceId == resourceId.Value)
+            .ToListAsync(cancellationToken);
 
-        // Filter to only MaskinportenSchema resources
-        return resources.Where(r => r.Resource.Type?.Name == MaskinportenSchemaTypeName).ToList();
+        // Group by resource
+        var groupedByResource = delegatedResources
+            .GroupBy(ar => ar.ResourceId)
+            .Select(g => new ResourcePermissionDto
+            {
+                Resource = DtoMapper.Convert(g.First().Resource),
+                Permissions = g.Select(ar => new PermissionDto
+                {
+                    From = DtoMapper.Convert(consumer.Value),
+                    To = DtoMapper.Convert(ar.Assignment.To),
+                    Role = DtoMapper.ConvertCompactRole(ar.Assignment.Role)
+                }).ToList()
+            })
+            .ToList();
+
+        return groupedByResource;
     }
 
     /// <inheritdoc />
@@ -285,41 +295,48 @@ public class MaskinportenSupplierService(
             return Problems.PartyNotFound;
         }
 
-        // Build resource filter (by ID or scope)
-        List<Guid>? resourceIds = null;
-        if (resourceId.HasValue)
-        {
-            resourceIds = [resourceId.Value];
-        }
-        else if (!string.IsNullOrWhiteSpace(scope))
-        {
-            resourceIds = await GetResourceIdsByScope(scope, cancellationToken);
-            if (resourceIds.Count == 0)
-            {
-                return new List<ResourcePermissionDto>(); // No matching resources
-            }
-        }
-
-        var connections = await connectionQuery.GetConnectionsAsync(
-            new ConnectionQueryFilter()
-            {
-                FromIds = consumerId.HasValue ? [consumerId.Value] : null,
-                ToIds = [supplierId],
-                RoleIds = [RoleConstants.Supplier.Id],
-                ResourceIds = resourceIds,
-                IncludeResources = true,
-                IncludeKeyRole = true,
-                EnrichEntities = true,
-            },
-            ConnectionQueryDirection.FromOthers,
-            true,
-            cancellationToken
+        // Scope filtering not yet implemented - requires Resource Registry integration
+        var problem = ValidationComposer.Validate(
+            ResourceValidation.ScopeFilterNotImplemented(scope)
         );
+        if (problem is { })
+        {
+            return problem;
+        }
 
-        var resources = DtoMapper.ConvertResources(connections);
+        // Direct EF query for delegated resources
+        var delegatedResources = await dbContext.AssignmentResources
+            .AsNoTracking()
+            .Include(ar => ar.Assignment)
+            .ThenInclude(a => a.From)
+            .ThenInclude(e => e.Type)
+            .Include(ar => ar.Assignment)
+            .ThenInclude(a => a.Role)
+            .Include(ar => ar.Resource)
+            .ThenInclude(r => r.Type)
+            .Where(ar => ar.Assignment.ToId == supplierId)
+            .Where(ar => ar.Assignment.RoleId == RoleConstants.Supplier.Id)
+            .Where(ar => ar.Resource.Type.Name == MaskinportenSchemaTypeName)
+            .WhereIf(consumerId.HasValue, ar => ar.Assignment.FromId == consumerId.Value)
+            .WhereIf(resourceId.HasValue, ar => ar.ResourceId == resourceId.Value)
+            .ToListAsync(cancellationToken);
 
-        // Filter to only MaskinportenSchema resources
-        return resources.Where(r => r.Resource.Type?.Name == MaskinportenSchemaTypeName).ToList();
+        // Group by resource
+        var groupedByResource = delegatedResources
+            .GroupBy(ar => ar.ResourceId)
+            .Select(g => new ResourcePermissionDto
+            {
+                Resource = DtoMapper.Convert(g.First().Resource),
+                Permissions = g.Select(ar => new PermissionDto
+                {
+                    From = DtoMapper.Convert(ar.Assignment.From),
+                    To = DtoMapper.Convert(supplier.Value),
+                    Role = DtoMapper.ConvertCompactRole(ar.Assignment.Role)
+                }).ToList()
+            })
+            .ToList();
+
+        return groupedByResource;
     }
 
     /// <inheritdoc />
@@ -382,25 +399,14 @@ public class MaskinportenSupplierService(
             return validation.Problem;
         }
 
-        // Validate resource is MaskinportenSchema
-        var resourceObj = await dbContext.Resources
-            .Include(r => r.Type)
-            .AsNoTracking()
-            .FirstOrDefaultAsync(r => r.RefId == resource, cancellationToken);
-
-        if (resourceObj == null)
+        // Validate resource exists and is MaskinportenSchema
+        var resourceResult = await GetResourceByRefId(resource, cancellationToken);
+        if (resourceResult.IsProblem)
         {
-            return ValidationComposer.Validate(
-                ResourceValidation.ResourceExists(resourceObj, resource)
-            );
+            return resourceResult.Problem;
         }
 
-        if (!resourceObj.Type.Name.Equals(MaskinportenSchemaTypeName, StringComparison.InvariantCultureIgnoreCase))
-        {
-            return ValidationComposer.Validate(
-                ResourceValidation.ResourceTypeIs(resourceObj, MaskinportenSchemaTypeName)
-            );
-        }
+        var resourceObj = resourceResult.Value;
 
         // Perform delegation check
         var by = await GetEntity(auditAccessor.AuditValues.ChangedBy, cancellationToken);
@@ -467,24 +473,13 @@ public class MaskinportenSupplierService(
         }
 
         // Validate resource exists and is MaskinportenSchema
-        var resourceObj = await dbContext.Resources
-            .Include(r => r.Type)
-            .AsNoTracking()
-            .FirstOrDefaultAsync(r => r.RefId == resource, cancellationToken);
-
-        if (resourceObj == null)
+        var resourceResult = await GetResourceByRefId(resource, cancellationToken);
+        if (resourceResult.IsProblem)
         {
-            return ValidationComposer.Validate(
-                ResourceValidation.ResourceExists(resourceObj, resource)
-            );
+            return resourceResult.Problem as ValidationProblemInstance;
         }
 
-        if (!resourceObj.Type.Name.Equals(MaskinportenSchemaTypeName, StringComparison.InvariantCultureIgnoreCase))
-        {
-            return ValidationComposer.Validate(
-                ResourceValidation.ResourceTypeIs(resourceObj, MaskinportenSchemaTypeName)
-            );
-        }
+        var resourceObj = resourceResult.Value;
 
         // Find the supplier assignment (not rightholder)
         var assignment = await dbContext.Assignments
@@ -556,12 +551,7 @@ public class MaskinportenSupplierService(
     /// <inheritdoc />
     public async Task<Result<Entity>> GetEntity(string organizationNumber, CancellationToken cancellationToken = default)
     {
-        var entity = await dbContext.Entities
-            .AsNoTracking()
-            .Include(e => e.Type)
-            .Where(e => e.RefId == organizationNumber)
-            .Where(e => e.TypeId == EntityTypeConstants.Organization.Id)
-            .FirstOrDefaultAsync(cancellationToken);
+        var entity = await entityService.GetByOrgNoWithType(organizationNumber, cancellationToken);
 
         if (entity is null)
         {
@@ -582,6 +572,14 @@ public class MaskinportenSupplierService(
         if (resource is null)
         {
             return Problems.InvalidResource;
+        }
+
+        // Validate that the resource is a MaskinportenSchema
+        if (!resource.Type.Name.Equals(MaskinportenSchemaTypeName, StringComparison.InvariantCultureIgnoreCase))
+        {
+            return ValidationComposer.Validate(
+                ResourceValidation.ResourceTypeIs(resource, MaskinportenSchemaTypeName)
+            );
         }
 
         return resource;
@@ -618,21 +616,6 @@ public class MaskinportenSupplierService(
 
     private static bool IsOrganization(Entity entity)
         => entity.TypeId == EntityTypeConstants.Organization.Id;
-
-    private async Task<List<Guid>> GetResourceIdsByScope(string scope, CancellationToken cancellationToken)
-    {
-        // Fallback: Use exact RefId matching until authoritative scope metadata is available.
-        // This assumes RefId matches the Maskinporten scope claim (may not always be true).
-        // Future implementation should use proper scope claim storage and Resource Registry lookup.
-        var resources = await dbContext.Resources
-            .Include(r => r.Type)
-            .Where(r => r.Type.Name == MaskinportenSchemaTypeName)
-            .Where(r => r.RefId == scope) // Exact match only - no substring matching
-            .Select(r => r.Id)
-            .ToListAsync(cancellationToken);
-
-        return resources;
-    }
 
     #endregion
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -1,0 +1,524 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Altinn.AccessManagement.Core.Errors;
+using Altinn.AccessMgmt.Core.Models;
+using Altinn.AccessMgmt.Core.Services.Contracts;
+using Altinn.AccessMgmt.Core.Utils;
+using Altinn.AccessMgmt.Core.Validation;
+using Altinn.AccessMgmt.PersistenceEF.Audit;
+using Altinn.AccessMgmt.PersistenceEF.Constants;
+using Altinn.AccessMgmt.PersistenceEF.Contexts;
+using Altinn.AccessMgmt.PersistenceEF.Models;
+using Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
+using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
+using Altinn.Authorization.Api.Contracts.AccessManagement;
+using Altinn.Authorization.ProblemDetails;
+using Microsoft.EntityFrameworkCore;
+
+namespace Altinn.AccessMgmt.Core.Services;
+
+/// <summary>
+/// Service for managing Maskinporten supplier relationships and scope delegations
+/// </summary>
+public class MaskinportenSupplierService(
+    AppDbContext dbContext,
+    ConnectionQuery connectionQuery,
+    IAuditAccessor auditAccessor,
+    IConnectionService connectionService) : IMaskinportenSupplierService
+{
+    private const string MaskinportenSchemaTypeName = "MaskinportenSchema";
+
+    /// <inheritdoc />
+    public async Task<Result<AssignmentDto>> AddSupplier(Guid consumerId, Guid supplierId, CancellationToken cancellationToken = default)
+    {
+        var (consumer, supplier) = await GetAndValidateOrganizations(consumerId, supplierId, cancellationToken);
+        if (consumer.IsProblem)
+        {
+            return consumer.Problem;
+        }
+
+        // Check if assignment already exists
+        var existingAssignment = await dbContext.Assignments
+            .AsNoTracking()
+            .Where(e => e.FromId == consumerId)
+            .Where(e => e.ToId == supplierId)
+            .Where(e => e.RoleId == RoleConstants.Supplier.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (existingAssignment is { })
+        {
+            return DtoMapper.Convert(existingAssignment);
+        }
+
+        // Create new supplier assignment
+        var assignment = new Assignment()
+        {
+            FromId = consumerId,
+            ToId = supplierId,
+            RoleId = RoleConstants.Supplier.Id,
+        };
+
+        await dbContext.Assignments.AddAsync(assignment, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return DtoMapper.Convert(assignment);
+    }
+
+    /// <inheritdoc />
+    public async Task<ValidationProblemInstance> RemoveSupplier(Guid consumerId, Guid supplierId, bool cascade = false, CancellationToken cancellationToken = default)
+    {
+        var (validation, _) = await GetAndValidateOrganizations(consumerId, supplierId, cancellationToken);
+        if (validation.IsProblem)
+        {
+            return validation.Problem as ValidationProblemInstance;
+        }
+
+        var existingAssignment = await dbContext.Assignments
+            .AsTracking()
+            .Where(e => e.FromId == consumerId)
+            .Where(e => e.ToId == supplierId)
+            .Where(e => e.RoleId == RoleConstants.Supplier.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (existingAssignment is null)
+        {
+            return null;
+        }
+
+        if (!cascade)
+        {
+            var assignedResources = await dbContext.AssignmentResources
+                .AsNoTracking()
+                .Where(p => p.AssignmentId == existingAssignment.Id)
+                .ToListAsync(cancellationToken);
+
+            var problem = ValidationComposer.Validate(
+                ResourceValidation.HasAssignedResources(assignedResources)
+            );
+
+            if (problem is { })
+            {
+                return problem;
+            }
+        }
+
+        dbContext.Remove(existingAssignment);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IEnumerable<ConnectionDto>>> GetSuppliers(Guid consumerId, Guid? supplierId = null, CancellationToken cancellationToken = default)
+    {
+        var consumer = await GetEntity(consumerId, cancellationToken);
+        if (consumer.IsProblem)
+        {
+            return consumer.Problem;
+        }
+
+        var connections = await connectionQuery.GetConnectionsAsync(
+            new ConnectionQueryFilter()
+            {
+                FromIds = [consumerId],
+                ToIds = supplierId.HasValue ? [supplierId.Value] : null,
+                RoleIds = [RoleConstants.Supplier.Id],
+                EnrichEntities = true,
+                IncludeKeyRole = true,
+                ExcludeDeleted = false,
+            },
+            ConnectionQueryDirection.ToOthers,
+            true,
+            cancellationToken
+        );
+
+        return DtoMapper.ConvertToOthers(connections, getSingle: supplierId.HasValue);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IEnumerable<ConnectionDto>>> GetConsumers(Guid supplierId, Guid? consumerId = null, CancellationToken cancellationToken = default)
+    {
+        var supplier = await GetEntity(supplierId, cancellationToken);
+        if (supplier.IsProblem)
+        {
+            return supplier.Problem;
+        }
+
+        var connections = await connectionQuery.GetConnectionsAsync(
+            new ConnectionQueryFilter()
+            {
+                FromIds = consumerId.HasValue ? [consumerId.Value] : null,
+                ToIds = [supplierId],
+                RoleIds = [RoleConstants.Supplier.Id],
+                EnrichEntities = true,
+                IncludeKeyRole = true,
+                ExcludeDeleted = false,
+            },
+            ConnectionQueryDirection.FromOthers,
+            true,
+            cancellationToken
+        );
+
+        return DtoMapper.ConvertFromOthers(connections, getSingle: consumerId.HasValue);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IEnumerable<ResourcePermissionDto>>> GetSupplierResources(
+        Guid consumerId,
+        Guid? supplierId = null,
+        Guid? resourceId = null,
+        string? scope = null,
+        CancellationToken cancellationToken = default)
+    {
+        var consumer = await GetEntity(consumerId, cancellationToken);
+        if (consumer.IsProblem)
+        {
+            return consumer.Problem;
+        }
+
+        // Build resource filter (by ID or scope)
+        List<Guid>? resourceIds = null;
+        if (resourceId.HasValue)
+        {
+            resourceIds = [resourceId.Value];
+        }
+        else if (!string.IsNullOrWhiteSpace(scope))
+        {
+            resourceIds = await GetResourceIdsByScope(scope, cancellationToken);
+            if (resourceIds.Count == 0)
+            {
+                return new List<ResourcePermissionDto>(); // No matching resources
+            }
+        }
+
+        var connections = await connectionQuery.GetConnectionsAsync(
+            new ConnectionQueryFilter()
+            {
+                FromIds = [consumerId],
+                ToIds = supplierId.HasValue ? [supplierId.Value] : null,
+                RoleIds = [RoleConstants.Supplier.Id],
+                ResourceIds = resourceIds,
+                IncludeResources = true,
+                IncludeKeyRole = true,
+                EnrichEntities = true,
+            },
+            ConnectionQueryDirection.ToOthers,
+            true,
+            cancellationToken
+        );
+
+        var resources = DtoMapper.ConvertResources(connections);
+
+        // Filter to only MaskinportenSchema resources
+        return resources.Where(r => r.Resource.Type?.Name == MaskinportenSchemaTypeName).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<IEnumerable<ResourcePermissionDto>>> GetConsumerResources(
+        Guid supplierId,
+        Guid? consumerId = null,
+        Guid? resourceId = null,
+        string? scope = null,
+        CancellationToken cancellationToken = default)
+    {
+        var supplier = await GetEntity(supplierId, cancellationToken);
+        if (supplier.IsProblem)
+        {
+            return supplier.Problem;
+        }
+
+        // Build resource filter (by ID or scope)
+        List<Guid>? resourceIds = null;
+        if (resourceId.HasValue)
+        {
+            resourceIds = [resourceId.Value];
+        }
+        else if (!string.IsNullOrWhiteSpace(scope))
+        {
+            resourceIds = await GetResourceIdsByScope(scope, cancellationToken);
+            if (resourceIds.Count == 0)
+            {
+                return new List<ResourcePermissionDto>();
+            }
+        }
+
+        var connections = await connectionQuery.GetConnectionsAsync(
+            new ConnectionQueryFilter()
+            {
+                FromIds = consumerId.HasValue ? [consumerId.Value] : null,
+                ToIds = [supplierId],
+                RoleIds = [RoleConstants.Supplier.Id],
+                ResourceIds = resourceIds,
+                IncludeResources = true,
+                IncludeKeyRole = true,
+                EnrichEntities = true,
+            },
+            ConnectionQueryDirection.FromOthers,
+            true,
+            cancellationToken
+        );
+
+        var resources = DtoMapper.ConvertResources(connections);
+
+        // Filter to only MaskinportenSchema resources
+        return resources.Where(r => r.Resource.Type?.Name == MaskinportenSchemaTypeName).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<ResourceCheckDto>> ResourceDelegationCheck(
+        Guid consumerId,
+        string resource,
+        string languageCode = "nb",
+        CancellationToken cancellationToken = default)
+    {
+        var consumer = await GetEntity(consumerId, cancellationToken);
+        if (consumer.IsProblem)
+        {
+            return consumer.Problem;
+        }
+
+        if (!IsOrganization(consumer.Value))
+        {
+            return Problems.PartyNotFound;
+        }
+
+        // Validate that the resource is a MaskinportenSchema
+        var resourceObj = await dbContext.Resources
+            .Include(r => r.Type)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.RefId == resource, cancellationToken);
+
+        if (resourceObj == null || !resourceObj.Type.Name.Equals(MaskinportenSchemaTypeName, StringComparison.InvariantCultureIgnoreCase))
+        {
+            return Problems.InvalidResource;
+        }
+
+        // Use authenticated user from audit context
+        var authenticatedUserId = auditAccessor.AuditValues.ChangedBy;
+
+        // Delegate to ConnectionService with allowMaskinportenSchema = true for MaskinportenSchema resources
+        // This allows delegation even if delegable=false, but still requires valid access rights
+        return await connectionService.ResourceDelegationCheck(
+            authenticatedUserId,
+            consumerId,
+            resource,
+            configureConnection: null,
+            languageCode: languageCode,
+            ignoreDelegableFlag: false,
+            allowMaskinportenSchema: true,
+            cancellationToken: cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<bool>> AddResource(
+        Guid consumerId,
+        Guid supplierId,
+        string resource,
+        CancellationToken cancellationToken = default)
+    {
+        var (validation, entities) = await GetAndValidateOrganizations(consumerId, supplierId, cancellationToken);
+        if (validation.IsProblem)
+        {
+            return validation.Problem;
+        }
+
+        // Validate resource is MaskinportenSchema
+        var resourceObj = await dbContext.Resources
+            .Include(r => r.Type)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.RefId == resource, cancellationToken);
+
+        if (resourceObj == null)
+        {
+            return ValidationComposer.Validate(
+                ResourceValidation.ResourceExists(resourceObj, resource)
+            );
+        }
+
+        if (!resourceObj.Type.Name.Equals(MaskinportenSchemaTypeName, StringComparison.InvariantCultureIgnoreCase))
+        {
+            return Problems.InvalidResource;
+        }
+
+        // Get authenticated user
+        var by = await GetEntity(auditAccessor.AuditValues.ChangedBy, cancellationToken);
+        if (by.IsProblem)
+        {
+            return by.Problem;
+        }
+
+        // Perform delegation check
+        var delegationCheck = await ResourceDelegationCheck(consumerId, resource, cancellationToken: cancellationToken);
+        if (delegationCheck.IsProblem)
+        {
+            return delegationCheck.Problem;
+        }
+
+        // Get all delegable rights from the delegation check
+        var delegableRightKeys = delegationCheck.Value.Rights
+            .Where(r => r.Result)
+            .Select(r => r.Right.Key)
+            .ToList();
+
+        if (!delegableRightKeys.Any())
+        {
+            return Problems.NotAuthorizedForDelegationRequest;
+        }
+
+        // Ensure supplier assignment exists
+        var connection = await GetSuppliers(consumerId, supplierId, cancellationToken);
+        if (!connection.IsSuccess || !connection.Value.Any())
+        {
+            return Problems.MissingConnection;
+        }
+
+        // Delegate all available rights
+        return await connectionService.AddResource(
+            entities.Consumer,
+            entities.Supplier,
+            resourceObj,
+            new RightKeyListDto { DirectRightKeys = delegableRightKeys },
+            by.Value,
+            configureConnection: null,
+            cancellationToken: cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<ValidationProblemInstance> RemoveResource(
+        Guid consumerId,
+        Guid supplierId,
+        string resource,
+        CancellationToken cancellationToken = default)
+    {
+        var (validation, _) = await GetAndValidateOrganizations(consumerId, supplierId, cancellationToken);
+        if (validation.IsProblem)
+        {
+            return validation.Problem as ValidationProblemInstance;
+        }
+
+        // Validate resource exists and is MaskinportenSchema
+        var resourceObj = await dbContext.Resources
+            .Include(r => r.Type)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.RefId == resource, cancellationToken);
+
+        if (resourceObj == null)
+        {
+            return ValidationComposer.Validate(
+                ResourceValidation.ResourceExists(resourceObj, resource)
+            );
+        }
+
+        if (!resourceObj.Type.Name.Equals(MaskinportenSchemaTypeName, StringComparison.InvariantCultureIgnoreCase))
+        {
+            return ValidationComposer.Validate(
+                ResourceValidation.ResourceTypeIs(resourceObj, MaskinportenSchemaTypeName)
+            );
+        }
+
+        return await connectionService.RemoveResource(
+            consumerId,
+            supplierId,
+            resourceObj.Id,
+            configureConnection: null,
+            cancellationToken: cancellationToken);
+    }
+
+    #region Private Helper Methods
+
+    private async Task<Result<Entity>> GetEntity(Guid entityId, CancellationToken cancellationToken)
+    {
+        var entity = await dbContext.Entities
+            .AsNoTracking()
+            .Include(e => e.Type)
+            .FirstOrDefaultAsync(e => e.Id == entityId, cancellationToken);
+
+        if (entity is null)
+        {
+            return Problems.PartyNotFound;
+        }
+
+        return entity;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<Entity>> GetEntity(string organizationNumber, CancellationToken cancellationToken = default)
+    {
+        var entity = await dbContext.Entities
+            .AsNoTracking()
+            .Include(e => e.Type)
+            .Where(e => e.RefId == organizationNumber)
+            .Where(e => e.TypeId == EntityTypeConstants.Organization.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (entity is null)
+        {
+            return Problems.PartyNotFound;
+        }
+
+        return entity;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<Resource>> GetResourceByRefId(string resourceRefId, CancellationToken cancellationToken = default)
+    {
+        var resource = await dbContext.Resources
+            .AsNoTracking()
+            .Include(r => r.Type)
+            .FirstOrDefaultAsync(r => r.RefId == resourceRefId, cancellationToken);
+
+        if (resource is null)
+        {
+            return Problems.InvalidResource;
+        }
+
+        return resource;
+    }
+
+    private async Task<(Result<bool> Validation, (Entity Consumer, Entity Supplier))> GetAndValidateOrganizations(
+        Guid consumerId,
+        Guid supplierId,
+        CancellationToken cancellationToken)
+    {
+        var entities = await dbContext.Entities
+            .AsNoTracking()
+            .Where(e => e.Id == consumerId || e.Id == supplierId)
+            .Include(e => e.Type)
+            .ToListAsync(cancellationToken);
+
+        var consumer = entities.FirstOrDefault(e => e.Id == consumerId);
+        var supplier = entities.FirstOrDefault(e => e.Id == supplierId);
+
+        var problem = ValidationComposer.Validate(
+            EntityValidation.FromExists(consumer),
+            EntityValidation.ToExists(supplier),
+            EntityTypeValidation.FromIsOfType(consumer?.TypeId ?? Guid.Empty, [EntityTypeConstants.Organization.Id]),
+            EntityTypeValidation.ToIsOfType(supplier?.TypeId ?? Guid.Empty, [EntityTypeConstants.Organization.Id])
+        );
+
+        if (problem is { })
+        {
+            return (problem, default);
+        }
+
+        return (true, (consumer, supplier));
+    }
+
+    private static bool IsOrganization(Entity entity)
+        => entity.TypeId == EntityTypeConstants.Organization.Id;
+
+    private async Task<List<Guid>> GetResourceIdsByScope(string scope, CancellationToken cancellationToken)
+    {
+        // Query resources by scope claim (this assumes resources have scope metadata stored)
+        // For now, we'll use RefId matching - adjust based on actual schema
+        var resources = await dbContext.Resources
+            .Include(r => r.Type)
+            .Where(r => r.Type.Name == MaskinportenSchemaTypeName)
+            .Where(r => r.RefId.Contains(scope)) // Simplified - adjust based on actual scope storage
+            .Select(r => r.Id)
+            .ToListAsync(cancellationToken);
+
+        return resources;
+    }
+
+    #endregion
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/ValidationErrors.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/ValidationErrors.cs
@@ -142,5 +142,11 @@ public static class ValidationErrors
     /// </summary>
     public static ValidationErrorDescriptor PackageIsNotAssignableToRecipient { get; }
         = _factory.Create(33, "Package is not assignable to the recipient entity type.");
+
+    /// <summary>
+    /// Gets a validation error descriptor for when clearing delegation policy rules fails.
+    /// </summary>
+    public static ValidationErrorDescriptor PolicyClearFailed { get; }
+        = _factory.Create(34, "Failed to clear delegation policy rules.");
 }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/ValidationErrors.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/ValidationErrors.cs
@@ -148,5 +148,11 @@ public static class ValidationErrors
     /// </summary>
     public static ValidationErrorDescriptor PolicyClearFailed { get; }
         = _factory.Create(34, "Failed to clear delegation policy rules.");
+
+    /// <summary>
+    /// Gets a validation error descriptor for when scope filtering is not yet implemented.
+    /// </summary>
+    public static ValidationErrorDescriptor ScopeFilterNotImplemented { get; }
+        = _factory.Create(35, "Scope filtering is not yet implemented. Use the 'resource' parameter to filter by specific resource identifier instead.");
 }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/ValidationErrors.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/ValidationErrors.cs
@@ -120,7 +120,7 @@ public static class ValidationErrors
         = _factory.Create(29, "Instance must use a valid URN format: 'urn:altinn:instance-id:', 'urn:altinn:correspondence-id:', or 'urn:altinn:dialog-id:'.");
 
     /// <summary>
-    /// Gets a validation error descriptor for when a Resource not exists.
+    /// Gets a validation error descriptor for when a resource does not exist.
     /// </summary>
     public static ValidationErrorDescriptor ResourceNotExists { get; }
         = _factory.Create(30, "Resource does not exist.");

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/ValidationErrors.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/ValidationErrors.cs
@@ -118,4 +118,29 @@ public static class ValidationErrors
     /// </summary>
     public static ValidationErrorDescriptor InvalidInstanceUrn { get; }
         = _factory.Create(29, "Instance must use a valid URN format: 'urn:altinn:instance-id:', 'urn:altinn:correspondence-id:', or 'urn:altinn:dialog-id:'.");
+
+    /// <summary>
+    /// Gets a validation error descriptor for when a Resource not exists.
+    /// </summary>
+    public static ValidationErrorDescriptor ResourceNotExists { get; }
+        = _factory.Create(30, "Resource does not exist.");
+
+    /// <summary>
+    /// Gets a validation error descriptor for when assignment has resources delegated.
+    /// </summary>
+    public static ValidationErrorDescriptor AssignmentResourcesExist { get; }
+        = _factory.Create(31, "Assignment has resources delegated.");
+
+    /// <summary>
+    /// Gets a validation error descriptor for invalid resource type.
+    /// </summary>
+    public static ValidationErrorDescriptor InvalidResourceType { get; }
+        = _factory.Create(32, "Invalid resource type.");
+
+    /// <summary>
+    /// Gets a validation error descriptor for when package is not assignable to recipient.
+    /// </summary>
+    public static ValidationErrorDescriptor PackageIsNotAssignableToRecipient { get; }
+        = _factory.Create(33, "Package is not assignable to the recipient entity type.");
 }
+

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/ValidationErrors.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/ValidationErrors.cs
@@ -148,11 +148,5 @@ public static class ValidationErrors
     /// </summary>
     public static ValidationErrorDescriptor PolicyClearFailed { get; }
         = _factory.Create(34, "Failed to clear delegation policy rules.");
-
-    /// <summary>
-    /// Gets a validation error descriptor for when scope filtering is not yet implemented.
-    /// </summary>
-    public static ValidationErrorDescriptor ScopeFilterNotImplemented { get; }
-        = _factory.Create(35, "Scope filtering is not yet implemented. Use the 'resource' parameter to filter by specific resource identifier instead.");
 }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/EntityValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/EntityValidation.cs
@@ -1,4 +1,4 @@
-using Altinn.AccessManagement.Core.Errors;
+﻿using Altinn.AccessManagement.Core.Errors;
 using Altinn.AccessMgmt.PersistenceEF.Models;
 using Altinn.Authorization.ProblemDetails;
 
@@ -64,5 +64,19 @@ public static class EntityValidation
     internal static RuleExpression ToExists(Entity party) => () =>
     {
         return EntityExists(party, "to")();
+    };
+
+    internal static RuleExpression FromIsNotTo(Guid fromId, Guid toId, string fromParamName = "party", string toParamName = "supplier") => () =>
+    {
+        if (fromId != toId)
+        {
+            return null;
+        }
+
+        return (ref ValidationErrorBuilder errors) =>
+        {
+            errors.Add(ValidationErrors.InvalidQueryParameter, $"QUERY/{fromParamName}", [new(fromParamName, "An organization cannot delegate to itself.")]);
+            errors.Add(ValidationErrors.InvalidQueryParameter, $"QUERY/{toParamName}", [new(toParamName, "An organization cannot delegate to itself.")]);
+        };
     };
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
@@ -147,4 +147,17 @@ public static class ResourceValidation
             errors.Add(ValidationErrors.PolicyClearFailed, $"POLICY/{paramName}", [new("assignmentResources", "Failed to clear delegation policies during cascade deletion.")]);
         };
     };
+
+    internal static RuleExpression ScopeFilterNotImplemented(string scope, string paramName = "scope") => () =>
+    {
+        if (string.IsNullOrWhiteSpace(scope))
+        {
+            return null;
+        }
+
+        return (ref ValidationErrorBuilder errors) =>
+        {
+            errors.Add(ValidationErrors.ScopeFilterNotImplemented, $"QUERY/{paramName}", [new("scope", "Scope filtering is not yet implemented. Use the 'resource' parameter to filter by specific resource identifier instead.")]);
+        };
+    };
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
@@ -93,13 +93,16 @@ public static class ResourceValidation
         return null;
     };
 
-    internal static RuleExpression HasAssignedResources(IEnumerable<AssignmentResource> assignedResources) => () =>
+    internal static RuleExpression HasAssignedResources(IEnumerable<AssignmentResource> assignedResources, string paramName = "cascade") => () =>
     {
+        ArgumentNullException.ThrowIfNull(assignedResources);
+        ArgumentException.ThrowIfNullOrEmpty(paramName);
+
         if (assignedResources.Any())
         {
             return (ref ValidationErrorBuilder errors) =>
             {
-                errors.Add(ValidationErrors.AssignmentResourcesExist, "assignment", [new("assignmentResources", "Cannot remove supplier assignment while resources are still delegated. Use cascade=true or remove resources first.")]);
+                errors.Add(ValidationErrors.AssignmentResourcesExist, $"QUERY/{paramName}", [new("assignmentResources", "Cannot remove supplier assignment while resources are still delegated. Use cascade=true or remove resources first.")]);
             };
         }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
@@ -147,17 +147,4 @@ public static class ResourceValidation
             errors.Add(ValidationErrors.PolicyClearFailed, $"POLICY/{paramName}", [new("assignmentResources", "Failed to clear delegation policies during cascade deletion.")]);
         };
     };
-
-    internal static RuleExpression ScopeFilterNotImplemented(string scope, string paramName = "scope") => () =>
-    {
-        if (string.IsNullOrWhiteSpace(scope))
-        {
-            return null;
-        }
-
-        return (ref ValidationErrorBuilder errors) =>
-        {
-            errors.Add(ValidationErrors.ScopeFilterNotImplemented, $"QUERY/{paramName}", [new("scope", "Scope filtering is not yet implemented. Use the 'resource' parameter to filter by specific resource identifier instead.")]);
-        };
-    };
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
@@ -3,6 +3,7 @@ using Altinn.AccessMgmt.PersistenceEF.Constants;
 using Altinn.AccessMgmt.PersistenceEF.Models;
 using Altinn.Authorization.Api.Contracts.AccessManagement;
 using Altinn.Authorization.ProblemDetails;
+using ValidationErrors = Altinn.AccessMgmt.Core.Utils.Models.ValidationErrors;
 
 namespace Altinn.AccessMgmt.Core.Validation;
 
@@ -90,5 +91,31 @@ public static class ResourceValidation
         }
 
         return null;
+    };
+
+    internal static RuleExpression HasAssignedResources(IEnumerable<AssignmentResource> assignedResources) => () =>
+    {
+        if (assignedResources.Any())
+        {
+            return (ref ValidationErrorBuilder errors) =>
+            {
+                errors.Add(ValidationErrors.AssignmentResourcesExist, "assignment", [new("assignmentResources", "Cannot remove supplier assignment while resources are still delegated. Use cascade=true or remove resources first.")]);
+            };
+        }
+
+        return null;
+    };
+
+    internal static RuleExpression ResourceTypeIs(Resource resource, string expectedTypeName, string paramName = "resource") => () =>
+    {
+        if (resource?.Type?.Name?.Equals(expectedTypeName, StringComparison.InvariantCultureIgnoreCase) == true)
+        {
+            return null;
+        }
+
+        return (ref ValidationErrorBuilder errors) =>
+        {
+            errors.Add(ValidationErrors.InvalidResourceType, $"QUERY/{paramName}", [new("resourceType", $"Resource '{resource?.RefId}' must be of type '{expectedTypeName}'.")]);
+        };
     };
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
@@ -93,11 +93,12 @@ public static class ResourceValidation
         return null;
     };
 
-    internal static RuleExpression HasAssignedResources(bool hasAssignedResources, string paramName = "cascade") => () =>
+    internal static RuleExpression HasAssignedResources(IReadOnlyCollection<AssignmentResource> assignedResources, string paramName = "cascade") => () =>
     {
+        ArgumentNullException.ThrowIfNull(assignedResources);
         ArgumentException.ThrowIfNullOrEmpty(paramName);
 
-        if (hasAssignedResources)
+        if (assignedResources.Any())
         {
             return (ref ValidationErrorBuilder errors) =>
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
@@ -93,12 +93,11 @@ public static class ResourceValidation
         return null;
     };
 
-    internal static RuleExpression HasAssignedResources(IEnumerable<AssignmentResource> assignedResources, string paramName = "cascade") => () =>
+    internal static RuleExpression HasAssignedResources(bool hasAssignedResources, string paramName = "cascade") => () =>
     {
-        ArgumentNullException.ThrowIfNull(assignedResources);
         ArgumentException.ThrowIfNullOrEmpty(paramName);
 
-        if (assignedResources.Any())
+        if (hasAssignedResources)
         {
             return (ref ValidationErrorBuilder errors) =>
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
@@ -122,7 +122,7 @@ public static class ResourceValidation
         };
     };
 
-    internal static RuleExpression PolicyClearSucceeded(string policyVersion, string resourceRefId, string paramName = "resource") => () =>
+    internal static RuleExpression PolicyClearFailed(string policyVersion, string resourceRefId, string paramName = "resource") => () =>
     {
         if (policyVersion is not null)
         {
@@ -135,7 +135,7 @@ public static class ResourceValidation
         };
     };
 
-    internal static RuleExpression PolicyCascadeClearSucceeded(string policyVersion, string paramName = "cascade") => () =>
+    internal static RuleExpression PolicyCascadeClearFailed(string policyVersion, string paramName = "cascade") => () =>
     {
         if (policyVersion is not null)
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
@@ -121,4 +121,30 @@ public static class ResourceValidation
             errors.Add(ValidationErrors.InvalidResourceType, $"QUERY/{paramName}", [new("resourceType", $"Resource '{resource?.RefId}' must be of type '{expectedTypeName}'.")]);
         };
     };
+
+    internal static RuleExpression PolicyClearSucceeded(string policyVersion, string resourceRefId, string paramName = "resource") => () =>
+    {
+        if (policyVersion is not null)
+        {
+            return null;
+        }
+
+        return (ref ValidationErrorBuilder errors) =>
+        {
+            errors.Add(ValidationErrors.PolicyClearFailed, $"POLICY/{paramName}", [new("resource", $"Failed to clear delegation policy for resource '{resourceRefId}'.")]);
+        };
+    };
+
+    internal static RuleExpression PolicyCascadeClearSucceeded(string policyVersion, string paramName = "cascade") => () =>
+    {
+        if (policyVersion is not null)
+        {
+            return null;
+        }
+
+        return (ref ValidationErrorBuilder errors) =>
+        {
+            errors.Add(ValidationErrors.PolicyClearFailed, $"POLICY/{paramName}", [new("assignmentResources", "Failed to clear delegation policies during cascade deletion.")]);
+        };
+    };
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/ResourceValidation.cs
@@ -131,7 +131,7 @@ public static class ResourceValidation
 
         return (ref ValidationErrorBuilder errors) =>
         {
-            errors.Add(ValidationErrors.PolicyClearFailed, $"POLICY/{paramName}", [new("resource", $"Failed to clear delegation policy for resource '{resourceRefId}'.")]);
+            errors.Add(ValidationErrors.PolicyClearFailed, $"QUERY/{paramName}", [new("resource", $"Failed to clear delegation policy for resource '{resourceRefId}'.")]);
         };
     };
 
@@ -144,7 +144,7 @@ public static class ResourceValidation
 
         return (ref ValidationErrorBuilder errors) =>
         {
-            errors.Add(ValidationErrors.PolicyClearFailed, $"POLICY/{paramName}", [new("assignmentResources", "Failed to clear delegation policies during cascade deletion.")]);
+            errors.Add(ValidationErrors.PolicyClearFailed, $"QUERY/{paramName}", [new("assignmentResources", "Failed to clear delegation policies during cascade deletion.")]);
         };
     };
 }


### PR DESCRIPTION
# Implement Maskinporten Suppliers and Consumers APIs

## Summary

Implements enduser API endpoints for managing Maskinporten supplier relationships and MaskinportenSchema scope delegations.

**Key Features:**
- Consumer API: Manage suppliers and delegate MaskinportenSchema resources
- Supplier API: View consumers and manage received delegations  
- Organization-to-organization only
- Reuses existing `Assignments` table with `RoleConstants.Supplier`
- New enduser-specific authorization policies: `POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ/WRITE`

## API Endpoints

### Consumer Perspective (`/maskinportensuppliers`)
- `POST /` - Add supplier
- `GET /` - List suppliers  
- `DELETE /?cascade={bool}` - Remove supplier (cascade deletes resources)
- `GET /resources/delegationcheck` - Check if resource is delegable
- `POST /resources` - Delegate resource to supplier
- `GET /resources` - List delegated resources (filter: supplier, resource)
- `DELETE /resources` - Remove delegation

### Supplier Perspective (`/maskinportenconsumers`)  
- `GET /` - List consumers
- `DELETE /` - Relinquish consumer connection
- `GET /resources` - List received resources (filter: consumer, resource)
- `DELETE /resources` - Remove delegation

## Files Changed

**New Files:**
- `IMaskinportenSupplierService.cs` - Service interface (10 methods)
- `MaskinportenSupplierService.cs` - Service implementation (~500 lines)  
- `MaskinportenSuppliersController.cs` - Consumer API (6 endpoints)
- `MaskinportenConsumersController.cs` - Supplier API (4 endpoints)

**Modified Files:**
- `ConnectionService.cs` + `IConnectionService.cs` - Added `allowMaskinportenSchema` parameter to `ResourceDelegationCheck()`
- `EntityService.cs` + `IEntityService.cs` - Added `GetByOrgNoWithType()` method
- `ResourceValidation.cs` - Added validation rules: `HasAssignedResources()`, `ResourceTypeIs()`, `PolicyClearFailed()`, `PolicyCascadeClearFailed()`
- `ValidationErrors.cs` - Added error codes 30-34
- `ServiceCollectionExtensions.cs` - Registered `IMaskinportenSupplierService`
- `AuthzConstants.cs` - Added `POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ/WRITE` constants
- `AccessManagementHost.cs` - Configured enduser-specific authorization policies

## Technical Implementation

### Enduser-Specific Authorization
Controllers use **enduser-specific authorization policies** that work with query parameter `party` (Guid):
- `POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ` - Uses `EndUserResourceAccessRequirement`
- `POLICY_MASKINPORTEN_DELEGATION_ENDUSER_WRITE` - Uses `EndUserResourceAccessRequirement`

These policies correctly build PDP requests from `[FromQuery] Guid party`, unlike the route-based policies that expect `{party}` (int) in the route template.

**DelegationCheck endpoint** uses `AuthenticationHelper.GetAuthenticatedPartyUuid()` to support both regular users and systemusers with API-administrator rights.

### Organization-Only Enforcement
Both APIs validate that consumer and supplier are organization entities, rejecting persons and system users.

### MaskinportenSchema-Only Resources
Service validates resource type before all operations:
```csharp
if (!resourceObj.Type.Name.Equals("MaskinportenSchema", StringComparison.InvariantCultureIgnoreCase))
    return Problems.InvalidResource;
```

Type validation is performed in `GetResourceByRefId()` helper method to avoid duplication.

### Delegable Flag Override
MaskinportenSchema resources are marked `delegable=false` in Resource Registry to prevent general delegation, but they ARE delegable for Maskinporten supplier relationships. Added `allowMaskinportenSchema` parameter to enable this:

```csharp
bool isMaskinPortenSchemaResource = resourceDto.Type.Name.Equals("MaskinportenSchema", ...);
bool isResourceDelegable = ignoreDelegableFlag 
    || resourceMetadata.Delegable 
    || (allowMaskinportenSchema && isMaskinPortenSchemaResource);
```

When `allowMaskinportenSchema=true`, MaskinportenSchema resources bypass the `delegable=false` check.

### Policy Management Architecture
The service uses `ISingleRightsService` for direct authorization policy manipulation in resource operations (add/remove):
- Ensures correct `RoleConstants.Supplier` context
- Provides fine-grained control over delegation rules
- Enables cascade deletion (removes all resource policies before deleting supplier assignment)
- **Validates policy operations**: Checks for null return from `ClearPolicyRules()` and fails the operation to maintain DB-policy consistency

### Cascade Deletion
`DELETE /maskinportensuppliers?cascade=true` removes supplier assignment and all delegated resources:
- Without cascade: Returns `ValidationErrors.AssignmentResourcesExist` (AM-00031) if resources exist
- With cascade: Clears all resource policies via `ISingleRightsService.ClearPolicyRules()` before removing assignment

**Known limitation**: Cascade deletion is not fully atomic. If `ClearPolicyRules()` fails for one resource after successfully clearing others, the previously cleared policies remain cleared while the database records are preserved. This maintains partial consistency (DB claims delegations exist, but some policies are empty). The operation can be retried to complete the cascade.

### Query Optimization
- Uses `OrganizationIdentifier` index for efficient organization lookups
- Reuses `EntityService.GetByOrgNoWithType()` to avoid duplicate organization query logic
- Direct EF queries on `Assignments` and `AssignmentResources` tables (following `ClientDelegationService` pattern)
- Materialize-then-map pattern for DTO conversion to avoid EF expression tree errors

## Testing Checklist



**Unit Tests:**
- [ ] Organization validation (reject persons/system users)
- [ ] Resource type validation (reject non-MaskinportenSchema)
- [ ] Cascade deletion behavior
- [ ] Partial cascade failure handling

To be implemented in https://github.com/Altinn/altinn-authorization-tmp/issues/2839

**Integration Tests:**
- [ ] End-to-end flow: Add supplier → Delegate resource → View → Remove
- [ ] Authorization enforcement (`POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ/WRITE`)
- [ ] SystemUser/API-administrator support in DelegationCheck
- [ ] MaskinportenSchema delegation works despite `delegable=false` in Resource Registry
- [ ] Cascade deletion removes all resources
- [ ] Non-cascade deletion fails when resources exist

**Manual Testing:**
- [ ] Test all 10 endpoints via Swagger/Postman
- [ ] Verify error messages for validation failures
- [ ] Verify supplier/consumer perspective consistency

## Breaking Changes

None - entirely new functionality.

## Migration Notes

- No database migrations required (reuses existing `Assignments` and `AssignmentResources` tables)
- New authorization policies configured: `POLICY_MASKINPORTEN_DELEGATION_ENDUSER_READ/WRITE` (uses `EndUserResourceAccessRequirement` for query-based party parameter)
- Service automatically registered in DI container
