### PR TITLE
Requests for MaskinportenSchema resources are not allowed

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/RequestService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/RequestService.cs
@@ -136,8 +136,11 @@ public class RequestService(AppDbContext db, IOptions<CoreAppsettings> appsettin
     /// <inheritdoc/>
     public async Task<Result<RequestDto>> CreateResourceRequest(Guid toId, Guid fromId, Guid byId, Guid roleId, Guid resourceId, RequestStatus status = RequestStatus.Pending, CancellationToken ct = default)
     {
+        var resource = await db.Resources.Include(r => r.Type).FirstOrDefaultAsync(r => r.Id == resourceId, ct);
+
         var problem = ValidationComposer.Validate(
-            PackageValidation.SelfAssignmentNotAllowed(fromId, toId)
+            PackageValidation.SelfAssignmentNotAllowed(fromId, toId),
+            PackageValidation.ResourceIsAssignable(resource)
         );
 
         if (problem is { })

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/PackageValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/PackageValidation.cs
@@ -131,6 +131,23 @@ public static class PackageValidation
     };
 
     /// <summary>
+    /// Checks if resource is assignable.
+    /// </summary>
+    /// <param name="resource">resource</param>
+    /// <param name="paramName">name of the query parameter</param>
+    /// <returns></returns>
+    internal static RuleExpression ResourceIsAssignable(Resource resource, string paramName = "resource") => () =>
+    {
+        if (resource.Type.Name == "MaskinportenSchema")
+        {
+            return (ref ValidationErrorBuilder errors) =>
+                        errors.Add(ValidationErrors.ResourceIsNotDelegable, paramName, [new(paramName, $"Resource '{resource.Name}' is of type 'MaskinportenSchema' and cannot be requested.")]);
+        }
+
+        return null;
+    };
+
+    /// <summary>
     /// Checks if request is from self
     /// </summary>
     /// <param name="fromId">From</param>

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/RequestControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/RequestControllerTest.cs
@@ -65,8 +65,15 @@ public class RequestControllerTest
             Name = "CreateResourceTestType",
         };
 
+        private static readonly ResourceType TestMaskinportenSchemaResourceType = new()
+        {
+            Id = Guid.Parse("0196c001-0000-7000-8000-000000000002"),
+            Name = "MaskinportenSchema",
+        };
+
         private static readonly Guid TestResourceId = Guid.Parse("0196b001-0000-7000-8000-000000000002");
         private const string TestResourceRefId = "create-resource-test-1";
+        private const string TestMaskinportenSchemaResourceRefId = "create-resource-test-2";
 
         public CreateResourceRequest(ApiFixture fixture)
         {
@@ -75,6 +82,8 @@ public class RequestControllerTest
             fixture.EnsureSeedOnce<CreateResourceRequest>(db =>
             {
                 db.ResourceTypes.Add(TestResourceType);
+                db.ResourceTypes.Add(TestMaskinportenSchemaResourceType);
+
                 db.SaveChanges();
                 db.Resources.Add(new Resource
                 {
@@ -85,6 +94,17 @@ public class RequestControllerTest
                     ProviderId = ProviderConstants.ResourceRegistry,
                     TypeId = TestResourceType.Id,
                 });
+
+                db.Resources.Add(new Resource
+                {
+                    Id = Guid.CreateVersion7(),
+                    Name = "TestMaskinportenSchemaResource",
+                    Description = "Test resource for ServiceOwner API tests",
+                    RefId = TestMaskinportenSchemaResourceRefId,
+                    ProviderId = TestData.ServiceOwnerNAV,
+                    TypeId = TestMaskinportenSchemaResourceType.Id,
+                });
+
                 db.SaveChanges();
             });
         }
@@ -106,6 +126,20 @@ public class RequestControllerTest
 
             var obj = await response.Content.ReadFromJsonAsync<RequestDto>(TestContext.Current.CancellationToken);
             Assert.Equal(RequestStatus.Pending, obj.Status);
+        }
+
+        [Fact]
+        public async Task CreateRequest_WithMaskinportenSchemaResource_Returns400()
+        {
+            // KnutVik er styremedlem i BakerJohnsen (seeded via TestData.Assignments)
+            var client = CreateSystemClient(Fixture, TestData.KnutVik.Id);
+
+            var response = await client.PostAsync(
+                $"{Route}/resource?party={TestData.KnutVik.Id}&to={TestData.BakerJohnsen.Id}&resource={TestMaskinportenSchemaResourceRefId}",
+                null,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
     }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Controllers/RequestControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Controllers/RequestControllerTest.cs
@@ -129,6 +129,12 @@ public class RequestControllerTest
             Name = "ServiceOwnerTestResourceType",
         };
 
+        private static readonly ResourceType TestMaskinportenSchemaResourceType = new()
+        {
+            Id = Guid.Parse("0196c001-0000-7000-8000-000000000002"),
+            Name = "MaskinportenSchema",
+        };
+
         public CreateResourceRequestTest(ApiFixture fixture)
         {
             Fixture = fixture;
@@ -136,6 +142,7 @@ public class RequestControllerTest
             fixture.EnsureSeedOnce<CreateResourceRequestTest>(db =>
             {
                 db.ResourceTypes.Add(TestResourceType);
+                db.ResourceTypes.Add(TestMaskinportenSchemaResourceType);
                 db.SaveChanges();
 
                 db.Resources.Add(new Resource
@@ -147,6 +154,17 @@ public class RequestControllerTest
                     ProviderId = TestData.ServiceOwnerNAV,
                     TypeId = TestResourceType.Id,
                 });
+
+                db.Resources.Add(new Resource
+                {
+                    Id = Guid.CreateVersion7(),
+                    Name = "TestMaskinportenSchemaResource",
+                    Description = "Test resource for ServiceOwner API tests",
+                    RefId = "test-resource-so-maskinporten-1",
+                    ProviderId = TestData.ServiceOwnerNAV,
+                    TypeId = TestMaskinportenSchemaResourceType.Id,
+                });
+
                 db.SaveChanges();
             });
         }
@@ -225,6 +243,28 @@ public class RequestControllerTest
                 From = from,
                 To = to,
                 Resource = "test-resource-so-1"
+            };
+
+            var response = await client.PostAsJsonAsync(
+                Route + "/resource",
+                body,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateRequest_WithMaskinportenSchemaResource_Returns400()
+        {
+            var client = CreateClient(Fixture, TestData.BakerJohnsen.Entity.OrganizationIdentifier);
+            var from = $"urn:altinn:organization:identifier-no:{TestData.BakerJohnsen.Entity.OrganizationIdentifier}";
+            var to = $"urn:altinn:person:identifier-no:{TestData.LarsBakke.Entity.PersonIdentifier}";
+
+            var body = new RequestResourceDto
+            {
+                From = from,
+                To = to,
+                Resource = "test-resource-so-maskinporten-1"
             };
 
             var response = await client.PostAsJsonAsync(


### PR DESCRIPTION
## Description
- Added validation to not not allow maskinportenSchema resources to be requested
- Added tests for ServiceOwner and Enduser

## Related Issue(s)
- #2964 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
