### PR TITLE
ci: fix Report-failed-tests step finding no MTP logs after --results-directory was added

### DIFF
--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -207,11 +207,18 @@ jobs:
         shell: pwsh
         working-directory: ${{ inputs.path }}
         run: |
+          # The Test step passes `--results-directory TestResults/` to MTP,
+          # so the per-project logs land in `<vertical>/TestResults/` (and,
+          # for some configurations, in the per-project `bin/.../TestResults/`).
+          # Match either layout — the `Directory.Name -eq 'TestResults'`
+          # filter still keeps us off arbitrary `*.log` files elsewhere in
+          # the working tree, while the `*_net9.0_x64.log` filename pattern
+          # already constrains to MTP-shaped per-project logs.
           $logs = Get-ChildItem -Path . -Recurse -Filter '*_net9.0_x64.log' -ErrorAction SilentlyContinue |
-                  Where-Object { $_.FullName -match [regex]::Escape([IO.Path]::Combine('bin','Release','net9.0','TestResults')) }
+                  Where-Object { $_.Directory.Name -eq 'TestResults' }
 
           if (-not $logs) {
-              Write-Host "No MTP per-project logs found under bin/Release/net9.0/TestResults/." -ForegroundColor Yellow
+              Write-Host "No MTP per-project logs found in any TestResults/ directory under $(Get-Location)." -ForegroundColor Yellow
               exit 0
           }
 


### PR DESCRIPTION
## Summary

Fixes the `Report failed tests` CI step ([`tpl-vertical-ci.yml:196`](https://github.com/Altinn/altinn-authorization-tmp/blob/main/.github/workflows/tpl-vertical-ci.yml#L196)) which currently logs `No MTP per-project logs found under bin/Release/net9.0/TestResults/.` and exits early on every failure run, instead of doing what it's supposed to do — surface failing test names + assertion context directly in the workflow log so reviewers don't have to download the artifact.

## Root cause

The Test step passes `--results-directory TestResults/` to MTP. With that flag, per-project `<Project>_<tfm>_<arch>.log` files land in `<vertical>/TestResults/` (i.e. relative to the vertical root), not under the per-project `bin/Release/net9.0/TestResults/`. The Report step's `Where-Object` filter still pinned to the old path, so `Get-ChildItem` was finding the logs but the filter was discarding them all.

The artifact-upload step ([`:331`](https://github.com/Altinn/altinn-authorization-tmp/blob/main/.github/workflows/tpl-vertical-ci.yml#L331)) uses the broader glob `${{ inputs.path }}/**/TestResults/*.log` and continues to upload the logs as artifacts — confirming the logs do exist on disk; the report step was just looking in the wrong subtree.

## Fix

Replace the path-pinning filter with `Directory.Name -eq 'TestResults'`. The filename pattern (`*_net9.0_x64.log`) already constrains to MTP-shaped per-project logs, so the looser parent-dir filter still keeps us off arbitrary `*.log` files elsewhere in the working tree. Updates the empty-result warning to reflect the new search location.

No change to the failure-line parsing / context extraction / `::error::` annotation emission below — that logic is correct and already works against the format MTP currently writes.

Closes #2986.

## Test plan

- [x] Diff is one workflow file, two-line filter change + an updated comment.
- [x] Filename pattern `*_net9.0_x64.log` is unchanged, so MTP-format constraint stands.
- [ ] CI green on this branch.
- [ ] On the next intentional test failure (e.g. a regression PR), the `Report failed tests` step prints the per-test failure block instead of the "No MTP logs found" warning.
