### PR TITLE
Centralize and tune the SonarCloud CI configuration

### DIFF
--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -221,6 +221,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          # Sonar needs full git history for accurate blame, SCM authors,
+          # and "new code" period detection on PRs.
+          fetch-depth: 0
       - name: Install .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
@@ -238,11 +242,26 @@ jobs:
           distribution: "microsoft"
           java-version: 17
 
+      - name: Cache SonarCloud scanner and analysis cache
+        # Caches both the dotnet-sonarscanner / dotnet-coverage global tools
+        # (~80MB) and Sonar's incremental analysis cache under ~/.sonar/cache.
+        # Keyed per-vertical so each project's analysis cache is isolated;
+        # bumped when the scanner version changes.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.sonar/cache
+            ~/.dotnet/tools
+          key: ${{ runner.os }}-sonar-11.2.1-${{ inputs.slug }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-sonar-11.2.1-${{ inputs.slug }}-
+            ${{ runner.os }}-sonar-11.2.1-
+
       - name: Install SonarCloud scanner and dependencies
         shell: bash
         run: |
-          dotnet tool install --global dotnet-sonarscanner
-          dotnet tool install --global dotnet-coverage
+          dotnet tool list --global | grep -q dotnet-sonarscanner || dotnet tool install --global dotnet-sonarscanner --version 11.2.1
+          dotnet tool list --global | grep -q dotnet-coverage      || dotnet tool install --global dotnet-coverage
 
       - name: Analyze
         working-directory: ${{ inputs.path }}

--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -275,6 +275,7 @@ jobs:
           dotnet-sonarscanner begin \
             /key:"$SONAR_KEY" \
             /name:"$SONAR_NAME" \
+            /o:"altinn" \
             /d:sonar.token="$SONAR_TOKEN" \
             /s:"$GITHUB_WORKSPACE/SonarQube.Analysis.xml"
 

--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -256,15 +256,8 @@ jobs:
           dotnet-sonarscanner begin \
             /key:"$SONAR_KEY" \
             /name:"$SONAR_NAME" \
-            /o:"altinn" /d:sonar.token="$SONAR_TOKEN" \
-            /d:sonar.scanner.scanAll=false \
-            /d:sonar.project.monorepo.enabled=true \
-            /d:sonar.exclusions="**/Migration/**,**/Altinn.AccessMgmt.FFB/**,**/Altinn.AccessMgmt.WebComponents/**" \
-            /d:sonar.coverage.exclusions="**/Migration/**,**/Altinn.AccessMgmt.FFB/**,**/Altinn.AccessMgmt.WebComponents/**" \
-            /d:sonar.test.exclusions="**/test/**/*" \
-            /d:sonar.host.url="https://sonarcloud.io" \
-            /d:sonar.cs.vstest.reportsPaths="**/*.trx" \
-            /d:sonar.cs.vscoveragexml.reportsPaths="TestResults/coverage.xml"
+            /d:sonar.token="$SONAR_TOKEN" \
+            /s:"$GITHUB_WORKSPACE/SonarQube.Analysis.xml"
 
           dotnet build --no-incremental
           # xUnit v3 routes `dotnet test` through Microsoft Testing Platform (MTP).

--- a/SonarQube.Analysis.xml
+++ b/SonarQube.Analysis.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Shared SonarCloud analysis settings for the Altinn Authorization monorepo.
+
+  Consumed by `dotnet-sonarscanner` when passed via the `/s:` flag, e.g.
+      dotnet-sonarscanner begin /k:<key> /n:<name> /s:"$GITHUB_WORKSPACE/SonarQube.Analysis.xml" ...
+
+  Per-vertical values (sonar.projectKey, sonar.projectName, sonar.token) are
+  supplied by CI — keep them out of this file.
+-->
+<SonarQubeAnalysisProperties xmlns="http://www.sonarsource.com/msbuild/analysisproperties/1.0">
+
+  <!-- SonarCloud target -->
+  <Property Name="sonar.host.url">https://sonarcloud.io</Property>
+  <Property Name="sonar.organization">altinn</Property>
+
+  <!-- Monorepo: each vertical is scanned as its own SonarCloud project -->
+  <Property Name="sonar.project.monorepo.enabled">true</Property>
+
+  <!-- Only scan files MSBuild knows about (skip node_modules, infra/, docs/, etc.) -->
+  <Property Name="sonar.scanner.scanAll">false</Property>
+
+  <Property Name="sonar.sourceEncoding">UTF-8</Property>
+
+  <!--
+    Files excluded from analysis entirely (no issues, no metrics, no coverage).
+    Keep this list narrow — prefer sonar.coverage.exclusions / sonar.cpd.exclusions
+    when the code should still be analyzed for issues.
+  -->
+  <Property Name="sonar.exclusions">
+    **/Migration/**/*,
+    **/Migrations/**/*,
+    **/Altinn.AccessMgmt.FFB/**/*,
+    **/Altinn.AccessMgmt.WebComponents/**/*,
+    **/*.g.cs,
+    **/*.Designer.cs,
+    **/bin/**/*,
+    **/obj/**/*
+  </Property>
+
+  <!--
+    Test code is detected automatically by dotnet-sonarscanner via MSBuild
+    (IsTestProject / test SDK references). This list excludes test code from
+    *test analysis* — i.e. Sonar will not raise issues on test files. Source
+    code under src/.../src/ is unaffected.
+  -->
+  <Property Name="sonar.test.exclusions">
+    **/test/**/*,
+    **/*.Tests/**/*,
+    **/*.TestUtils/**/*,
+    **/*.Mocks/**/*
+  </Property>
+
+  <!--
+    Coverage exclusions: tests, generated code, and migrations don't need
+    line coverage. Mirrors the runsettings under src/coverage.runsettings.
+  -->
+  <Property Name="sonar.coverage.exclusions">
+    **/test/**/*,
+    **/*.Tests/**/*,
+    **/*.TestUtils/**/*,
+    **/*.Mocks/**/*,
+    **/Migration/**/*,
+    **/Migrations/**/*,
+    **/Program.cs,
+    **/Startup.cs,
+    **/*.g.cs,
+    **/*.Designer.cs,
+    **/Properties/AssemblyInfo.cs,
+    **/Altinn.AccessMgmt.FFB/**/*,
+    **/Altinn.AccessMgmt.WebComponents/**/*
+  </Property>
+
+  <!--
+    Copy/paste detector exclusions: model / DTO classes are intentionally
+    repetitive (property bags) and trip duplication checks for no real
+    signal. Real source files keep duplication enforcement.
+  -->
+  <Property Name="sonar.cpd.exclusions">
+    **/Models/**/*,
+    **/Dto/**/*,
+    **/Dtos/**/*,
+    **/Entities/**/*,
+    **/Contracts/**/*,
+    **/*Dto.cs,
+    **/*Request.cs,
+    **/*Response.cs
+  </Property>
+
+  <!-- .NET reports — produced by `dotnet-coverage` + xUnit v3 TRX in CI -->
+  <Property Name="sonar.cs.vscoveragexml.reportsPaths">TestResults/coverage.xml</Property>
+  <Property Name="sonar.cs.vstest.reportsPaths">**/*.trx</Property>
+
+  <!--
+    Quality gate behavior. `wait=false` keeps PR checks fast (Sonar still
+    posts results asynchronously). Flip to `true` if you want CI to block
+    until the gate result is known.
+  -->
+  <Property Name="sonar.qualitygate.wait">false</Property>
+
+</SonarQubeAnalysisProperties>

--- a/SonarQube.Analysis.xml
+++ b/SonarQube.Analysis.xml
@@ -3,16 +3,20 @@
   Shared SonarCloud analysis settings for the Altinn Authorization monorepo.
 
   Consumed by `dotnet-sonarscanner` when passed via the `/s:` flag, e.g.
-      dotnet-sonarscanner begin /k:<key> /n:<name> /s:"$GITHUB_WORKSPACE/SonarQube.Analysis.xml" ...
+      dotnet-sonarscanner begin /k:<key> /n:<name> /o:<org> /s:".../SonarQube.Analysis.xml" ...
 
-  Per-vertical values (sonar.projectKey, sonar.projectName, sonar.token) are
-  supplied by CI — keep them out of this file.
+  IMPORTANT: the scanner does NOT allow these properties to be set in this
+  file — they MUST come from CLI flags:
+      sonar.projectKey      → /k:
+      sonar.projectName     → /n:
+      sonar.projectVersion  → /v:
+      sonar.organization    → /o:
+  Every other property listed here is shared across all verticals.
 -->
-<SonarQubeAnalysisProperties xmlns="http://www.sonarsource.com/msbuild/analysisproperties/1.0">
+<SonarQubeAnalysisProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sonarsource.com/msbuild/integration/2015/1">
 
   <!-- SonarCloud target -->
   <Property Name="sonar.host.url">https://sonarcloud.io</Property>
-  <Property Name="sonar.organization">altinn</Property>
 
   <!-- Monorepo: each vertical is scanned as its own SonarCloud project -->
   <Property Name="sonar.project.monorepo.enabled">true</Property>
@@ -27,16 +31,7 @@
     Keep this list narrow — prefer sonar.coverage.exclusions / sonar.cpd.exclusions
     when the code should still be analyzed for issues.
   -->
-  <Property Name="sonar.exclusions">
-    **/Migration/**/*,
-    **/Migrations/**/*,
-    **/Altinn.AccessMgmt.FFB/**/*,
-    **/Altinn.AccessMgmt.WebComponents/**/*,
-    **/*.g.cs,
-    **/*.Designer.cs,
-    **/bin/**/*,
-    **/obj/**/*
-  </Property>
+  <Property Name="sonar.exclusions">**/Migration/**/*,**/Migrations/**/*,**/Altinn.AccessMgmt.FFB/**/*,**/Altinn.AccessMgmt.WebComponents/**/*,**/*.g.cs,**/*.Designer.cs,**/bin/**/*,**/obj/**/*</Property>
 
   <!--
     Test code is detected automatically by dotnet-sonarscanner via MSBuild
@@ -44,48 +39,20 @@
     *test analysis* — i.e. Sonar will not raise issues on test files. Source
     code under src/.../src/ is unaffected.
   -->
-  <Property Name="sonar.test.exclusions">
-    **/test/**/*,
-    **/*.Tests/**/*,
-    **/*.TestUtils/**/*,
-    **/*.Mocks/**/*
-  </Property>
+  <Property Name="sonar.test.exclusions">**/test/**/*,**/*.Tests/**/*,**/*.TestUtils/**/*,**/*.Mocks/**/*</Property>
 
   <!--
     Coverage exclusions: tests, generated code, and migrations don't need
     line coverage. Mirrors the runsettings under src/coverage.runsettings.
   -->
-  <Property Name="sonar.coverage.exclusions">
-    **/test/**/*,
-    **/*.Tests/**/*,
-    **/*.TestUtils/**/*,
-    **/*.Mocks/**/*,
-    **/Migration/**/*,
-    **/Migrations/**/*,
-    **/Program.cs,
-    **/Startup.cs,
-    **/*.g.cs,
-    **/*.Designer.cs,
-    **/Properties/AssemblyInfo.cs,
-    **/Altinn.AccessMgmt.FFB/**/*,
-    **/Altinn.AccessMgmt.WebComponents/**/*
-  </Property>
+  <Property Name="sonar.coverage.exclusions">**/test/**/*,**/*.Tests/**/*,**/*.TestUtils/**/*,**/*.Mocks/**/*,**/Migration/**/*,**/Migrations/**/*,**/Program.cs,**/Startup.cs,**/*.g.cs,**/*.Designer.cs,**/Properties/AssemblyInfo.cs,**/Altinn.AccessMgmt.FFB/**/*,**/Altinn.AccessMgmt.WebComponents/**/*</Property>
 
   <!--
     Copy/paste detector exclusions: model / DTO classes are intentionally
     repetitive (property bags) and trip duplication checks for no real
     signal. Real source files keep duplication enforcement.
   -->
-  <Property Name="sonar.cpd.exclusions">
-    **/Models/**/*,
-    **/Dto/**/*,
-    **/Dtos/**/*,
-    **/Entities/**/*,
-    **/Contracts/**/*,
-    **/*Dto.cs,
-    **/*Request.cs,
-    **/*Response.cs
-  </Property>
+  <Property Name="sonar.cpd.exclusions">**/Models/**/*,**/Dto/**/*,**/Dtos/**/*,**/Entities/**/*,**/Contracts/**/*,**/*Dto.cs,**/*Request.cs,**/*Response.cs</Property>
 
   <!-- .NET reports — produced by `dotnet-coverage` + xUnit v3 TRX in CI -->
   <Property Name="sonar.cs.vscoveragexml.reportsPaths">TestResults/coverage.xml</Property>

--- a/docs/SONARCLOUD.md
+++ b/docs/SONARCLOUD.md
@@ -10,8 +10,8 @@ in **monorepo mode** so projects are isolated despite sharing a repository.
 
 | File | What it controls |
 |---|---|
-| [`SonarQube.Analysis.xml`](../SonarQube.Analysis.xml) | Shared analysis settings: organization, host, exclusions, coverage report paths, duplication exclusions. The single source of truth — referenced from CI via `/s:`. |
-| [`.github/workflows/tpl-vertical-ci.yml`](../.github/workflows/tpl-vertical-ci.yml) | The `analyze` job. Passes per-vertical key/name and `SONAR_TOKEN` to `dotnet-sonarscanner`; everything else comes from the XML. |
+| [`SonarQube.Analysis.xml`](../SonarQube.Analysis.xml) | Shared analysis settings: host URL, exclusions, coverage report paths, duplication exclusions, monorepo flag. Referenced from CI via `/s:`. |
+| [`.github/workflows/tpl-vertical-ci.yml`](../.github/workflows/tpl-vertical-ci.yml) | The `analyze` job. Passes the four CLI-only properties (key / name / org / token) inline; everything else comes from the XML. |
 | `src/apps/<vertical>/conf.json` | Per-vertical opt-in / project key (see below). |
 
 The CI invocation is intentionally minimal:
@@ -20,12 +20,24 @@ The CI invocation is intentionally minimal:
 dotnet-sonarscanner begin \
   /key:"$SONAR_KEY" \
   /name:"$SONAR_NAME" \
+  /o:"altinn" \
   /d:sonar.token="$SONAR_TOKEN" \
   /s:"$GITHUB_WORKSPACE/SonarQube.Analysis.xml"
 ```
 
-If you need to change exclusions, coverage paths, or the quality-gate-wait
-behaviour, edit the XML — not the workflow.
+The scanner restricts four properties to CLI flags only — they cannot be
+moved into `SonarQube.Analysis.xml`:
+
+| Property | CLI flag |
+|---|---|
+| `sonar.projectKey` | `/k:` |
+| `sonar.projectName` | `/n:` |
+| `sonar.projectVersion` | `/v:` |
+| `sonar.organization` | `/o:` |
+
+Everything else (host URL, exclusions, coverage paths, monorepo flag,
+quality-gate-wait, etc.) lives in the XML. If you need to change one of
+those, edit the XML — not the workflow.
 
 ## Per-vertical setup
 

--- a/docs/SONARCLOUD.md
+++ b/docs/SONARCLOUD.md
@@ -1,0 +1,127 @@
+# SonarCloud
+
+SonarCloud runs static analysis on every push and PR — code smells, bugs,
+security hotspots, duplication, and ingested test coverage. Each vertical
+(`apps/*`, `libs/*`, `pkgs/*`) is its own SonarCloud project under the shared
+[`altinn`](https://sonarcloud.io/organizations/altinn) organization, scanned
+in **monorepo mode** so projects are isolated despite sharing a repository.
+
+## Where the config lives
+
+| File | What it controls |
+|---|---|
+| [`SonarQube.Analysis.xml`](../SonarQube.Analysis.xml) | Shared analysis settings: organization, host, exclusions, coverage report paths, duplication exclusions. The single source of truth — referenced from CI via `/s:`. |
+| [`.github/workflows/tpl-vertical-ci.yml`](../.github/workflows/tpl-vertical-ci.yml) | The `analyze` job. Passes per-vertical key/name and `SONAR_TOKEN` to `dotnet-sonarscanner`; everything else comes from the XML. |
+| `src/apps/<vertical>/conf.json` | Per-vertical opt-in / project key (see below). |
+
+The CI invocation is intentionally minimal:
+
+```bash
+dotnet-sonarscanner begin \
+  /key:"$SONAR_KEY" \
+  /name:"$SONAR_NAME" \
+  /d:sonar.token="$SONAR_TOKEN" \
+  /s:"$GITHUB_WORKSPACE/SonarQube.Analysis.xml"
+```
+
+If you need to change exclusions, coverage paths, or the quality-gate-wait
+behaviour, edit the XML — not the workflow.
+
+## Per-vertical setup
+
+Each vertical's `conf.json` declares whether SonarCloud runs and under which
+project key. Two shapes:
+
+```jsonc
+// Enabled
+{ "sonarcloud": { "projectKey": "Authorization_AccessManagement" } }
+
+// Disabled (the analyze job is skipped entirely)
+{ "sonarcloud": false }
+```
+
+Current state:
+
+| Vertical | Project key |
+|---|---|
+| `apps/Altinn.AccessManagement` | `Authorization_AccessManagement` |
+| `apps/Altinn.Authorization` | `Authorization_Authorization` |
+| `apps/Altinn.Register` | *disabled* (`sonarcloud: false`) |
+
+To onboard a new vertical: create the SonarCloud project under the `altinn`
+organization (Sonar UI → New project → GitHub → pick the repo → set monorepo
+mode), then add `"sonarcloud": { "projectKey": "..." }` to its `conf.json`.
+
+## Exclusions
+
+`SonarQube.Analysis.xml` defines four orthogonal exclusion lists:
+
+| Property | Effect | Used for |
+|---|---|---|
+| `sonar.exclusions` | File is invisible to Sonar — no issues, metrics, or coverage | Migrations, generated `.g.cs` / `.Designer.cs`, the FFB / WebComponents folders |
+| `sonar.test.exclusions` | File is not analyzed *as test code* | Everything under `**/test/**`, `*.Tests`, `*.TestUtils`, `*.Mocks` |
+| `sonar.coverage.exclusions` | File is analyzed for issues but excluded from line-coverage % | Test code, `Program.cs` / `Startup.cs`, generated files, migrations |
+| `sonar.cpd.exclusions` | File is exempt from copy/paste detection | Property-bag files: `Models/`, `Dto(s)/`, `Entities/`, `Contracts/`, `*Dto.cs`, `*Request.cs`, `*Response.cs` |
+
+**Pick the narrowest one that solves your problem.** Most additions belong in
+`coverage.exclusions` or `cpd.exclusions`; reach for `exclusions` only when
+the file genuinely shouldn't be analyzed at all.
+
+## Coverage import
+
+Sonar consumes the `analyze` job's own coverage run (VSCoverage XML at
+`TestResults/coverage.xml`) plus xUnit v3 TRX reports for test results. The
+`build-and-test` job's cobertura coverage is **not** the same artifact — see
+[issue #2934](https://github.com/Altinn/altinn-authorization-tmp/issues/2934)
+for the unification work and the coverage-format constraints. For local
+coverage workflow see [testing/COVERAGE.md](testing/COVERAGE.md).
+
+## Quality gate
+
+The default SonarCloud quality gate applies. PR decoration posts inline
+comments for issues introduced in the PR's "new code" period; the gate
+result is reported as a check but **does not block merging**
+(`sonar.qualitygate.wait=false` in the XML). To make it blocking, flip that
+property to `true` — expect ~30–90 s added to PR check time.
+
+## Common operations
+
+**Add an exclusion.** Edit `SonarQube.Analysis.xml` and the change applies to
+every vertical on the next CI run. No per-project config needed.
+
+**Disable Sonar for a vertical.** Set `"sonarcloud": false` in the vertical's
+`conf.json`. The `analyze` job's `if:` guard then skips it entirely — no
+project deletion required on Sonar's side.
+
+**Bump the scanner version.** Update the pinned version in two places that
+must agree: the `--version` flag in the *Install SonarCloud scanner*
+step in `tpl-vertical-ci.yml`, and the cache key prefix on the same job
+(otherwise the cache hands the old binary to the new pinned install).
+
+**Mark something as "won't fix" or "false positive".** Do it in the
+SonarCloud UI for the affected vertical's project — these decisions are
+project-scoped state, not source-controlled.
+
+## Debugging a failed analyze run
+
+1. Check the `Analyze` step log in the failing job. The scanner prints a
+   summary URL near the end (`Quality gate status:` line) — open it for
+   the per-issue breakdown.
+2. If the failure is in `dotnet-sonarscanner begin`, the cause is usually
+   an invalid `SONAR_TOKEN` or a project key mismatch. Confirm the key in
+   `conf.json` matches a project that exists in the `altinn` org.
+3. If `dotnet build` inside the analyze step fails but `build-and-test`
+   succeeded, the issue is almost always the `--no-incremental` rebuild
+   hitting an analyzer that's tolerated by the incremental build. Reproduce
+   locally with `dotnet build --no-incremental`.
+4. If coverage is reported as 0 % despite passing tests, check that
+   `TestResults/coverage.xml` exists in the analyze job — the path is
+   relative to the vertical's `working-directory`, not the repo root.
+
+## Related
+
+- [testing/CI.md](testing/CI.md) — overall pipeline shape.
+- [testing/COVERAGE.md](testing/COVERAGE.md) — local coverage workflow and
+  threshold enforcement.
+- [Tracking issue #2936](https://github.com/Altinn/altinn-authorization-tmp/issues/2936)
+  — open follow-ups for the SonarCloud setup.

--- a/docs/testing/CI.md
+++ b/docs/testing/CI.md
@@ -88,5 +88,6 @@ post-hoc. (Decision: [`TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/40_CI_First_
 ## Related docs
 
 - [COVERAGE.md](COVERAGE.md) — threshold mechanics and local-dev workflow.
+- [../SONARCLOUD.md](../SONARCLOUD.md) — SonarCloud config, exclusions, per-vertical setup.
 - [GETTING_STARTED.md](GETTING_STARTED.md) — local prerequisites.
 - [`TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/INDEX.md`](TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/INDEX.md) — every CI change is logged here.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -21,6 +21,7 @@ self-contained; none of them is a wall of text.
 | 7 | [FLUENT_ASSERTIONS_GUIDELINES.md](FLUENT_ASSERTIONS_GUIDELINES.md) | When and how to use FluentAssertions |
 | 8 | [COVERAGE.md](COVERAGE.md) | Running coverage locally, per-assembly thresholds, ratcheting |
 | 9 | [CI.md](CI.md) | How tests run in the pipeline, Microsoft Testing Platform (MTP), artifacts |
+| 10 | [../SONARCLOUD.md](../SONARCLOUD.md) | Static analysis: exclusions, per-vertical setup, quality gate, debugging |
 
 ## Historical / reference
 


### PR DESCRIPTION
## Summary

- Pull shared SonarCloud settings (organization, host, monorepo, exclusions, report paths) out of inline `/d:` flags in `tpl-vertical-ci.yml` into a new repo-root `SonarQube.Analysis.xml`, referenced via `/s:`. Per-vertical key/name and the `SONAR_TOKEN` secret stay inline; everything else is now a single source of truth.
- Broaden exclusions while we're there: coverage now ignores `*.Tests` / `*.TestUtils` / `*.Mocks`, `Program.cs` / `Startup.cs`, and generated `.g.cs` / `.Designer.cs` files. New `sonar.cpd.exclusions` silences duplication noise on `Models/`, `Dto(s)/`, `Entities/`, `Contracts/`, and `*Dto.cs` / `*Request.cs` / `*Response.cs`.
- Tighten the analyze job: `fetch-depth: 0` on checkout (Sonar needs full history for accurate blame and PR "new code" period), pin `dotnet-sonarscanner` to 11.2.1 (was unpinned, picked up latest on every run), and cache `~/.sonar/cache` + `~/.dotnet/tools` per vertical so the ~80 MB tool install and Sonar's incremental analysis cache don't rebuild every run.

Tracked under #2936. Out-of-scope follow-ups split into #2934 (eliminate duplicate test execution) and #2935 (skip SonarCloud on bot PRs).

## Out of scope (intentionally)

The `build-and-test` and `analyze` jobs run in parallel today and both rebuild + re-run all tests, doubling per-vertical CI minutes. Merging them would eliminate the duplicate test run, but SonarCloud's C# scanner does not accept cobertura coverage import — the merge would force a choice between rewriting `eng/testing/check-coverage-thresholds.ps1` to parse VSCoverage XML or producing two coverage formats. Both are real decisions that deserve their own PR with explicit team buy-in. See #2934.

## Test plan

- [ ] Trigger a full vertical CI run (e.g. `ci.yml` against `src/apps/Altinn.AccessManagement`) on this branch and confirm:
  - [ ] Sonar `Analyze` job still uploads a successful analysis with the same project key.
  - [ ] Coverage % on SonarCloud is unchanged or *higher* (broader coverage exclusions should not lower it; the new `*.Tests` / `*.Mocks` exclusions only remove test code that was producing noise).
  - [ ] Duplication count drops on Models/Dto-heavy projects (e.g. `Altinn.AccessMgmt.Persistence`).
  - [ ] Cache hit on the second run of the same vertical (`Cache restored from key:` line in the workflow log).
- [ ] Confirm PR decoration on this PR itself shows Sonar posting comments with proper file links (validates `fetch-depth: 0`).