### PR TITLE
Skip SonarCloud analysis on Renovate / Dependabot PRs

### DIFF
--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -217,7 +217,20 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    if: inputs.sonarProjectKey != 'false' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
+    # Skip Sonar when:
+    #   - the vertical opted out (sonarProjectKey == 'false')
+    #   - the PR is from a fork (no SONAR_TOKEN access)
+    #   - the PR was opened by Renovate / Dependabot — these only touch
+    #     dependency manifests and produce no useful Sonar findings, so
+    #     analysing them just burns Sonar minutes per vertical.
+    # On push events `github.event.pull_request.user.login` is null, so the
+    # bot checks pass and Sonar still runs on merges into main (including
+    # the merge of a bot-authored PR).
+    if: >-
+      inputs.sonarProjectKey != 'false'
+      && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
+      && github.event.pull_request.user.login != 'renovate[bot]'
+      && github.event.pull_request.user.login != 'dependabot[bot]'
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5


### PR DESCRIPTION
## Summary

Bot-authored PRs only touch dependency manifests (`Directory.Packages.props`, `package.json`, GitHub Actions versions) and produce no useful Sonar findings. Currently each one runs the full `analyze` job per vertical, burning Sonar minutes for nothing.

This extends the existing `if:` guard on the `analyze` job in [tpl-vertical-ci.yml:217-220](.github/workflows/tpl-vertical-ci.yml#L217-L220) to skip when the PR author is `renovate[bot]` or `dependabot[bot]`.

## Implementation note

Uses `github.event.pull_request.user.login` rather than `github.actor`. The two are usually equivalent for bot-opened PRs, but `user.login` is tied to the PR author specifically — `github.actor` reflects whoever last interacted with the PR (including the merger). On push events `github.event.pull_request.user.login` is null, so the bot comparisons evaluate to true and Sonar still runs — including on the push that merges a bot PR into main.

## Test plan

- [ ] Open this PR — confirm Sonar `Analyze` jobs run (this PR is human-authored).
- [ ] Wait for the next Renovate / Dependabot PR — confirm `Analyze` jobs are skipped (`This check was skipped` in PR check summary).
- [ ] After a Renovate / Dependabot PR merges to main — confirm Sonar runs on the resulting push (look for the `Analyze` job in the post-merge `ci.yml` run on main).

Closes #2935. Tracker: #2936.