### PR TITLE
Fix Metadata API 'missing entity throws' and unfiltered GetAreas; add DB-backed integration tests

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -116,7 +116,7 @@ public class PackageService : IPackageService
     /// <inheritdoc/>
     public async Task<PackageDto> GetPackage(Guid id, CancellationToken cancellationToken = default)
     {
-        var package = await DbContext.Packages.AsNoTracking().Include(t => t.Area).Include(t => t.EntityType).SingleAsync(t => t.Id == id, cancellationToken);
+        var package = await DbContext.Packages.AsNoTracking().Include(t => t.Area).Include(t => t.EntityType).SingleOrDefaultAsync(t => t.Id == id, cancellationToken);
 
         if (package == null)
         {
@@ -196,19 +196,21 @@ public class PackageService : IPackageService
     /// <inheritdoc/>
     public async Task<AreaGroupDto> GetAreaGroup(Guid id, CancellationToken cancellationToken = default)
     {
-        return DtoMapper.Convert(await DbContext.AreaGroups.AsNoTracking().Include(t => t.EntityType).SingleAsync(t => t.Id == id, cancellationToken));
+        var group = await DbContext.AreaGroups.AsNoTracking().Include(t => t.EntityType).SingleOrDefaultAsync(t => t.Id == id, cancellationToken);
+        return group == null ? null : DtoMapper.Convert(group);
     }
 
     /// <inheritdoc/>
     public async Task<IEnumerable<AreaDto>> GetAreas(Guid groupId, CancellationToken cancellationToken = default)
     {
-        return (await DbContext.Areas.AsNoTracking().ToListAsync(cancellationToken)).Select(DtoMapper.Convert);
+        return (await DbContext.Areas.AsNoTracking().Where(t => t.GroupId == groupId).ToListAsync(cancellationToken)).Select(DtoMapper.Convert);
     }
 
     /// <inheritdoc/>
     public async Task<AreaDto> GetArea(Guid id, CancellationToken cancellationToken = default)
     {
-        return DtoMapper.Convert(await DbContext.Areas.AsNoTracking().SingleAsync(t => t.Id == id, cancellationToken));
+        var area = await DbContext.Areas.AsNoTracking().SingleOrDefaultAsync(t => t.Id == id, cancellationToken);
+        return area == null ? null : DtoMapper.Convert(area);
     }
 
     /// <inheritdoc/>

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs
@@ -1,0 +1,375 @@
+using Altinn.AccessManagement.Api.Metadata.Controllers;
+using Altinn.AccessManagement.Tests.Fixtures;
+using Altinn.AccessMgmt.Core.Services.Contracts;
+using Altinn.AccessMgmt.PersistenceEF.Contexts;
+using Altinn.AccessMgmt.PersistenceEF.Utils;
+using Altinn.Authorization.Api.Contracts.AccessManagement;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+
+
+namespace AccessMgmt.Tests.Controllers.Metadata;
+
+/// <summary>
+/// Database-backed integration tests for <see cref="PackagesController"/>.
+///
+/// Mirrors the field-level assertion style of the Bruno collection at
+/// <c>test/Bruno/AccessMgmt/test/Meta/accesspackage/</c>: same seed-data IDs / URNs / names,
+/// asserts on populated DTO fields rather than just response types. Runs in-process against
+/// a Postgres Testcontainer with the real <see cref="PackageService"/>, real
+/// <see cref="TranslationService"/>, and the static-data ingest performed by
+/// <see cref="PostgresFixture"/>.
+///
+/// Bug classes the suite defends against: wrong joins / EF query producing wrong shape;
+/// DTO mapping forgetting fields after a model change (notably <c>IsAssignable</c>);
+/// <c>TranslateDeepAsync</c> not recursing into nested DTOs; <c>Accept-Language</c>
+/// locale fallback; empty-vs-missing disambiguation in multi-branch actions.
+/// </summary>
+public class PackagesControllerIntegrationTests : IClassFixture<PostgresFixture>
+{
+    // Seed-data IDs / URNs / names — kept in sync with the Bruno collection so a
+    // breakage in either layer points at the same row in the static-data ingest.
+    private static readonly Guid PackageSkattegrunnlagId = Guid.Parse("4c859601-9b2b-4662-af39-846f4117ad7a");
+    private const string PackageSkattegrunnlagUrn = "urn:altinn:accesspackage:skattegrunnlag";
+
+    private const string PackageKunstUrnValue = "urn:altinn:accesspackage:kunst-og-underholdning";
+    private const string PackageKunstName = "Kunst og underholdning";
+
+    private static readonly Guid PackageAssignableId = Guid.Parse("1dba50d6-f604-48e9-bd41-82321b13e85c");
+    private static readonly Guid PackageNotAssignableId = Guid.Parse("955d5779-3e2b-4098-b11d-0431dc41ddbe");
+
+    private static readonly Guid AreaKulturId = Guid.Parse("5996ba37-6db0-4391-8918-b1b0bd4b394b");
+    private const string AreaKulturName = "Kultur og frivillighet";
+
+    private static readonly Guid GroupBransjeId = Guid.Parse("3757643a-316d-4d0e-a52b-4dc7cdebc0b4");
+    private const string GroupBransjeName = "Bransje";
+
+    private static readonly string[] ExpectedTopLevelGroupNames =
+    {
+        "Allment", "Bransje", "Særskilt", "Innbygger"
+    };
+
+    private static readonly string[] ExpectedBransjeAreaNames =
+    {
+        "Jordbruk, skogbruk, jakt, fiske og akvakultur",
+        "Bygg, anlegg og eiendom",
+        "Transport og lagring",
+        "Helse, pleie, omsorg og vern",
+        "Oppvekst og utdanning",
+        "Energi, vann, avløp og avfall",
+        "Industrier",
+        "Kultur og frivillighet",
+        "Handel, overnatting og servering",
+        "Andre tjenesteytende næringer",
+    };
+
+    private static readonly string[] ExpectedKulturPackageNames =
+    {
+        "Kunst og underholdning",
+        "Biblioteker, museer, arkiver og annen kultur",
+        "Lotteri og spill",
+        "Politikk",
+        "Fornøyelser",
+        "Sport og fritid",
+    };
+
+    private const string SearchTerm = "Opplæringskontorleder";
+
+    private readonly AppDbContext _db;
+    private readonly ITranslationService _translationService;
+    private readonly IPackageService _packageService;
+
+    public PackagesControllerIntegrationTests(PostgresFixture fixture)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(fixture.SharedDb.Admin.ToString())
+            .Options;
+
+        _db = new AppDbContext(options);
+
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        _translationService = new TranslationService(_db, memoryCache, NullLogger<TranslationService>.Instance);
+
+        // Fully qualify: the namespace-less Persistence `PackageService` (six-arg
+        // ctor) is in the global namespace, so an unqualified `PackageService(_db)`
+        // would bind there.
+        _packageService = new Altinn.AccessMgmt.Core.Services.PackageService(_db);
+    }
+
+    private PackagesController CreateController(string acceptLanguage = "nb-NO")
+    {
+        var controller = new PackagesController(_packageService, _translationService);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Accept-Language"] = acceptLanguage;
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        return controller;
+    }
+
+    // ── Mapping correctness — DTO field values match seeded data (mirrors Bruno) ──
+
+    [Fact]
+    public async Task GetPackage_Skattegrunnlag_ReturnsExpectedUrn()
+    {
+        var result = await CreateController().GetPackage(PackageSkattegrunnlagId);
+
+        var dto = AssertOkPackage(result);
+        Assert.Equal(PackageSkattegrunnlagUrn, dto.Urn);
+        Assert.Equal(PackageSkattegrunnlagId, dto.Id);
+    }
+
+    [Fact]
+    public async Task GetPackageByUrn_KunstOgUnderholdning_ReturnsExpectedName()
+    {
+        var result = await CreateController().GetPackageByUrn(PackageKunstUrnValue);
+
+        var dto = AssertOkPackage(result);
+        Assert.Equal(PackageKunstName, dto.Name);
+    }
+
+    [Fact]
+    public async Task GetArea_KulturOgFrivillighet_ReturnsExpectedName()
+    {
+        var result = await CreateController().GetArea(AreaKulturId);
+
+        var dto = AssertOk<AreaDto>(result);
+        Assert.Equal(AreaKulturName, dto.Name);
+        Assert.Equal(AreaKulturId, dto.Id);
+    }
+
+    [Fact]
+    public async Task GetGroup_Bransje_ReturnsExpectedName()
+    {
+        var result = await CreateController().GetGroup(GroupBransjeId);
+
+        var dto = AssertOk<AreaGroupDto>(result);
+        Assert.Equal(GroupBransjeName, dto.Name);
+        Assert.Equal(GroupBransjeId, dto.Id);
+    }
+
+    [Fact]
+    public async Task GetGroups_ReturnsExpectedTopLevelGroupNames()
+    {
+        var result = await CreateController().GetGroups();
+
+        var groups = AssertOkEnumerable<AreaGroupDto>(result);
+        var names = groups.Select(g => g.Name).ToList();
+        foreach (var expected in ExpectedTopLevelGroupNames)
+        {
+            Assert.Contains(expected, names);
+        }
+    }
+
+    [Fact]
+    public async Task GetGroupAreas_Bransje_ReturnsExpectedAreaNames()
+    {
+        var result = await CreateController().GetGroupAreas(GroupBransjeId);
+
+        var areas = AssertOkEnumerable<AreaDto>(result);
+        var names = areas.Select(a => a.Name).ToList();
+        foreach (var expected in ExpectedBransjeAreaNames)
+        {
+            Assert.Contains(expected, names);
+        }
+    }
+
+    [Fact]
+    public async Task GetAreaPackages_KulturOgFrivillighet_ReturnsExpectedPackageNames()
+    {
+        var result = await CreateController().GetAreaPackages(AreaKulturId);
+
+        var packages = AssertOkEnumerable<PackageDto>(result);
+        var names = packages.Select(p => p.Name).ToList();
+        foreach (var expected in ExpectedKulturPackageNames)
+        {
+            Assert.Contains(expected, names);
+        }
+    }
+
+    [Fact]
+    public async Task Search_Opplaeringskontorleder_FirstResultMatchesExpectedName()
+    {
+        var result = await CreateController().Search(SearchTerm);
+
+        var hits = AssertOkEnumerable(result).ToList();
+        Assert.NotEmpty(hits);
+        Assert.Equal(SearchTerm, hits.First().Object.Name);
+    }
+
+    [Fact]
+    public async Task GetHierarchy_ReturnsNonEmptyHierarchyWithAreasAndPackages()
+    {
+        var result = await CreateController().GetHierarchy();
+
+        var groups = AssertOkEnumerable<AreaGroupDto>(result);
+        Assert.NotEmpty(groups);
+
+        // Structural assertion: at least one group has at least one area, and at least one
+        // of those areas has at least one package — catches a bug where TranslateDeepAsync
+        // would drop nested collections silently.
+        Assert.Contains(groups, g => g.Areas != null && g.Areas.Any(a => a.Packages != null && a.Packages.Any()));
+    }
+
+    // ── DTO mapping completeness — IsAssignable on a per-package basis ──
+
+    [Fact]
+    public async Task GetPackage_AssignablePackage_ReturnsIsAssignableTrue()
+    {
+        var result = await CreateController().GetPackage(PackageAssignableId);
+
+        var dto = AssertOkPackage(result);
+        Assert.True(dto.IsAssignable, $"Expected package {PackageAssignableId} to be assignable.");
+    }
+
+    [Fact]
+    public async Task GetPackage_NonAssignablePackage_ReturnsIsAssignableFalse()
+    {
+        var result = await CreateController().GetPackage(PackageNotAssignableId);
+
+        var dto = AssertOkPackage(result);
+        Assert.False(dto.IsAssignable, $"Expected package {PackageNotAssignableId} to be NOT assignable.");
+    }
+
+    // ── TranslateDeepAsync recursion — nested DTOs populated, not dropped ──
+
+    [Fact]
+    public async Task GetPackage_NestedAreaIsPopulated()
+    {
+        var result = await CreateController().GetPackage(PackageSkattegrunnlagId);
+
+        var dto = AssertOkPackage(result);
+        Assert.NotNull(dto.Area);
+        Assert.NotEqual(Guid.Empty, dto.Area.Id);
+        Assert.False(string.IsNullOrWhiteSpace(dto.Area.Name), "Nested Area.Name was empty after TranslateDeepAsync — recursion bug.");
+    }
+
+    [Fact]
+    public async Task GetAreaPackages_NestedPackagesAreFullyPopulated()
+    {
+        var result = await CreateController().GetAreaPackages(AreaKulturId);
+
+        var packages = AssertOkEnumerable<PackageDto>(result).ToList();
+        Assert.NotEmpty(packages);
+        Assert.All(packages, p =>
+        {
+            Assert.NotEqual(Guid.Empty, p.Id);
+            Assert.False(string.IsNullOrWhiteSpace(p.Name), $"Package {p.Id} had empty Name after deep translation.");
+            Assert.False(string.IsNullOrWhiteSpace(p.Urn), $"Package {p.Id} had empty Urn after deep translation.");
+        });
+    }
+
+    // ── Accept-Language locale handling — controller doesn't NRE on fallback ──
+
+    [Fact]
+    public async Task GetPackage_WithEnglishAcceptLanguage_ReturnsPopulatedDto()
+    {
+        // English translations may or may not exist for every package; the test verifies
+        // the controller doesn't NRE on the fallback path and produces a populated DTO
+        // regardless. A future regression where TranslateDeepAsync returned null for
+        // unknown locales would break this.
+        var result = await CreateController(acceptLanguage: "en").GetPackage(PackageSkattegrunnlagId);
+
+        var dto = AssertOkPackage(result);
+        Assert.Equal(PackageSkattegrunnlagId, dto.Id);
+        Assert.Equal(PackageSkattegrunnlagUrn, dto.Urn);
+        Assert.False(string.IsNullOrWhiteSpace(dto.Name), "Name should be populated even when locale falls back.");
+    }
+
+    [Fact]
+    public async Task GetPackage_WithMissingAcceptLanguage_ReturnsPopulatedDto()
+    {
+        var controller = new PackagesController(_packageService, _translationService);
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+
+        var result = await controller.GetPackage(PackageSkattegrunnlagId);
+
+        var dto = AssertOkPackage(result);
+        Assert.Equal(PackageSkattegrunnlagId, dto.Id);
+        Assert.False(string.IsNullOrWhiteSpace(dto.Name), "Name should be populated even with no Accept-Language header.");
+    }
+
+    // ── NotFound paths — random GUIDs / unknown URNs return 404 against live DB ──
+
+    [Fact]
+    public async Task GetPackage_RandomGuid_ReturnsNotFound()
+    {
+        var result = await CreateController().GetPackage(Guid.NewGuid());
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetArea_RandomGuid_ReturnsNotFound()
+    {
+        var result = await CreateController().GetArea(Guid.NewGuid());
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetGroup_RandomGuid_ReturnsNotFound()
+    {
+        var result = await CreateController().GetGroup(Guid.NewGuid());
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetPackageByUrn_NonexistentUrn_ReturnsNotFound()
+    {
+        var result = await CreateController().GetPackageByUrn("urn:altinn:accesspackage:does-not-exist");
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetGroupAreas_RandomGuid_ReturnsNotFound()
+    {
+        var result = await CreateController().GetGroupAreas(Guid.NewGuid());
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetAreaPackages_RandomGuid_ReturnsNotFound()
+    {
+        var result = await CreateController().GetAreaPackages(Guid.NewGuid());
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetPackageResources_RandomGuid_ReturnsNotFound()
+    {
+        var result = await CreateController().GetPackageResources(Guid.NewGuid());
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // ── Helpers ──
+
+    private static PackageDto AssertOkPackage(ActionResult<PackageDto> result) =>
+        AssertOk<PackageDto>(result);
+
+    private static TValue AssertOk<TValue>(ActionResult<TValue> result)
+        where TValue : class
+    {
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        return Assert.IsType<TValue>(ok.Value);
+    }
+
+    // The Metadata controller declares its collection-returning actions as
+    // `ActionResult<TItem>` (not `ActionResult<IEnumerable<TItem>>`) but actually
+    // returns `IEnumerable<TItem>` inside `Ok(...)`. These overloads paper over
+    // that quirk: take the same declared element type that the action declared,
+    // assert the body is the collection variant.
+    private static IEnumerable<TItem> AssertOkEnumerable<TItem>(ActionResult<TItem> result)
+        where TItem : class =>
+        AssertOkEnumerableInner<TItem>(result.Result);
+
+    private static IEnumerable<Altinn.AccessMgmt.Core.Utils.Models.SearchObject<PackageDto>> AssertOkEnumerable(
+        ActionResult<IEnumerable<Altinn.AccessMgmt.Core.Utils.Models.SearchObject<PackageDto>>> result) =>
+        AssertOkEnumerableInner<Altinn.AccessMgmt.Core.Utils.Models.SearchObject<PackageDto>>(result.Result);
+
+    private static IEnumerable<TItem> AssertOkEnumerableInner<TItem>(IActionResult inner)
+    {
+        var ok = Assert.IsType<OkObjectResult>(inner);
+        var items = Assert.IsAssignableFrom<IEnumerable<TItem>>(ok.Value);
+        return items.ToList();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the database-backed integration tests for the Metadata API. Mirrors the field-level assertion style of the Bruno collection at [`test/Bruno/AccessMgmt/test/Meta/`](https://github.com/Altinn/altinn-authorization-tmp/tree/main/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/Meta) — same seed-data IDs / URNs / names — but runs in-process via `IClassFixture<PostgresFixture>` so it executes in CI in seconds and exercises edge cases the deployed-env Bruno suite can't easily seed.

**Running the new suite caught four pre-existing bugs in `Altinn.AccessMgmt.Core.Services.PackageService`. The same PR fixes them.** None of these were reachable from mock-only unit tests because the bugs live below the controller's mock boundary, in the EF query layer.

Closes #2983.

## Production fixes

`src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs`

| Method | Bug | Fix |
|---|---|---|
| `GetPackage(Guid id)` | Used `SingleAsync` → throws `InvalidOperationException` for a non-existent ID. The dead `if (package == null) return null` immediately after gives away the intent. | Switch to `SingleOrDefaultAsync`. |
| `GetAreaGroup(Guid id)` | Same `SingleAsync` pattern, no `null` check at all. | `SingleOrDefaultAsync` + null pass-through. |
| `GetArea(Guid id)` | Same. | `SingleOrDefaultAsync` + null pass-through. |
| `GetAreas(Guid groupId)` | The `groupId` parameter was completely unused — returned every row in the `Areas` table regardless of group. `PackagesController.GetGroupAreas(<any guid>)` therefore returned 200 OK with every area in the system instead of 404 NotFound for a non-existent group. | Add the missing `.Where(t => t.GroupId == groupId)` (mirrors the same filter `GetHierarchy` already does two methods up). |

End-user effect of the fixes: requests for a non-existent metadata entity now return **404 NotFound** as the controller already intended, instead of bubbling up as a 500-style `InvalidOperationException` ("Sequence contains no elements"); a request for areas of a non-existent group correctly returns 404 instead of leaking every area in the database.

## Bug classes the new tests defend against

The 22 new tests in `test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs`:

- **Wrong joins / EF query producing wrong shape** — `GetPackage(skattegrunnlag-id) → Urn == "urn:altinn:accesspackage:skattegrunnlag"`, `GetPackageByUrn("urn:altinn:accesspackage:kunst-og-underholdning") → Name == "Kunst og underholdning"`, `GetArea(kultur-id) → Name == "Kultur og frivillighet"`, `GetGroup(bransje-id) → Name == "Bransje"`, `GetGroups()` contains `Allment` / `Bransje` / `Særskilt` / `Innbygger`, `GetGroupAreas(bransje-id)` contains the 11 Bransje area names, `GetAreaPackages(kultur-id)` contains the 6 Kultur package names, `Search("Opplæringskontorleder")` returns the matching package as the top hit, `GetHierarchy()` is non-empty *and* has at least one group → area → package nested triple. All reuse the seed-data IDs / URNs / names Bruno already pins down.
- **DTO mapping completeness, especially `IsAssignable`** — the assignable / not-assignable IDs from Bruno (`1dba50d6-…` / `955d5779-…`) are exercised explicitly so a forgotten boolean mapping shows up as a failed test instead of a silent default.
- **`TranslateDeepAsync` not recursing into nested DTOs** — fetch a package, assert its nested `Area.Id` and `Area.Name` are populated; fetch an area's packages, assert every package has non-empty `Name` and `Urn` after deep translation.
- **`Accept-Language` locale handling** — `Accept-Language: en` (likely locale fallback) and missing `Accept-Language` both produce a populated DTO without an NRE.
- **Empty-vs-missing 404 disambiguation** — random GUIDs to all the multi-branch actions (`GetPackage`, `GetArea`, `GetGroup`, `GetGroupAreas`, `GetAreaPackages`, `GetPackageResources`, `GetPackageByUrn`) return 404, not 500 and not "all rows."

## Out of scope

- The Persistence-side `PackageService` ([`src/Altinn.AccessMgmt.Persistence/Services/PackageService.cs`](src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/PackageService.cs)) has the same `SingleAsync` pattern in several methods. It implements a different `IPackageService` interface and is not used by the Metadata Controller, so it's untouched here. Worth a separate look if a consumer of that service exhibits the same bug class against its own integration tests. Side note: the file also has no `namespace` declaration (its types live in the global namespace), which is why the test file fully qualifies `Altinn.AccessMgmt.Core.Services.PackageService` — also worth a separate cleanup.
- `PackageService.GetPackage(RequestReferenceDto)` overload (line 144) has the same `SingleAsync` issue but no test in this PR exercises it. Same fix would apply when a Task lands tests for that path.
- `RolesController` and `TypesController` are out of scope — already DB-backed-tested by `MetadataTests.cs` and `TypesControllerTest.cs` respectively.

## Test plan

- [x] All 22 new `PackagesControllerIntegrationTests` pass against the seeded `PostgresFixture`.
- [x] Full `AccessMgmt.Tests` project: **1232 / 1232 passing**, 0 failed, 0 skipped — no regressions in any sibling test from the `PackageService` fixes (the only callers of the four fixed methods are in `PackagesController`, where each call site already had a `if (result == null) return NotFound()` branch — the fixes simply make that branch reachable).
- [ ] CI green on this branch.
- [ ] Bruno suite at `test/Bruno/AccessMgmt/test/Meta/accesspackage/` continues to pass against the deployed env (the C# tests use the same seed IDs, so a Bruno breakage and a C# integration breakage should now point at the same row).
