### PR TITLE
Telemetri for PDP authorization

### DIFF
--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Altinn.Authorization.csproj
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Altinn.Authorization.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Azure.Storage.Blobs" />
         <PackageReference Include="IdentityModel" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
-        <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
+        <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
         <PackageReference Include="Altinn.Platform.Storage.Interface" />
         <PackageReference Include="JWTCookieAuthentication" />
         <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Altinn.Authorization.csproj
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Altinn.Authorization.csproj
@@ -22,6 +22,7 @@
         <PackageReference Include="Azure.Storage.Blobs" />
         <PackageReference Include="IdentityModel" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+        <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
         <PackageReference Include="Altinn.Platform.Storage.Interface" />
         <PackageReference Include="JWTCookieAuthentication" />
         <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
@@ -20,6 +20,7 @@ using Altinn.Platform.Authorization.Models.External;
 using Altinn.Platform.Authorization.Repositories.Interface;
 using Altinn.Platform.Authorization.Services.Interface;
 using Altinn.Platform.Authorization.Services.Interfaces;
+using Altinn.Platform.Authorization.Telemetry;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using AutoMapper;
@@ -403,7 +404,53 @@ namespace Altinn.Platform.Authorization.Controllers
                 await _eventLog.CreateAuthorizationEvent(_featureManager, decisionRequest, HttpContext, finalResponse, cancellationToken);
             }
 
+            await RecordPdpDecisionMetric(decisionRequest, cancellationToken);
+
             return finalResponse;
+        }
+
+        /// <summary>
+        /// Resolves the resource owner and resource identifier for the current decision request and records
+        /// a PDP decision counter increment so that PDP usage can be attributed back to the service owner of
+        /// the resource being protected.
+        /// </summary>
+        private async Task RecordPdpDecisionMetric(XacmlContextRequest decisionRequest, CancellationToken cancellationToken)
+        {
+            try
+            {
+                PolicyResourceType resourceType = PolicyHelper.GetPolicyResourceType(decisionRequest, out string resourceRegistryId, out string org, out string app);
+
+                string ownerOrg;
+                string resourceId;
+
+                switch (resourceType)
+                {
+                    case PolicyResourceType.AltinnApps:
+                        ownerOrg = string.IsNullOrEmpty(org) ? DecisionTelemetry.UnknownDimensionValue : org;
+                        resourceId = $"app_{org}_{app}";
+                        break;
+
+                    case PolicyResourceType.ResourceRegistry:
+                        // GetResourceAsync is cached in ResourceRegistryWrapper with the same TTL as policies,
+                        // so calls from IsAccessListAuthorized and from here collapse to a single cold lookup.
+                        ServiceResource resource = await _resourceRegistry.GetResourceAsync(resourceRegistryId, cancellationToken);
+                        ownerOrg = resource?.HasCompetentAuthority?.Orgcode ?? DecisionTelemetry.UnknownDimensionValue;
+                        resourceId = resourceRegistryId;
+                        break;
+
+                    default:
+                        ownerOrg = DecisionTelemetry.UnknownDimensionValue;
+                        resourceId = DecisionTelemetry.UnknownDimensionValue;
+                        break;
+                }
+
+                DecisionTelemetry.RecordDecision(ownerOrg, resourceId);
+            }
+            catch (Exception ex)
+            {
+                // Telemetry must never break the authorization flow.
+                _logger.LogWarning(ex, "// DecisionController // RecordPdpDecisionMetric // Failed to record PdpDecisions metric");
+            }
         }
 
         private async Task<bool> IsAccessListAuthorized(XacmlContextRequest decisionRequest, CancellationToken cancellationToken = default)

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
@@ -422,7 +422,7 @@ namespace Altinn.Platform.Authorization.Controllers
         {
             try
             {
-                PolicyResourceType resourceType = PolicyHelper.GetPolicyResourceType(decisionRequest, out string resourceRegistryId, out string org, out string app);
+                PolicyResourceType resourceType = PolicyHelper.GetPolicyResourceType(decisionRequest, out string policyResourceId, out string org, out string app);
 
                 string ownerOrg;
                 string resourceId;
@@ -437,9 +437,9 @@ namespace Altinn.Platform.Authorization.Controllers
                     case PolicyResourceType.ResourceRegistry:
                         // GetResourceAsync is cached in ResourceRegistryWrapper with the same TTL as policies,
                         // so calls from IsAccessListAuthorized and from here collapse to a single cold lookup.
-                        ServiceResource resource = await _resourceRegistry.GetResourceAsync(resourceRegistryId, cancellationToken);
+                        ServiceResource resource = await _resourceRegistry.GetResourceAsync(policyResourceId, cancellationToken);
                         ownerOrg = resource?.HasCompetentAuthority?.Orgcode ?? DecisionTelemetry.UnknownDimensionValue;
-                        resourceId = resourceRegistryId;
+                        resourceId = policyResourceId;
                         break;
 
                     default:

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
@@ -386,6 +386,12 @@ namespace Altinn.Platform.Authorization.Controllers
 
             XacmlContextResponse finalResponse = delegationContextResponse ?? rolesContextResponse;
             XacmlContextResult finalResult = finalResponse.Results.First();
+
+            // Recorded before the access-list early-return below so that every exit path with a
+            // computed decision is counted. The metric is dimensioned on the request, not the
+            // response, so its placement does not depend on which response is ultimately returned.
+            await RecordPdpDecisionMetric(decisionRequest, cancellationToken);
+
             if (finalResult.Decision.Equals(XacmlContextDecision.Permit) && !await IsAccessListAuthorized(decisionRequest, cancellationToken))
             {
                 return new XacmlContextResponse(new XacmlContextResult(XacmlContextDecision.Deny)
@@ -403,8 +409,6 @@ namespace Altinn.Platform.Authorization.Controllers
             {
                 await _eventLog.CreateAuthorizationEvent(_featureManager, decisionRequest, HttpContext, finalResponse, cancellationToken);
             }
-
-            await RecordPdpDecisionMetric(decisionRequest, cancellationToken);
 
             return finalResponse;
         }

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
@@ -51,6 +51,7 @@ namespace Altinn.Platform.Authorization.Controllers
         private readonly IResourceRegistry _resourceRegistry;
         private readonly IRegisterService _registerService;
         private readonly IAccessListAuthorization _accessListAuthorization;
+        private readonly DecisionTelemetry _decisionTelemetry;
         private readonly IMapper _mapper;
 
         private readonly SortedDictionary<string, AuthInfo> _appInstanceInfo = new();
@@ -77,6 +78,7 @@ namespace Altinn.Platform.Authorization.Controllers
         /// <param name="memoryCache">memory cache</param>
         /// <param name="eventLog">the authorization event logger</param>
         /// <param name="featureManager">the feature manager</param>
+        /// <param name="decisionTelemetry">PDP decision metric recorder</param>
         /// <param name="mapper">The model mapper</param>
         public DecisionController(
             IAccessManagementWrapper accessManagement,
@@ -91,6 +93,7 @@ namespace Altinn.Platform.Authorization.Controllers
             IMemoryCache memoryCache,
             IEventLog eventLog,
             IFeatureManager featureManager,
+            DecisionTelemetry decisionTelemetry,
             IMapper mapper)
         {
             _pdp = new PolicyDecisionPoint();
@@ -105,6 +108,7 @@ namespace Altinn.Platform.Authorization.Controllers
             _resourceRegistry = resourceRegistry;
             _registerService = registerService;
             _accessListAuthorization = accessListAuthorization;
+            _decisionTelemetry = decisionTelemetry;
             _mapper = mapper;
         }
 
@@ -448,7 +452,7 @@ namespace Altinn.Platform.Authorization.Controllers
                         break;
                 }
 
-                DecisionTelemetry.RecordDecision(ownerOrg, resourceId);
+                _decisionTelemetry.RecordDecision(ownerOrg, resourceId);
             }
             catch (Exception ex)
             {

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
@@ -21,10 +21,12 @@ using Altinn.Platform.Authorization.Services;
 using Altinn.Platform.Authorization.Services.Implementation;
 using Altinn.Platform.Authorization.Services.Interface;
 using Altinn.Platform.Authorization.Services.Interfaces;
+using Altinn.Platform.Authorization.Telemetry;
 using Altinn.Platform.Telemetry;
 using AltinnCore.Authentication.JwtCookie;
 
 using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Azure.Security.KeyVault.Secrets;
 
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
@@ -39,6 +41,8 @@ using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Npgsql;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
 using Swashbuckle.AspNetCore.Filters;
 using Yuniql.AspNetCore;
 using Yuniql.PostgreSql;
@@ -286,8 +290,15 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         services.AddApplicationInsightsTelemetryProcessor<IdentityTelemetryFilter>();
         services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
 
+        // OpenTelemetry pipeline for System.Diagnostics.Metrics instruments (e.g. PDP decision metrics)
+        // shipped to Azure Monitor alongside the classic Application Insights SDK.
+        services.AddOpenTelemetry()
+            .UseAzureMonitor(options => options.ConnectionString = applicationInsightsConnectionString);
+
         logger.LogInformation("Startup // ApplicationInsightsConnectionString = {applicationInsightsConnectionString}", applicationInsightsConnectionString);
     }
+
+    services.ConfigureOpenTelemetryMeterProvider(provider => provider.AddMeter(DecisionTelemetry.MeterName));
 
     services.AddMvc(options =>
     {

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
@@ -26,7 +26,7 @@ using Altinn.Platform.Telemetry;
 using AltinnCore.Authentication.JwtCookie;
 
 using Azure.Identity;
-using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Security.KeyVault.Secrets;
 
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
@@ -290,10 +290,12 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         services.AddApplicationInsightsTelemetryProcessor<IdentityTelemetryFilter>();
         services.AddSingleton<ITelemetryInitializer, CustomTelemetryInitializer>();
 
-        // OpenTelemetry pipeline for System.Diagnostics.Metrics instruments (e.g. PDP decision metrics)
-        // shipped to Azure Monitor alongside the classic Application Insights SDK.
+        // Metrics-only OpenTelemetry pipeline for System.Diagnostics.Metrics instruments (e.g. PDP
+        // decision metrics) shipped to Azure Monitor. Traces and logs continue to flow through the
+        // classic Application Insights SDK above to avoid duplicate ingestion.
         services.AddOpenTelemetry()
-            .UseAzureMonitor(options => options.ConnectionString = applicationInsightsConnectionString);
+            .WithMetrics(metrics => metrics
+                .AddAzureMonitorMetricExporter(options => options.ConnectionString = applicationInsightsConnectionString));
 
         logger.LogInformation("Startup // ApplicationInsightsConnectionString = {applicationInsightsConnectionString}", applicationInsightsConnectionString);
     }

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
@@ -300,6 +300,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         logger.LogInformation("Startup // ApplicationInsightsConnectionString = {applicationInsightsConnectionString}", applicationInsightsConnectionString);
     }
 
+    services.AddSingleton<DecisionTelemetry>();
     services.ConfigureOpenTelemetryMeterProvider(provider => provider.AddMeter(DecisionTelemetry.MeterName));
 
     services.AddMvc(options =>

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Telemetry/DecisionTelemetry.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Telemetry/DecisionTelemetry.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 
 namespace Altinn.Platform.Authorization.Telemetry
@@ -7,39 +6,45 @@ namespace Altinn.Platform.Authorization.Telemetry
     /// Telemetry definitions for the Policy Decision Point, exposing metrics that attribute PDP
     /// usage back to the resource owner so that volume and cost can be allocated per service owner.
     /// </summary>
-    [ExcludeFromCodeCoverage]
-    internal static class DecisionTelemetry
+    public sealed class DecisionTelemetry
     {
         /// <summary>
         /// Meter name registered with the OpenTelemetry meter provider in Program.cs. Any change
         /// here must be reflected in the <c>AddMeter</c> call, otherwise the instrument will be
         /// silently dropped.
         /// </summary>
-        internal const string MeterName = "Altinn.Authorization.Pdp";
+        public const string MeterName = "Altinn.Authorization.Pdp";
 
         /// <summary>
         /// Dimension value used when an owner or resource identifier cannot be resolved.
         /// </summary>
-        internal const string UnknownDimensionValue = "unknown";
+        public const string UnknownDimensionValue = "unknown";
 
-        private const string OwnerOrgTag = "owner_org";
-        private const string ResourceIdTag = "resource_id";
+        private const string OwnerOrgTag = "resource.owner.org";
+        private const string ResourceIdTag = "resource.id";
 
-        private static readonly Meter Meter = new(MeterName);
+        private readonly Counter<long> _pdpDecisions;
 
         /// <summary>
-        /// Counts PDP authorization decisions, dimensioned by the resource owner organization and
-        /// the resource identifier.
+        /// Initializes a new instance of the <see cref="DecisionTelemetry"/> class. Registered as a
+        /// singleton so the underlying <see cref="Meter"/> lifetime is owned by <see cref="IMeterFactory"/>
+        /// and integrates with OpenTelemetry resource attribution.
         /// </summary>
-        internal static readonly Counter<long> PdpDecisions =
-            Meter.CreateCounter<long>("pdp.decisions", unit: "1", description: "Number of PDP authorization decisions evaluated");
+        public DecisionTelemetry(IMeterFactory meterFactory)
+        {
+            Meter meter = meterFactory.Create(MeterName);
+            _pdpDecisions = meter.CreateCounter<long>(
+                "altinn.pdp.decisions",
+                unit: "1",
+                description: "Number of PDP authorization decisions evaluated");
+        }
 
         /// <summary>
         /// Records a single PDP decision with the given owner and resource identifier.
         /// </summary>
-        internal static void RecordDecision(string ownerOrg, string resourceId)
+        public void RecordDecision(string ownerOrg, string resourceId)
         {
-            PdpDecisions.Add(
+            _pdpDecisions.Add(
                 1,
                 new KeyValuePair<string, object?>(OwnerOrgTag, ownerOrg),
                 new KeyValuePair<string, object?>(ResourceIdTag, resourceId));

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Telemetry/DecisionTelemetry.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Telemetry/DecisionTelemetry.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+
+namespace Altinn.Platform.Authorization.Telemetry
+{
+    /// <summary>
+    /// Telemetry definitions for the Policy Decision Point, exposing metrics that attribute PDP
+    /// usage back to the resource owner so that volume and cost can be allocated per service owner.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal static class DecisionTelemetry
+    {
+        /// <summary>
+        /// Meter name registered with the OpenTelemetry meter provider in Program.cs. Any change
+        /// here must be reflected in the <c>AddMeter</c> call, otherwise the instrument will be
+        /// silently dropped.
+        /// </summary>
+        internal const string MeterName = "Altinn.Authorization.Pdp";
+
+        /// <summary>
+        /// Dimension value used when an owner or resource identifier cannot be resolved.
+        /// </summary>
+        internal const string UnknownDimensionValue = "unknown";
+
+        private const string OwnerOrgTag = "owner_org";
+        private const string ResourceIdTag = "resource_id";
+
+        private static readonly Meter Meter = new(MeterName);
+
+        /// <summary>
+        /// Counts PDP authorization decisions, dimensioned by the resource owner organization and
+        /// the resource identifier.
+        /// </summary>
+        internal static readonly Counter<long> PdpDecisions =
+            Meter.CreateCounter<long>("pdp.decisions", unit: "1", description: "Number of PDP authorization decisions evaluated");
+
+        /// <summary>
+        /// Records a single PDP decision with the given owner and resource identifier.
+        /// </summary>
+        internal static void RecordDecision(string ownerOrg, string resourceId)
+        {
+            PdpDecisions.Add(
+                1,
+                new KeyValuePair<string, object?>(OwnerOrgTag, ownerOrg),
+                new KeyValuePair<string, object?>(ResourceIdTag, resourceId));
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a PDP usage metric so authorization decisions can be attributed back to the resource owner for cost allocation and per-owner dashboards.

- **New `Telemetry/DecisionTelemetry.cs`** — static `Meter` (`Altinn.Authorization.Pdp`) with a `Counter<long>` `pdp.decisions`, tagged `owner_org` + `resource_id`. Uses `System.Diagnostics.Metrics` directly, matching the pattern in `PipelineTelemetry` / `LeaseTelemetry`.
- **`DecisionController`** — new `RecordPdpDecisionMetric` helper called at the end of the private `Authorize(XacmlContextRequest …)` funnel (covers standard `Post`, `AuthorizeExternal`, and multi-decision sub-requests). Owner resolution:
  - `AltinnApps` → `urn:altinn:org` value from the XACML request.
  - `ResourceRegistry` → `ServiceResource.HasCompetentAuthority.Orgcode` via the already-cached `GetResourceAsync`.
  - Fallback → `"unknown"` for both dimensions.
  - Wrapped in try/catch + warning log so telemetry issues can never break authorization.
- **`Program.cs`** — wires `AddOpenTelemetry().UseAzureMonitor(...)` inside the existing `if (applicationInsightsConnectionString …)` block, and unconditionally subscribes the meter via `ConfigureOpenTelemetryMeterProvider(p => p.AddMeter(DecisionTelemetry.MeterName))`. The classic `AddApplicationInsightsTelemetry` path is left in place — it still handles request/log tracing and the existing telemetry filters/initializer.
- **`Altinn.Authorization.csproj`** — adds `Azure.Monitor.OpenTelemetry.AspNetCore` (version pinned centrally in `Directory.Packages.props`).

Approach note: the linked issue originally proposed `TelemetryClient.GetMetric()`. We moved to `System.Diagnostics.Metrics.Meter` + OpenTelemetry because the classic Application Insights SDK is in maintenance mode and the rest of the codebase has standardized on the `Meter` pattern (`PipelineTelemetry`, `LeaseTelemetry`, `AccessManagementHost`). The issue has been updated to reflect the new approach.

## Related Issue(s)
- #2761

## Verification
- [x] **Your** code builds clean without any errors or warnings (local `dotnet build` on `Altinn.Authorization` — 0 errors, only pre-existing warnings)
- [ ] Manual testing done (required) — **pending**: need to deploy to a non-production environment and confirm the `pdp.decisions` counter with `owner_org` / `resource_id` dimensions shows up under custom metrics in Application Insights
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out) — **not yet**: unit tests for owner/resourceId resolution across `AltinnApps`, `ResourceRegistry`, and unknown fallback still to write (acceptance criteria on #2761)
- [ ] All tests run green — pending once new tests are added

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable) — N/A, internal telemetry only
