### PR TITLE
Add unit tests for Access Management Metadata API controllers

### DIFF
--- a/docs/testing/TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_2/07_Coverage_Api_Metadata_PackagesController.md
+++ b/docs/testing/TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_2/07_Coverage_Api_Metadata_PackagesController.md
@@ -1,0 +1,155 @@
+---
+step: 7
+title: Coverage — Api.Metadata `PackagesController` direct unit tests
+phase: B
+status: complete
+linkedIssues:
+  feature: 2976
+  task: 2977
+coverageDelta:
+  # Baseline is the post-Step-6 merged-cobertura figure
+  # (51.53% line / 51.11% branch). Step 7 run-coverage.ps1 result:
+  # 79.04% line, 77.78% branch — see Verification § Coverage.
+  Altinn.AccessManagement.Api.Metadata:
+    linePp: +27.51
+    branchPp: +26.67
+verifiedTests: 26
+testFailures: 0
+testSkips: 0
+touchedFiles: 1
+auditIds: [M6']
+---
+
+# Step 7 — Coverage: `Altinn.AccessManagement.Api.Metadata` `PackagesController`
+
+## Goal
+
+Resolve audit finding **M6'** for the Metadata host: close the remaining
+controller gap in `Altinn.AccessManagement.Api.Metadata` by adding direct
+Moq-based unit tests for the six untested actions on
+`PackagesController`. Same direct-controller pattern established in
+[`overhaul part-1 step 49`](../STEPS_PART_1/49_Coverage_Api_Internal_Controllers.md)
+and [`step 53`](../STEPS_PART_1/53_Coverage_6_7d_Part7.md): controllers
+are instantiated with mocked `IPackageService` + `ITranslationService`,
+no `WebApplicationFactory`, no Postgres.
+
+`RolesController` (covered by [`RolesControllerTest.cs`](../../../src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/RolesControllerTest.cs))
+and `TypesController.GetOrganizationSubTypes` (covered by
+[`TypesControllerTest.cs`](../../../src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/TypesControllerTest.cs))
+already have full direct-unit-test coverage; this step extends
+`PackagesControllerTest.cs`.
+
+## What changed
+
+### `src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs`
+
+15 new tests appended (11 → 26 in this class), each with the same
+shape: instantiate `PackagesController` with a mocked
+`IPackageService` (and a pass-through `ITranslationService`),
+invoke the action, assert on the `ActionResult.Result` discriminator
+(`OkObjectResult` / `NoContentResult` / `NotFoundResult`).
+
+Section coverage added:
+
+| Section | Tests | Branches covered |
+|---|---|---|
+| `GetGroupAreas(id)` | 3 | results found → 200; empty + group exists → 204; empty + group missing → 404 |
+| `GetArea(id)` | 2 | found → 200; missing → 404 |
+| `GetAreaPackages(id)` | 3 | results found → 200; empty + area exists → 204; empty + area missing → 404 |
+| `GetPackage(id)` | 2 | found → 200; missing → 404 |
+| `GetPackageByUrn(urnValue)` | 2 | found → 200; missing → 404 |
+| `GetPackageResources(id)` | 3 | results found → 200; empty + package exists → 204; empty + package missing → 404 |
+
+Additional change: `PassThroughTranslation()` was extended to also
+register pass-through stubs for `AreaDto`, `ResourceDto`, `TypeDto`,
+and `ProviderDto` — without these, `DeepTranslationExtensions`'
+`await translationService.TranslateAsync(item, …)` calls return a
+default-valued `ValueTask<T>` (i.e. `null`) on Moq-uninitialized
+mocks, which then NREs inside the deep-translation traversal. The
+existing `PackageDto` / `AreaGroupDto` setups are preserved unchanged.
+
+The 200-path tests on the three multi-branch actions also assert
+that the fallback service call (e.g. `GetAreaGroup` for
+`GetGroupAreas`) is **never** invoked when results are found —
+guarding the "happy path skips fallback lookup" invariant explicitly
+rather than relying on `Verify(Times.Never)` only on regression.
+
+## Verification
+
+### Tests
+
+```
+PackagesControllerTest (focused):  26 /   26 passed (0 failed, 0 skipped) — 690 ms
+AccessMgmt.Tests (full project): 1225 / 1225 passed (0 failed, 0 skipped) — 1m 50s
+Suite total (run-coverage.ps1):  2575 / 2559 passed (0 failed, 16 skipped)
+```
+
+The 16 suite-wide skips are unchanged from Step 6's run (Azurite-blocked
+`Host.Lease` × 2, the two carry-over `Sender_Confirms…` /
+`Receiver_Approves…` rewrite skips, and the 9 + 5 environmentally
+blocked tests in `Enduser.Api.Tests` and `Integration.Tests` already
+catalogued under L1' / Phase E.3). No new sibling regressions.
+
+The +39 net-new test count vs Step 6's 2536 baseline includes the 15
+new tests added by this step plus 24 tests that arrived via main since
+Step 6 ([apps#2959](https://github.com/Altinn/altinn-authorization-tmp/pull/2959),
+[apps#2965](https://github.com/Altinn/altinn-authorization-tmp/pull/2965),
+[apps#2928](https://github.com/Altinn/altinn-authorization-tmp/pull/2928)).
+
+### Coverage
+
+Baseline (post-Step-6 merged-cobertura, see
+[`INDEX.md` § Final Coverage](INDEX.md#final-coverage-measured)):
+
+| Assembly | Line% | Branch% |
+|---|---:|---:|
+| `Altinn.AccessManagement.Api.Metadata` | 51.53 | 51.11 |
+
+After Step 7 (merged-cobertura at `TestResults/coverage.cobertura.xml`):
+
+| Assembly | Line% | Branch% | ΔLine | ΔBranch |
+|---|---:|---:|---:|---:|
+| `Altinn.AccessManagement.Api.Metadata` | **79.04** | **77.78** | **+27.51 pp** | **+26.67 pp** |
+
+`check-coverage-thresholds.ps1` exit: **0** ✅. `Api.Metadata` is not on
+the enforced floors list, so the gain is pure progress; at 79.04 % it is
+now a **stronger Phase F.1 candidate** than the original 70 % floor
+sketched in [`INDEX.md` § F.1](INDEX.md#recommended-next-steps-priority-order)
+— consider promoting at floor 75 instead.
+
+## Deferred / follow-up
+
+- **`AccessManagementMetadataHost.cs` and `Program.cs`** —
+  bootstrap files that today read as ~0 % covered for the Metadata
+  host. Reaching them requires `WebApplicationFactory`-style
+  integration tests, not pure-logic Moq tests; out of scope for
+  Phase B.1. May be picked up under Phase D if a Metadata-host
+  integration suite is built.
+- **`TypesController.GetAllTypes` and `GetSubTypes`** — both
+  declared `private` in the source, yet decorated (in commented-out
+  attribute markers) with `[Route]` / `[HttpGet]`. ASP.NET Core
+  routing cannot reach them; they are dead code that contributes a
+  small amount of uncovered surface to the Metadata assembly. The
+  cleanup (delete or expose-and-test) is a separate code-hygiene
+  concern outside the testing-infrastructure overhaul, so no
+  test was added here.
+- **Phase B.2 / B.3** remain the next pure-logic targets per
+  [`INDEX.md` § Recommended Next Steps](INDEX.md#recommended-next-steps-priority-order):
+  `Persistence.Core` (largest gap), then `Integration.Platform`.
+- **Phase F.1 promotion** — `Api.Metadata` was added to the F.1
+  candidate list in [`INDEX.md` § Recommended Next Steps](INDEX.md#recommended-next-steps-priority-order)
+  at floor **75** (rather than the 70 originally sketched, since the
+  measured coverage of 79.04 % gives ~4 pp headroom). The Final
+  Coverage row was repositioned from rank 17 to rank 6.
+- **Drift in non-Metadata coverage rows** — the `run-coverage.ps1`
+  output also showed small shifts in five non-Metadata assemblies
+  vs the Step 6 baseline (Enterprise +2.31 pp, AccessManagement.Persistence
+  +1.86 pp, Api.Enduser +0.49 pp, Api.ServiceOwner +0.36 pp,
+  AccessMgmt.Core −0.61 pp). These reflect intervening main commits
+  ([apps#2959](https://github.com/Altinn/altinn-authorization-tmp/pull/2959),
+  [apps#2965](https://github.com/Altinn/altinn-authorization-tmp/pull/2965),
+  [apps#2928](https://github.com/Altinn/altinn-authorization-tmp/pull/2928))
+  rather than Step 7 work, so the rows were **not** edited inline —
+  a future closing sweep should re-baseline the whole Final Coverage
+  table in one pass to avoid drift accumulating row-by-row. Notes
+  added to the table preamble.

--- a/docs/testing/TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_2/INDEX.md
+++ b/docs/testing/TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_2/INDEX.md
@@ -335,6 +335,7 @@ the phase numbers in the
 | 4 | 2026-04-27 | A | Scaffold `Altinn.Authorization.Host.Pipeline.Tests` for **C3'/A.5** — new test project under `src/libs/Altinn.Authorization.Host/test/` mirroring `Lease.Tests` wiring (empty TFM trick + `xunit.runner.json` + ProjectReference to the production assembly). Added one `PipelineMessage<T>` ctor round-trip smoke test (1 passed) to keep test-discovery non-zero and avoid recreating C1'. Added to both root and per-package Host `.sln` files; build clean (0/0); xUnit v3 in-process runner discovers + passes the test. **The 0 % coverage on the production `Altinn.Authorization.Host.Pipeline` assembly itself is unchanged** — populating real Pipeline tests is Phase D.1, deferred. Test-project count: 10 → **11** | n/a (production assembly unchanged; smoke test only) | [04_Scaffold_Host_Pipeline_Tests.md](04_Scaffold_Host_Pipeline_Tests.md) |
 | 5 | 2026-04-27 | A | Resolve **C2'/A.2** — architect confirmed the `AccessManagementAuthorizedParties` feature flag has been always-on in production for some time and is ready to remove. The failing test `ValidateParty_NotAsAuthenticatedUser_Forbidden` was hitting the dead legacy `else` branch of `PartiesController.ValidateSelectedParty` only because the test class flipped the flag to `false` mid-class. Removed: the flag constant from `FeatureFlags.cs`; the `if(flag) { … } else { … }` branching from both `GetPartyList` and `ValidateSelectedParty` (keeping only the `AuthorizedParties` paths); the now-unused `_partiesWrapper` and `_featureManager` ctor params/fields from `PartiesController`; the now-orphaned `IParties.GetParties` and `IParties.ValidateSelectedParty` methods + their `PartiesWrapper` and `PartiesMock` impls; the `_featureManageMock` setup + flag-flipping legacy-vs-new comparison from `PartiesControllerTest.GetPartyList_AsAuthenticatedUser_Ok`. **No security-relevant condition in production** (the flag was always on); the originally-flagged "auth regression" was a test-hits-dead-code artefact. `Altinn.Authorization.Tests` 402/402/0/0/0 (was 402/401/1/0/0); 0 sibling regressions | n/a (dead-code removal; coverage of `Altinn.Authorization` largely unchanged) | [05_Remove_AccessManagementAuthorizedParties_Flag.md](05_Remove_AccessManagementAuthorizedParties_Flag.md) |
 | 6 | 2026-04-27 | A | T1 closing sweep — re-baselined PART_2.md §§1.1/1.4/1.5/1.6/2/4 + INDEX Final Coverage + Phase B/F priorities against the post-C5'-fix and post-Step-5 merged-cobertura view. Re-scoped Phase B.1 to drop `Api.Internal` (true coverage 73.63%, not the Step 1 figure of 48.56%); added `Api.Internal` as a NEW Phase F (L2') promotion candidate at floor 70. Re-scoped Phase F floor-raise list (Maskinporten 75→80, PEP 75→78, PersistenceEF 90→95). Updated §1.6 drift summary to flag that 5 of the Step 1 "regressions" were measurement artefacts. Coverage run 2536/2520/0/16; threshold check exit 0 ✅. **T1 (#2947) is now ready for the bundled PR.** | n/a (closing-sweep; no production code) | [06_T1_Closing_Sweep_and_Baseline_Refresh.md](06_T1_Closing_Sweep_and_Baseline_Refresh.md) |
+| 7 | 2026-04-29 | B | Resolve **B.1 / M6'** — added 15 direct Moq-based unit tests to `PackagesControllerTest.cs` covering the 6 untested `Altinn.AccessManagement.Api.Metadata.Controllers.PackagesController` actions (`GetGroupAreas`, `GetArea`, `GetAreaPackages`, `GetPackage`, `GetPackageByUrn`, `GetPackageResources`) — each exercising the 200-OK, 204-NoContent (where applicable), and 404-NotFound branches and (for the multi-branch actions) verifying the fallback service lookup is **never** invoked on the happy path. Extended `PassThroughTranslation()` with `AreaDto`/`ResourceDto`/`TypeDto`/`ProviderDto` setups so `DeepTranslationExtensions` doesn't NRE on un-mocked DTO types. **`Altinn.AccessManagement.Api.Metadata`: 51.53% → 79.04% line / 51.11% → 77.78% branch.** Suite 2575/2559/0/16; threshold check exit 0 ✅. Promotes Api.Metadata from "Phase F.1 floor 70 candidate" to "**Phase F.1 floor 75 candidate**". Test-class count for `PackagesControllerTest`: 11 → **26**. | **+27.51 pp** | [07_Coverage_Api_Metadata_PackagesController.md](07_Coverage_Api_Metadata_PackagesController.md) |
 
 ### Recommended Next Steps (priority order)
 
@@ -371,12 +372,14 @@ All items below are actionable unless otherwise noted. Ordering follows
 
 **Phase B — Pure-logic coverage (re-scoped at Step 6 after C5' fix):**
 
-6. **B.1 — Controller gap (M6').** Direct Moq tests for
-   `Altinn.AccessManagement.Api.Metadata` (51.53%) only. Mirror the
-   Part 1 Step 49 / Step 53 pattern. *(`Altinn.AccessManagement.Api.Internal`
-   was the other half of M6' — Step 6 re-baseline confirmed it's
-   actually 73.63% under proper aggregation, not the Step 1 figure of
-   48.56%; dropped from B.1.)*
+6. ~~**B.1 — Controller gap (M6').**~~ — **Done in Step 7**
+   ([07_Coverage_Api_Metadata_PackagesController.md](07_Coverage_Api_Metadata_PackagesController.md)):
+   added 15 direct Moq tests for the six untested `PackagesController`
+   actions in `Altinn.AccessManagement.Api.Metadata`, lifting the
+   assembly from 51.53% → **79.04% line** / 51.11% → 77.78% branch
+   (+27.51 pp / +26.67 pp). `RolesController` and `TypesController`
+   were already covered. **Promotes Api.Metadata to a Phase F.1
+   floor-75 candidate** (see item 19 below).
 7. **B.2 — Domain pure-logic (M5').** Identify remaining reachable
    targets in `Altinn.AccessMgmt.Persistence.Core` (25.39% — largest
    remaining pure-logic gap) and `Altinn.AccessMgmt.Core` (44.96%).
@@ -433,6 +436,8 @@ All items below are actionable unless otherwise noted. Ordering follows
     `eng/testing/coverage-thresholds.json`:
     `Altinn.Authorization.Host` (91.67% → floor 85),
     `Altinn.AccessManagement.Integration` (88.35% → floor 80),
+    **`Altinn.AccessManagement.Api.Metadata`** (79.04% → floor 75 —
+    NEW candidate after Step 7 raised it from 51.53%),
     `Altinn.AccessManagement.Api.Enduser` (73.88% → floor 70),
     **`Altinn.AccessManagement.Api.Internal`** (73.63% → floor 70 —
     NEW candidate revealed by Step 6 re-baseline),
@@ -461,20 +466,29 @@ shows up immediately.
 
 | Item | Blocker | Notes | Last re-checked |
 |---|---|---|---|
-| `Host.Lease` tests (Part 1 Phase 6.5 carry-over) | Azurite / Azure Storage Emulator required | Confirmed at Step 1 audit: 2 tests, both `Skip`ped, `Altinn.Authorization.Host.Lease` at 6.87% line. Tracked as **M4'** in [PART_2 §2](../TESTING_INFRASTRUCTURE_OVERHAUL_PART_2.md#2-findings--issues); Phase D.2 unblocks (Azurite Testcontainers fixture). | step 6 |
-| `Sender_ConfirmsDraftRequest_ReturnsPending` (Part 1 carry-over) | Environmental investigation needed | `[Skip]`ped during Part 1 Step 51 after the `ResourceRegistryMock` cache-hit fix landed. Confirmed still skipped at Step 1 audit. Will be reviewed under **L1'** / Phase E.3. | step 6 |
-| `Receiver_ApprovesPendingPackageRequest_ReturnsApproved` (Part 1 carry-over) | Fixture mis-seed — needs rewrite | `[Skip]`ped during Part 1 Step 62 with a TODO describing the proper rewrite (auth as MD of receiver + pre-existing Rightholder connection). Confirmed still skipped at Step 1. Will be reviewed under **L1'** / Phase E.3. | step 6 |
+| `Host.Lease` tests (Part 1 Phase 6.5 carry-over) | Azurite / Azure Storage Emulator required | Confirmed at Step 1 audit: 2 tests, both `Skip`ped, `Altinn.Authorization.Host.Lease` at 6.87% line. Tracked as **M4'** in [PART_2 §2](../TESTING_INFRASTRUCTURE_OVERHAUL_PART_2.md#2-findings--issues); Phase D.2 unblocks (Azurite Testcontainers fixture). | step 7 |
+| `Sender_ConfirmsDraftRequest_ReturnsPending` (Part 1 carry-over) | Environmental investigation needed | `[Skip]`ped during Part 1 Step 51 after the `ResourceRegistryMock` cache-hit fix landed. Confirmed still skipped at Step 1 audit. Will be reviewed under **L1'** / Phase E.3. | step 7 |
+| `Receiver_ApprovesPendingPackageRequest_ReturnsApproved` (Part 1 carry-over) | Fixture mis-seed — needs rewrite | `[Skip]`ped during Part 1 Step 62 with a TODO describing the proper rewrite (auth as MD of receiver + pre-existing Rightholder connection). Confirmed still skipped at Step 1. Will be reviewed under **L1'** / Phase E.3. | step 7 |
 
 ### Final Coverage (measured)
 
 **Re-baselined at Step 6 (2026-04-27)** against the post-C5'-fix and
-post-Step-5 merged-cobertura view (`TestResults/coverage.cobertura.xml`).
-Owned assemblies only (foreign / indirect packages omitted). Sorted
-by line% descending. Numbers are now reliable — see
+post-Step-5 merged-cobertura view (`TestResults/coverage.cobertura.xml`);
+**`Altinn.AccessManagement.Api.Metadata` re-measured at Step 7
+(2026-04-29)** after the M6' tests landed. Owned assemblies only
+(foreign / indirect packages omitted). Sorted by line% descending.
+Numbers are reliable — see
 [PART_2 §1.4](../TESTING_INFRASTRUCTURE_OVERHAUL_PART_2.md#14-coverage-baseline-line--branch-owned-assemblies-merged-cobertura)
 for full classification, Part 1 deltas, and the (large) Step 1 →
 Step 6 deltas where the C5' fix surfaced previously-mis-counted
-coverage.
+coverage. Several non-Metadata assemblies have drifted slightly
+(Enterprise +2.31 pp, AccessManagement.Persistence +1.86 pp,
+Api.Enduser +0.49 pp, Api.ServiceOwner +0.36 pp, AccessMgmt.Core
+−0.61 pp) since Step 6 due to intervening main commits ([apps#2959](https://github.com/Altinn/altinn-authorization-tmp/pull/2959),
+[apps#2965](https://github.com/Altinn/altinn-authorization-tmp/pull/2965),
+[apps#2928](https://github.com/Altinn/altinn-authorization-tmp/pull/2928));
+those rows are **not** refreshed here — a future closing sweep should
+re-baseline them all in one pass to avoid drift accumulating row-by-row.
 
 | # | Assembly | Line% | Branch% | Threshold (json) | Status |
 |---|---|---:|---:|---|---|
@@ -483,18 +497,18 @@ coverage.
 | 3 | `Altinn.AccessManagement.Integration` | 88.35 | 85.71 | — | ✅ Phase F promote (floor 80, L2') |
 | 4 | `Altinn.AccessManagement.Api.Maskinporten` | 80.36 | 80.00 | 75 (enf) | ✅ Phase F floor-raise candidate (75→80) |
 | 5 | `Altinn.Authorization.PEP` | 79.60 | 83.48 | 75 (enf) | ✅ Phase F floor-raise candidate (75→78) |
-| 6 | `Altinn.AccessManagement.Api.Enduser` | 73.88 | 65.36 | — | ✅ Phase F promote (floor 70, L2') |
-| 7 | `Altinn.AccessManagement.Api.Internal` | 73.63 | 75.56 | — | ✅ Phase F promote (floor 70, L2') — **NEW: C5' fix surfaced +25pp** |
-| 8 | `Altinn.AccessManagement.Api.ServiceOwner` | 69.58 | 57.94 | — | ✅ Phase F promote (floor 65, L2') |
-| 9 | `Altinn.Authorization` | 69.14 | 72.72 | 60 (enf) | ✅ |
-| 10 | `Altinn.AccessManagement.Core` | 66.49 | 63.37 | 60 (enf) | ✅ |
-| 11 | `Altinn.AccessManagement.Api.Enterprise` | 66.39 | 56.52 | 60 (enf) | ✅ |
-| 12 | `Altinn.Authorization.ABAC` | 63.28 | 63.52 | 60 (enf) | ✅ (coverage is *indirect* via `Altinn.Authorization.Tests`) |
-| 13 | `Altinn.Authorization.Host.Database` | 59.42 | 76.92 | — | ⚠ Just under 60 (M8') |
-| 14 | `Altinn.AccessManagement` (main app) | 57.57 | 60.64 | 60 (warn) | ⚠ Warn-only ratchet failing; -0.62pp regression vs Part 1 (M2'/L3') |
-| 15 | `Altinn.AccessManagement.Persistence` | 57.29 | 34.14 | — | ⏫ M3' Phase C (live-DB; closer to threshold than Step 1 indicated) |
-| 16 | `Altinn.Authorization.Integration.Platform` | 54.94 | 69.08 | — | ⏫ M7' Phase B.3 |
-| 17 | `Altinn.AccessManagement.Api.Metadata` | 51.53 | 51.11 | — | ⏫ M6' Phase B.1 (only remaining controller gap) |
+| 6 | `Altinn.AccessManagement.Api.Metadata` | 79.04 | 77.78 | — | ✅ Phase F promote (floor 75, L2') — **NEW: Step 7 raised from 51.53 % (B.1 / M6' done)** |
+| 7 | `Altinn.AccessManagement.Api.Enduser` | 73.88 | 65.36 | — | ✅ Phase F promote (floor 70, L2') |
+| 8 | `Altinn.AccessManagement.Api.Internal` | 73.63 | 75.56 | — | ✅ Phase F promote (floor 70, L2') — **NEW: C5' fix surfaced +25 pp** |
+| 9 | `Altinn.AccessManagement.Api.ServiceOwner` | 69.58 | 57.94 | — | ✅ Phase F promote (floor 65, L2') |
+| 10 | `Altinn.Authorization` | 69.14 | 72.72 | 60 (enf) | ✅ |
+| 11 | `Altinn.AccessManagement.Core` | 66.49 | 63.37 | 60 (enf) | ✅ |
+| 12 | `Altinn.AccessManagement.Api.Enterprise` | 66.39 | 56.52 | 60 (enf) | ✅ |
+| 13 | `Altinn.Authorization.ABAC` | 63.28 | 63.52 | 60 (enf) | ✅ (coverage is *indirect* via `Altinn.Authorization.Tests`) |
+| 14 | `Altinn.Authorization.Host.Database` | 59.42 | 76.92 | — | ⚠ Just under 60 (M8') |
+| 15 | `Altinn.AccessManagement` (main app) | 57.57 | 60.64 | 60 (warn) | ⚠ Warn-only ratchet failing; -0.62 pp regression vs Part 1 (M2'/L3') |
+| 16 | `Altinn.AccessManagement.Persistence` | 57.29 | 34.14 | — | ⏫ M3' Phase C (live-DB; closer to threshold than Step 1 indicated) |
+| 17 | `Altinn.Authorization.Integration.Platform` | 54.94 | 69.08 | — | ⏫ M7' Phase B.3 |
 | 18 | `Altinn.AccessMgmt.Persistence` | 47.32 | 34.27 | — | ⏫ M3' Phase C (live-DB) |
 | 19 | `Altinn.AccessMgmt.Core` | 44.96 | 35.05 | — | ⏫ M5' Phase B.2 |
 | 20 | `Altinn.Authorization.Api.Contracts` | 34.68 | 16.85 | — | DTO-heavy; low priority |

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
@@ -30,6 +30,14 @@ public class PackagesControllerTest
             .ReturnsAsync((PackageDto dto, string _, bool __) => dto);
         mock.Setup(x => x.TranslateAsync(It.IsAny<AreaGroupDto>(), It.IsAny<string>(), It.IsAny<bool>()))
             .ReturnsAsync((AreaGroupDto dto, string _, bool __) => dto);
+        mock.Setup(x => x.TranslateAsync(It.IsAny<AreaDto>(), It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync((AreaDto dto, string _, bool __) => dto);
+        mock.Setup(x => x.TranslateAsync(It.IsAny<ResourceDto>(), It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync((ResourceDto dto, string _, bool __) => dto);
+        mock.Setup(x => x.TranslateAsync(It.IsAny<TypeDto>(), It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync((TypeDto dto, string _, bool __) => dto);
+        mock.Setup(x => x.TranslateAsync(It.IsAny<ProviderDto>(), It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync((ProviderDto dto, string _, bool __) => dto);
         return mock;
     }
 
@@ -212,6 +220,264 @@ public class PackagesControllerTest
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
 
         var result = await controller.GetGroup(Guid.NewGuid());
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ── GetGroupAreas ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetGroupAreas_WhenAreasFound_Returns200Ok()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetAreas(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AreaDto> { new AreaDto { Id = Guid.NewGuid() } });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetGroupAreas(id);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.IsAssignableFrom<IEnumerable<AreaDto>>(ok.Value);
+        // GetAreaGroup must NOT be hit when areas were found.
+        serviceMock.Verify(s => s.GetAreaGroup(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetGroupAreas_WhenNoAreasButGroupExists_Returns204NoContent()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetAreas(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<AreaDto>());
+        serviceMock.Setup(s => s.GetAreaGroup(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AreaGroupDto { Id = id });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetGroupAreas(id);
+
+        Assert.IsType<NoContentResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetGroupAreas_WhenNoAreasAndGroupMissing_Returns404NotFound()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetAreas(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<AreaDto>)null);
+        serviceMock.Setup(s => s.GetAreaGroup(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AreaGroupDto)null);
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetGroupAreas(id);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ── GetArea ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetArea_WhenFound_Returns200Ok()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetArea(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AreaDto { Id = id });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetArea(id);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.NotNull(ok.Value);
+    }
+
+    [Fact]
+    public async Task GetArea_WhenNotFound_Returns404()
+    {
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetArea(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AreaDto)null);
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetArea(Guid.NewGuid());
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ── GetAreaPackages ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAreaPackages_WhenPackagesFound_Returns200Ok()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetPackagesByArea(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PackageDto> { new PackageDto { Id = Guid.NewGuid() } });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetAreaPackages(id);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.IsAssignableFrom<IEnumerable<PackageDto>>(ok.Value);
+        // GetArea must NOT be hit when packages were found.
+        serviceMock.Verify(s => s.GetArea(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAreaPackages_WhenNoPackagesButAreaExists_Returns204NoContent()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetPackagesByArea(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<PackageDto>());
+        serviceMock.Setup(s => s.GetArea(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AreaDto { Id = id });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetAreaPackages(id);
+
+        Assert.IsType<NoContentResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetAreaPackages_WhenNoPackagesAndAreaMissing_Returns404NotFound()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetPackagesByArea(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<PackageDto>)null);
+        serviceMock.Setup(s => s.GetArea(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AreaDto)null);
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetAreaPackages(id);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ── GetPackage ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPackage_WhenFound_Returns200Ok()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetPackage(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackageDto { Id = id });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetPackage(id);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.NotNull(ok.Value);
+    }
+
+    [Fact]
+    public async Task GetPackage_WhenNotFound_Returns404()
+    {
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetPackage(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PackageDto)null);
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetPackage(Guid.NewGuid());
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ── GetPackageByUrn ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPackageByUrn_WhenFound_Returns200Ok()
+    {
+        const string urn = "skattnaering";
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetPackageByUrnValue(urn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackageDto { Id = Guid.NewGuid() });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetPackageByUrn(urn);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.NotNull(ok.Value);
+    }
+
+    [Fact]
+    public async Task GetPackageByUrn_WhenNotFound_Returns404()
+    {
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetPackageByUrnValue(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PackageDto)null);
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetPackageByUrn("missing");
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ── GetPackageResources ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetPackageResources_WhenResourcesFound_Returns200Ok()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetPackageResources(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ResourceDto> { new ResourceDto { Id = Guid.NewGuid() } });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetPackageResources(id);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.IsAssignableFrom<IEnumerable<ResourceDto>>(ok.Value);
+        // GetPackage must NOT be hit when resources were found.
+        serviceMock.Verify(s => s.GetPackage(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPackageResources_WhenNoResourcesButPackageExists_Returns204NoContent()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetPackageResources(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<ResourceDto>());
+        serviceMock.Setup(s => s.GetPackage(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PackageDto { Id = id });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetPackageResources(id);
+
+        Assert.IsType<NoContentResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetPackageResources_WhenNoResourcesAndPackageMissing_Returns404NotFound()
+    {
+        var id = Guid.NewGuid();
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.GetPackageResources(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<ResourceDto>)null);
+        serviceMock.Setup(s => s.GetPackage(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PackageDto)null);
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.GetPackageResources(id);
 
         Assert.IsType<NotFoundResult>(result.Result);
     }


### PR DESCRIPTION
## Summary

Adds 15 direct Moq-based unit tests for the six previously-untested actions on `Altinn.AccessManagement.Api.Metadata.Controllers.PackagesController` — `GetGroupAreas`, `GetArea`, `GetAreaPackages`, `GetPackage`, `GetPackageByUrn`, `GetPackageResources`. Each test exercises the 200-OK / 204-NoContent / 404-NotFound branches; the three multi-branch actions also `Verify(Times.Never)` on the fallback service lookup to lock in the "happy path skips fallback" invariant.

`PassThroughTranslation()` was extended to register pass-through stubs for `AreaDto`, `ResourceDto`, `TypeDto`, and `ProviderDto` so `DeepTranslationExtensions` does not NRE on un-mocked DTO types during the new tests.

Closes the controller-coverage gap audit finding **M6'** for the Metadata host. `RolesController` and `TypesController` were already covered.

### Coverage

| Assembly | Before | After | Δ |
|---|---:|---:|---:|
| `Altinn.AccessManagement.Api.Metadata` (line) | 51.53 % | **79.04 %** | **+27.51 pp** |
| `Altinn.AccessManagement.Api.Metadata` (branch) | 51.11 % | **77.78 %** | **+26.67 pp** |

Suite total: 2575 / 2559 / 0 / 16 (passed / passed / failed / skipped); `eng/testing/check-coverage-thresholds.ps1` exit 0.

This promotes `Api.Metadata` from a Phase F.1 floor-70 candidate to a **floor-75 candidate** — the F.1 ratchet list in `INDEX.md` and the Final Coverage table have been updated accordingly.

### Context

- Audit finding: `M6'` — see [`TESTING_INFRASTRUCTURE_OVERHAUL_PART_2.md` § 2](https://github.com/Altinn/altinn-authorization-tmp/blob/main/docs/testing/TESTING_INFRASTRUCTURE_OVERHAUL/TESTING_INFRASTRUCTURE_OVERHAUL_PART_2.md#2-findings--issues).
- Step doc: [`STEPS_PART_2/07_Coverage_Api_Metadata_PackagesController.md`](https://github.com/Altinn/altinn-authorization-tmp/blob/feat/2977_metadata_controller_tests/docs/testing/TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_2/07_Coverage_Api_Metadata_PackagesController.md).
- Pattern mirrors Part 1 [`Step 49`](https://github.com/Altinn/altinn-authorization-tmp/blob/main/docs/testing/TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/49_Coverage_Api_Internal_Controllers.md) and [`Step 53`](https://github.com/Altinn/altinn-authorization-tmp/blob/main/docs/testing/TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/53_Coverage_6_7d_Part7.md) — controllers instantiated directly with mocked services, no `WebApplicationFactory`, no Postgres.
- Parent Feature: #2976 (Phase B umbrella; stays open until B.2 and B.3 also land).

Closes #2977.

## Test plan

- [x] `PackagesControllerTest` class: 26 / 26 passing locally (was 11; +15 new).
- [x] `AccessMgmt.Tests` project: 1225 / 1225 passing (no sibling regressions).
- [x] Full suite via `eng/testing/run-coverage.ps1`: 2575 / 2559 / 0 / 16 — skips unchanged from Step 6 baseline.
- [x] `eng/testing/check-coverage-thresholds.ps1` exit 0.
- [x] Build clean (0 errors); only pre-existing StyleCop / xUnit-analyzer warnings (none net-new in the scope of this change).
- [ ] CI green on this branch.
