### PR TITLE
Merge build-test-analyze CI job; skip Sonar on bot PRs

### DIFF
--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -1,4 +1,4 @@
-﻿name: "Template: Vertical CI"
+name: "Template: Vertical CI"
 
 on:
   workflow_call:
@@ -52,12 +52,25 @@ permissions:
   contents: read
 
 jobs:
-  build-and-test:
-    name: Build and Test
+  build-test-analyze:
+    # Single job that builds, tests (with coverage), runs the threshold
+    # check, packs (for pkg verticals), and uploads the SonarCloud analysis
+    # — all driven by ONE test execution. Previously split across two jobs
+    # (`build-and-test` and `analyze`) that each rebuilt and re-ran every
+    # test, doubling per-vertical CI minutes. SonarCloud's C# scanner does
+    # not accept cobertura, so coverage is collected once into the native
+    # `.coverage` binary and merged into both formats: cobertura for the
+    # PowerShell threshold check, VSCoverage XML for Sonar.
+    name: Build, Test, Analyze
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          # Sonar needs full git history for accurate blame, SCM authors,
+          # and "new code" period detection on PRs.
+          fetch-depth: 0
+
       - name: Install .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
@@ -69,36 +82,105 @@ jobs:
         run: dotnet workload restore
         working-directory: ${{ inputs.path }}
 
-      - name: Build
-        run: dotnet build -c Release -bl:binlog/build.binlog
-        working-directory: ${{ inputs.path }}
-
-      - name: Install dotnet-coverage
-        # Installed once per job so the Test step below can wrap `dotnet test`
-        # under `dotnet-coverage collect`. Keeping install in a separate step
-        # keeps the Test step's run log focused on test output and makes the
-        # install failure (if any) easy to spot as its own red checkmark.
-        run: dotnet tool install -g dotnet-coverage
+      - name: Detect SonarCloud config
+        # Single source of truth for "should Sonar run?". Exposed as a step
+        # output so the conditional Sonar steps below all reference one
+        # condition instead of repeating the inputs / fork check inline.
+        id: sonar
         shell: bash
+        run: |
+          if [[ "${{ inputs.sonarProjectKey }}" != "false" \
+             && "${{ github.event.pull_request.head.repo.fork }}" != "true" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Test
-        # Single test execution that ALSO collects coverage — this replaces
-        # the old "run tests twice" pattern (once for pass/fail, once under
-        # `dotnet-coverage` for XML). The Coverage threshold check step below
-        # is now parse-only and completes in seconds.
-        #
-        # `dotnet-coverage collect -- dotnet test` propagates the test
-        # command's exit code, so:
-        #   * exit 0 = tests passed
-        #   * exit 2 = real test failures (fails this step, red ❌)
-        #   * exit 8 = no tests ran (e.g. every test `[Skip]`ed because
-        #             required infra like Azurite is missing in CI) — we
-        #             swallow this via `--ignore-exit-code 8`
-        # The cobertura XML is written to TestResults/coverage.cobertura.xml
-        # relative to the vertical's working directory.
-        id: test
-        run: dotnet-coverage collect --nologo --output TestResults/coverage.cobertura.xml --output-format cobertura -- dotnet test -c Release --no-build -bl:binlog/test.binlog -- --ignore-exit-code 8
+      - name: Set up JDK 17
+        # Required by dotnet-sonarscanner. Skipped when Sonar is disabled
+        # for this vertical (e.g. Altinn.Register).
+        if: steps.sonar.outputs.enabled == 'true'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "microsoft"
+          java-version: 17
+
+      - name: Cache SonarCloud scanner and analysis cache
+        # Caches both the dotnet-sonarscanner / dotnet-coverage global tools
+        # (~80MB) and Sonar's incremental analysis cache under ~/.sonar/cache.
+        # Keyed per-vertical so each project's analysis cache is isolated;
+        # bumped when the scanner version changes.
+        if: steps.sonar.outputs.enabled == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.sonar/cache
+            ~/.dotnet/tools
+          key: ${{ runner.os }}-sonar-11.2.1-${{ inputs.slug }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-sonar-11.2.1-${{ inputs.slug }}-
+            ${{ runner.os }}-sonar-11.2.1-
+
+      - name: Install coverage and Sonar tools
+        # dotnet-coverage is needed by every vertical (collects test
+        # coverage). dotnet-sonarscanner is only needed when Sonar is on.
+        shell: bash
+        run: |
+          dotnet tool list --global | grep -q dotnet-coverage || dotnet tool install --global dotnet-coverage
+          if [[ "${{ steps.sonar.outputs.enabled }}" == "true" ]]; then
+            dotnet tool list --global | grep -q dotnet-sonarscanner || dotnet tool install --global dotnet-sonarscanner --version 11.2.1
+          fi
+
+      - name: SonarCloud begin
+        # Wraps the build/test that follow. The scanner injects its analyzers
+        # via MSBuild integration during the Build step; analysis data is
+        # then uploaded in the matching `SonarCloud end` step below.
+        id: sonar-begin
+        if: steps.sonar.outputs.enabled == 'true'
         working-directory: ${{ inputs.path }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed for PR decoration
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_KEY: ${{ inputs.sonarProjectKey }}
+          SONAR_NAME: ${{ inputs.sonarProjectName }}
+        shell: bash
+        run: |
+          dotnet-sonarscanner begin \
+            /key:"$SONAR_KEY" \
+            /name:"$SONAR_NAME" \
+            /o:"altinn" \
+            /d:sonar.token="$SONAR_TOKEN" \
+            /s:"$GITHUB_WORKSPACE/SonarQube.Analysis.xml"
+
+      - name: Build
+        # `--no-incremental` keeps the output deterministic between this run
+        # and any local rebuild — important when the SonarCloud scanner is
+        # wrapping the build, which is sensitive to stale analyzer outputs.
+        run: dotnet build -c Release --no-incremental -bl:binlog/build.binlog
+        working-directory: ${{ inputs.path }}
+
+      - name: Test (with coverage)
+        # ONE test execution per CI run. dotnet-coverage collects in the
+        # native `.coverage` binary format; the two Convert steps below
+        # produce cobertura (for the threshold check) and VSCoverage XML
+        # (for Sonar) without re-running the tests. xUnit v3 routes through
+        # Microsoft Testing Platform (MTP); arguments after `--` are
+        # forwarded to each per-project MTP runner:
+        #   --results-directory   write per-project artifacts under TestResults/
+        #   --report-xunit-trx    emit .trx files (consumed by Sonar via
+        #                         sonar.cs.vstest.reportsPaths)
+        #   --ignore-exit-code 8  treat "all tests [Skip]ped" as success
+        #                         (e.g. Host.Lease without Azurite)
+        # `dotnet-coverage collect -- dotnet test` propagates the test exit
+        # code, so a real test failure (exit 2) fails this step.
+        id: test
+        shell: bash
+        working-directory: ${{ inputs.path }}
+        run: |
+          dotnet-coverage collect --nologo \
+            --output TestResults/coverage.coverage --output-format coverage \
+            -- dotnet test -c Release --no-build -bl:binlog/test.binlog \
+              -- --results-directory TestResults/ --report-xunit-trx --ignore-exit-code 8
 
       - name: Report failed tests
         # When the Test step fails, surface the specific failing test names
@@ -162,11 +244,50 @@ jobs:
           Write-Host ""
           Write-Host "Total failing tests: $total"
 
+      - name: Convert coverage to cobertura
+        # Reads the native .coverage binary written by the Test step and
+        # emits cobertura — the format the PowerShell threshold check below
+        # parses. Runs even on test failure so a coverage regression isn't
+        # masked by a separate test failure.
+        if: always() && hashFiles(format('{0}/TestResults/coverage.coverage', inputs.path)) != ''
+        shell: bash
+        working-directory: ${{ inputs.path }}
+        run: |
+          dotnet-coverage merge --nologo \
+            --output TestResults/coverage.cobertura.xml --output-format cobertura \
+            TestResults/coverage.coverage
+
+      - name: Convert coverage to VSCoverage XML
+        # Sonar's C# scanner does not accept cobertura — it reads VSCoverage
+        # XML via sonar.cs.vscoveragexml.reportsPaths (configured in the
+        # repo-root SonarQube.Analysis.xml). Skip when Sonar is off for this
+        # vertical (no consumer).
+        if: always() && steps.sonar-begin.outcome == 'success' && hashFiles(format('{0}/TestResults/coverage.coverage', inputs.path)) != ''
+        shell: bash
+        working-directory: ${{ inputs.path }}
+        run: |
+          dotnet-coverage merge --nologo \
+            --output TestResults/coverage.xml --output-format xml \
+            TestResults/coverage.coverage
+
+      - name: SonarCloud end
+        # Uploads analysis to SonarCloud. Runs on test failure too — issues
+        # found by the scanner are still useful when tests are red. Gated on
+        # `sonar-begin succeeded` so the matching `end` is only invoked when
+        # there's something to close out.
+        if: always() && steps.sonar-begin.outcome == 'success'
+        working-directory: ${{ inputs.path }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: bash
+        run: dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"
+
       - name: Coverage threshold check
-        # Parse-only: reads TestResults/coverage.cobertura.xml produced by the
-        # Test step above and enforces per-assembly thresholds. Completes in
-        # seconds — no test re-run. See eng/testing/check-coverage-thresholds.ps1.
-        if: hashFiles(format('{0}/TestResults/coverage.cobertura.xml', inputs.path)) != ''
+        # Parse-only: reads TestResults/coverage.cobertura.xml produced by
+        # the Convert-to-cobertura step above and enforces per-assembly
+        # thresholds. Completes in seconds — no test re-run.
+        # See eng/testing/check-coverage-thresholds.ps1.
+        if: always() && hashFiles(format('{0}/TestResults/coverage.cobertura.xml', inputs.path)) != ''
         shell: pwsh
         working-directory: ${{ inputs.path }}
         run: |
@@ -189,12 +310,12 @@ jobs:
 
       - name: Upload test results
         # On failure only: capture MTP per-project logs and TRX reports so the
-        # cause can be diagnosed from GHA artifacts. The workflow `6_Test.txt`
+        # cause can be diagnosed from GHA artifacts. The workflow `Test.txt`
         # log contains only summary lines like "Failed: N, Passed: M"; per-test
         # detail lives in bin/.../TestResults/<Project>_<tfm>_<arch>.log.
         # We intentionally skip this on success — the logs aren't needed and
         # uploading them every run added 10+ MB per CI pipeline.
-        # Cobertura XML is not uploaded (it's reproducible locally via
+        # Coverage XML is not uploaded (it's reproducible locally via
         # eng/testing/run-coverage.ps1 and was the bulk of the artifact size).
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -213,82 +334,3 @@ jobs:
           path: ${{ inputs.path }}/binlog/*.binlog
           if-no-files-found: error
           retention-days: 1
-
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    if: inputs.sonarProjectKey != 'false' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          # Sonar needs full git history for accurate blame, SCM authors,
-          # and "new code" period detection on PRs.
-          fetch-depth: 0
-      - name: Install .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
-        with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-
-      - name: Restore dotnet workloads
-        run: dotnet workload restore
-        working-directory: ${{ inputs.path }}
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: "microsoft"
-          java-version: 17
-
-      - name: Cache SonarCloud scanner and analysis cache
-        # Caches both the dotnet-sonarscanner / dotnet-coverage global tools
-        # (~80MB) and Sonar's incremental analysis cache under ~/.sonar/cache.
-        # Keyed per-vertical so each project's analysis cache is isolated;
-        # bumped when the scanner version changes.
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.sonar/cache
-            ~/.dotnet/tools
-          key: ${{ runner.os }}-sonar-11.2.1-${{ inputs.slug }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-sonar-11.2.1-${{ inputs.slug }}-
-            ${{ runner.os }}-sonar-11.2.1-
-
-      - name: Install SonarCloud scanner and dependencies
-        shell: bash
-        run: |
-          dotnet tool list --global | grep -q dotnet-sonarscanner || dotnet tool install --global dotnet-sonarscanner --version 11.2.1
-          dotnet tool list --global | grep -q dotnet-coverage      || dotnet tool install --global dotnet-coverage
-
-      - name: Analyze
-        working-directory: ${{ inputs.path }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_KEY: ${{ inputs.sonarProjectKey }}
-          SONAR_NAME: ${{ inputs.sonarProjectName }}
-        shell: bash
-        run: |
-          dotnet-sonarscanner begin \
-            /key:"$SONAR_KEY" \
-            /name:"$SONAR_NAME" \
-            /o:"altinn" \
-            /d:sonar.token="$SONAR_TOKEN" \
-            /s:"$GITHUB_WORKSPACE/SonarQube.Analysis.xml"
-
-          dotnet build --no-incremental
-          # xUnit v3 routes `dotnet test` through Microsoft Testing Platform (MTP).
-          # Everything after `--` is forwarded to each per-project MTP runner:
-          #   --results-directory   emit artifacts (including the TRX below) under TestResults/
-          #   --report-xunit-trx    generate .trx files so Sonar's sonar.cs.vstest.reportsPaths picks them up
-          #                         (xUnit v3's built-in TRX reporter; the generic MTP
-          #                         --report-trx would need the separate
-          #                         Microsoft.Testing.Extensions.TrxReport package)
-          #   --ignore-exit-code 8  treat "all tests [Skip]ped" (e.g. Host.Lease without Azurite) as success
-          dotnet coverage collect 'dotnet test --no-build -- --results-directory TestResults/ --report-xunit-trx --ignore-exit-code 8' \
-            -f xml -o 'TestResults/coverage.xml'
-
-          dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -85,12 +85,23 @@ jobs:
       - name: Detect SonarCloud config
         # Single source of truth for "should Sonar run?". Exposed as a step
         # output so the conditional Sonar steps below all reference one
-        # condition instead of repeating the inputs / fork check inline.
+        # condition instead of repeating the checks inline.
+        # Sonar is disabled when:
+        #   - the vertical opted out (sonarProjectKey == 'false')
+        #   - the PR is from a fork (no SONAR_TOKEN access on forks)
+        #   - the PR was opened by Renovate / Dependabot — bot PRs only
+        #     touch dependency manifests and produce no useful Sonar
+        #     findings, so analysing them just burns Sonar minutes per
+        #     vertical. On push events `github.event.pull_request.user.login`
+        #     is null, so the bot checks pass and Sonar still runs on
+        #     merges to main (including the merge of a bot-authored PR).
         id: sonar
         shell: bash
         run: |
           if [[ "${{ inputs.sonarProjectKey }}" != "false" \
-             && "${{ github.event.pull_request.head.repo.fork }}" != "true" ]]; then
+             && "${{ github.event.pull_request.head.repo.fork }}" != "true" \
+             && "${{ github.event.pull_request.user.login }}" != "renovate[bot]" \
+             && "${{ github.event.pull_request.user.login }}" != "dependabot[bot]" ]]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"

--- a/docs/SONARCLOUD.md
+++ b/docs/SONARCLOUD.md
@@ -64,6 +64,20 @@ To onboard a new vertical: create the SonarCloud project under the `altinn`
 organization (Sonar UI → New project → GitHub → pick the repo → set monorepo
 mode), then add `"sonarcloud": { "projectKey": "..." }` to its `conf.json`.
 
+### Automatic skips
+
+Even when a vertical opts in, the `Detect SonarCloud config` step skips
+Sonar when:
+
+- the PR is from a fork (no `SONAR_TOKEN` access)
+- the PR was opened by `renovate[bot]` or `dependabot[bot]` — bot PRs only
+  touch dependency manifests and produce no useful Sonar findings, so
+  analysing them just burns Sonar minutes per vertical
+
+Pushes to `main` (including the merge commit of a bot-authored PR) always
+run Sonar — the bot author check uses `pull_request.user.login`, which is
+null on push events.
+
 ## Exclusions
 
 `SonarQube.Analysis.xml` defines four orthogonal exclusion lists:

--- a/docs/SONARCLOUD.md
+++ b/docs/SONARCLOUD.md
@@ -11,7 +11,7 @@ in **monorepo mode** so projects are isolated despite sharing a repository.
 | File | What it controls |
 |---|---|
 | [`SonarQube.Analysis.xml`](../SonarQube.Analysis.xml) | Shared analysis settings: host URL, exclusions, coverage report paths, duplication exclusions, monorepo flag. Referenced from CI via `/s:`. |
-| [`.github/workflows/tpl-vertical-ci.yml`](../.github/workflows/tpl-vertical-ci.yml) | The `analyze` job. Passes the four CLI-only properties (key / name / org / token) inline; everything else comes from the XML. |
+| [`.github/workflows/tpl-vertical-ci.yml`](../.github/workflows/tpl-vertical-ci.yml) | The `build-test-analyze` job. Passes the four CLI-only properties (key / name / org / token) inline; everything else comes from the XML. |
 | `src/apps/<vertical>/conf.json` | Per-vertical opt-in / project key (see below). |
 
 The CI invocation is intentionally minimal:
@@ -48,7 +48,7 @@ project key. Two shapes:
 // Enabled
 { "sonarcloud": { "projectKey": "Authorization_AccessManagement" } }
 
-// Disabled (the analyze job is skipped entirely)
+// Disabled (Sonar steps in build-test-analyze are skipped; build/test still run)
 { "sonarcloud": false }
 ```
 
@@ -81,12 +81,18 @@ the file genuinely shouldn't be analyzed at all.
 
 ## Coverage import
 
-Sonar consumes the `analyze` job's own coverage run (VSCoverage XML at
-`TestResults/coverage.xml`) plus xUnit v3 TRX reports for test results. The
-`build-and-test` job's cobertura coverage is **not** the same artifact — see
-[issue #2934](https://github.com/Altinn/altinn-authorization-tmp/issues/2934)
-for the unification work and the coverage-format constraints. For local
-coverage workflow see [testing/COVERAGE.md](testing/COVERAGE.md).
+Tests run **once** under `dotnet-coverage collect`, producing a native
+`.coverage` binary. Two `dotnet-coverage merge` steps then convert it to
+the formats consumed downstream:
+
+| Output | Consumer |
+|---|---|
+| `TestResults/coverage.cobertura.xml` | `eng/testing/check-coverage-thresholds.ps1` |
+| `TestResults/coverage.xml` *(VSCoverage XML)* | SonarCloud (via `sonar.cs.vscoveragexml.reportsPaths` in the XML config) |
+
+Sonar's C# scanner does not accept cobertura, which is why both formats are
+materialized. For local coverage workflow see
+[testing/COVERAGE.md](testing/COVERAGE.md).
 
 ## Quality gate
 
@@ -102,11 +108,13 @@ property to `true` — expect ~30–90 s added to PR check time.
 every vertical on the next CI run. No per-project config needed.
 
 **Disable Sonar for a vertical.** Set `"sonarcloud": false` in the vertical's
-`conf.json`. The `analyze` job's `if:` guard then skips it entirely — no
-project deletion required on Sonar's side.
+`conf.json`. The `Detect SonarCloud config` step in the workflow then sets
+`enabled=false`, and every Sonar-specific step downstream is skipped — no
+project deletion required on Sonar's side. Build, test, and the coverage
+threshold check still run as normal.
 
 **Bump the scanner version.** Update the pinned version in two places that
-must agree: the `--version` flag in the *Install SonarCloud scanner*
+must agree: the `--version` flag in the *Install coverage and Sonar tools*
 step in `tpl-vertical-ci.yml`, and the cache key prefix on the same job
 (otherwise the cache hands the old binary to the new pinned install).
 
@@ -114,21 +122,22 @@ step in `tpl-vertical-ci.yml`, and the cache key prefix on the same job
 SonarCloud UI for the affected vertical's project — these decisions are
 project-scoped state, not source-controlled.
 
-## Debugging a failed analyze run
+## Debugging a failed Sonar run
 
-1. Check the `Analyze` step log in the failing job. The scanner prints a
-   summary URL near the end (`Quality gate status:` line) — open it for
-   the per-issue breakdown.
-2. If the failure is in `dotnet-sonarscanner begin`, the cause is usually
-   an invalid `SONAR_TOKEN` or a project key mismatch. Confirm the key in
-   `conf.json` matches a project that exists in the `altinn` org.
-3. If `dotnet build` inside the analyze step fails but `build-and-test`
-   succeeded, the issue is almost always the `--no-incremental` rebuild
-   hitting an analyzer that's tolerated by the incremental build. Reproduce
-   locally with `dotnet build --no-incremental`.
-4. If coverage is reported as 0 % despite passing tests, check that
-   `TestResults/coverage.xml` exists in the analyze job — the path is
-   relative to the vertical's `working-directory`, not the repo root.
+1. Check the `SonarCloud end` step log in the failing job. The scanner
+   prints a summary URL near the end (`Quality gate status:` line) — open
+   it for the per-issue breakdown.
+2. If the failure is in `SonarCloud begin`, the cause is usually an invalid
+   `SONAR_TOKEN`, an `xmlns` typo in `SonarQube.Analysis.xml`, or a project
+   key mismatch. Confirm the key in `conf.json` matches a project that
+   exists in the `altinn` org.
+3. If `Build` fails but local builds pass, the issue is almost always the
+   `--no-incremental` rebuild hitting an analyzer that's tolerated by the
+   incremental build. Reproduce locally with `dotnet build --no-incremental`.
+4. If coverage is reported as 0 % despite passing tests, check that the
+   `Convert coverage to VSCoverage XML` step ran and produced
+   `TestResults/coverage.xml` — the path is relative to the vertical's
+   `working-directory`, not the repo root.
 
 ## Related
 

--- a/docs/testing/CI.md
+++ b/docs/testing/CI.md
@@ -1,27 +1,24 @@
 # Tests in CI
 
 Tests run per-vertical in parallel jobs. Each vertical (app/lib/pkg) has its
-own CI job driven by a shared template: `tpl-vertical-ci.yml`.
+own CI job driven by a shared template: `tpl-vertical-ci.yml`. Build, test,
+threshold enforcement, and SonarCloud analysis all happen in one job per
+vertical (`build-test-analyze`) so the test suite executes exactly once.
 
 ## Job structure
 
 For each vertical the pipeline runs:
 
-1. **Restore + build** — `dotnet build --configuration Release`.
-2. **Test + coverage (single pass)** — the tests are executed once under
-   `dotnet-coverage collect`, producing both a TRX report and
-   `TestResults/coverage.cobertura.xml`. See
+1. **SonarCloud begin** *(verticals that opt in via `conf.json`)* — `dotnet-sonarscanner begin` wraps the build/test that follow so the scanner can hook MSBuild's analyzers.
+2. **Restore + build** — `dotnet build -c Release --no-incremental`. The build inside Sonar's begin/end window is what gives the scanner its data.
+3. **Test + coverage (single pass)** — `dotnet-coverage collect` wraps `dotnet test` once, writing TRX reports plus a native `.coverage` binary. See
    [`TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/41_CI_Coverage_Single_Run.md`](TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/41_CI_Coverage_Single_Run.md).
-3. **Coverage threshold check** — parses the Cobertura XML and fails the
-   job if any enforced assembly is below its floor. See [COVERAGE.md](COVERAGE.md).
-4. **Sonar analyze** (Authorization vertical only) — `dotnet test` run
-   under `dotnet-sonarscanner begin/end` with MTP-friendly arguments
-   (`--report-xunit-trx --ignore-exit-code 8`). See
-   [`TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/38_CI_MTP_Followups_Sonar_And_Coverage.md`](TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/38_CI_MTP_Followups_Sonar_And_Coverage.md).
-5. **Report failed tests** — post-test step that parses MTP logs and emits
-   per-failure `::group::` + `::error title::` annotations on GitHub Actions.
-6. **Upload artifacts** on failure — MTP `*.log` / `*.trx` files from
-   `TestResults/`. Retention: 3 days. See
+4. **Convert coverage** — two `dotnet-coverage merge` calls turn the binary into cobertura (for the threshold check) and VSCoverage XML (for Sonar). No re-running tests.
+5. **SonarCloud end** *(verticals that opt in)* — uploads the analysis. Runs even if tests failed so issues found by the scanner are still posted. See [../SONARCLOUD.md](../SONARCLOUD.md).
+6. **Coverage threshold check** — parses the cobertura XML and fails the job if any enforced assembly is below its floor. See [COVERAGE.md](COVERAGE.md).
+7. **Pack** — `dotnet pack` for `pkg`-type verticals only.
+8. **Report failed tests** — post-test step that parses MTP logs and emits per-failure `::group::` + `::error title::` annotations on GitHub Actions.
+9. **Upload artifacts** on failure — MTP `*.log` / `*.trx` files from `TestResults/`. Retention: 3 days. See
    [`TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/40_CI_First_Green_Run_Hardening.md`](TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/40_CI_First_Green_Run_Hardening.md).
 
 ## Microsoft Testing Platform (MTP)


### PR DESCRIPTION
## Summary

Two related SonarCloud CI changes — bundled together because they both touch the same Sonar guard logic.

### 1. Merge `build-and-test` and `analyze` into one job (closes #2934)

The test suite now runs **once per CI run per vertical** instead of twice. This is **option 2** from #2934 — collect coverage once into the native `.coverage` binary, then run `dotnet-coverage merge` twice to produce both formats:

| Output | Consumer |
|---|---|
| `TestResults/coverage.cobertura.xml` | `eng/testing/check-coverage-thresholds.ps1` (unchanged) |
| `TestResults/coverage.xml` *(VSCoverage XML)* | SonarCloud (`sonar.cs.vscoveragexml.reportsPaths`) |

The threshold script and `SonarQube.Analysis.xml` are untouched. The dual-format merge replaces the previous pattern where `analyze` re-ran every test just to get a different coverage format.

### 2. Skip Sonar on Renovate / Dependabot PRs (closes #2935)

Bot-authored PRs only touch dependency manifests and produce no useful Sonar findings. The new `Detect SonarCloud config` step now returns `enabled=false` when `github.event.pull_request.user.login` is `renovate[bot]` or `dependabot[bot]`. On push events that field is null, so Sonar still runs on the push that merges a bot PR into `main`.

## Other tidy-ups in the same job

- **DRY the Sonar guard.** The four-condition `if:` (project key, fork, two bot authors) is computed once in `Detect SonarCloud config` and exposed as `steps.sonar.outputs.enabled`. Every Sonar-specific step references that one output.
- **Build always uses `--no-incremental`.** Required by Sonar (the scanner is sensitive to stale analyzer outputs); harmless overhead for non-Sonar verticals on a fresh runner.
- **`fetch-depth: 0` always.** Was previously only on the analyze checkout; now on the merged job. Sonar needs full git history for blame / "new code" period; the cost on this repo is negligible.

## Test plan

- [ ] Trigger `ci.yml` on this branch (this PR is human-authored, so Sonar should run).
- [ ] Confirm a single `Build, Test, Analyze` job per vertical — no separate `Analyze` job in the matrix.
- [ ] Verticals with Sonar enabled (AccessManagement, Authorization): SonarCloud receives the analysis with the same project key, coverage % is unchanged or higher, PR decoration posts comments.
- [ ] Vertical with Sonar disabled (Register): `Set up JDK 17`, `Cache SonarCloud scanner …`, `SonarCloud begin`, `Convert coverage to VSCoverage XML`, and `SonarCloud end` are all marked **skipped**; build / test / threshold check / pack / uploads still run.
- [ ] On a deliberate test failure: `SonarCloud end` and `Coverage threshold check` still run (`if: always()`), so the analysis is uploaded and the threshold result is reported even when tests are red.
- [ ] After merge, watch the next Renovate / Dependabot PR — confirm every Sonar step is **skipped**, and that the post-merge push to `main` runs Sonar normally.
- [ ] Compare per-vertical CI minutes against the most recent green run on `main`. Expected drop: roughly 30–40 % per vertical (one fewer test run).

## Tracker

Closes #2934, closes #2935. Tracker: #2936.