### PR TITLE
New SimpleSearch for metadata packages

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
@@ -36,10 +36,11 @@ public class PackagesController : ControllerBase
     /// <param name="resourceProviderCode">Tjenesteeier OrgCode (DIGDIR, KRT, NAV, SKATT)</param>   
     /// <param name="searchInResources">Søk i ressurs verdier</param>
     /// <param name="typeName">Package for type (e.g. Organization, Person)</param>
+    /// <param name="simpleSearch">Use new simple search</param>
     /// <returns>Liste over søkeresultater.</returns>
     [Route("search")]
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<SearchObject<PackageDto>>>> Search([FromQuery] string term, [FromQuery] List<string> resourceProviderCode = null, [FromQuery] bool searchInResources = false, [FromQuery] string? typeName = null)
+    public async Task<ActionResult<IEnumerable<SearchObject<PackageDto>>>> Search([FromQuery] string term, [FromQuery] List<string> resourceProviderCode = null, [FromQuery] bool searchInResources = false, [FromQuery] string? typeName = null, [FromQuery] bool simpleSearch = true)
     {
         Guid? typeId = null;
         if (!string.IsNullOrEmpty(typeName))
@@ -52,7 +53,7 @@ public class PackagesController : ControllerBase
             typeId = type.Id;
         }
 
-        var res = await packageService.Search(term, resourceProviderCode, searchInResources, typeId);
+        var res = await packageService.Search(term, resourceProviderCode, searchInResources, typeId, simpleSearch);
         if (res == null || !res.Any())
         {
             return NoContent();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
@@ -53,7 +53,10 @@ public class PackagesController : ControllerBase
             typeId = type.Id;
         }
 
-        var res = await packageService.Search(term, resourceProviderCode, searchInResources, typeId, simpleSearch);
+        var res = simpleSearch
+            ? await packageService.SimpleSearch(term, resourceProviderCode, searchInResources, typeId)
+            : await packageService.FuzzySearch(term, resourceProviderCode, searchInResources, typeId);
+
         if (res == null || !res.Any())
         {
             return NoContent();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
@@ -54,32 +54,29 @@ public class PackagesController : ControllerBase
         }
 
         var res = simpleSearch
-            ? await packageService.SimpleSearch(term, resourceProviderCode, searchInResources, typeId)
-            : await packageService.FuzzySearch(term, resourceProviderCode, searchInResources, typeId);
+            ? await packageService.SimpleSearch(
+                term: term, 
+                resourceProviderCodes: resourceProviderCode, 
+                searchInResources: searchInResources, 
+                typeId: typeId, 
+                languageCode: this.GetLanguageCode(), 
+                allowPartialTranslation: this.AllowPartialTranslation()
+                )
+            : await packageService.FuzzySearch(
+                term: term,
+                resourceProviderCodes: resourceProviderCode,
+                searchInResources: searchInResources,
+                typeId: typeId,
+                languageCode: this.GetLanguageCode(),
+                allowPartialTranslation: this.AllowPartialTranslation()
+                );
 
         if (res == null || !res.Any())
         {
             return NoContent();
         }
 
-        // Translate each search result with deep translation for nested objects
-        var translatedResults = new List<SearchObject<PackageDto>>();
-        foreach (var searchResult in res)
-        {
-            var translatedDto = await searchResult.Object.TranslateDeepAsync(
-                translationService,
-                this.GetLanguageCode(),
-                this.AllowPartialTranslation());
-            
-            translatedResults.Add(new SearchObject<PackageDto> 
-            { 
-                Object = translatedDto,
-                Score = searchResult.Score,
-                Fields = searchResult.Fields
-            });
-        }
-
-        return Ok(translatedResults);
+        return Ok(res);
     }
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
@@ -18,10 +18,20 @@ public interface IPackageService
     /// <param name="resourceProviderCodes">Resource.Provider.Code (brreg, digdir, skatt)</param>
     /// <param name="searchInResources">Indicate if term should filter on resource values</param>
     /// <param name="typeId">Filter for entityType</param>
-    /// <param name="useSimpleSearch">Use new simple search</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>A list of search results containing packages that match the term.</returns>
-    Task<IEnumerable<SearchObject<PackageDto>>> Search(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, bool useSimpleSearch = true, CancellationToken cancellationToken = default);
+    Task<IEnumerable<SearchObject<PackageDto>>> FuzzySearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Searches for packages based on a search term.
+    /// </summary>
+    /// <param name="term">The search term to filter packages.</param>
+    /// <param name="resourceProviderCodes">Resource.Provider.Code (brreg, digdir, skatt)</param>
+    /// <param name="searchInResources">Indicate if term should filter on resource values</param>
+    /// <param name="typeId">Filter for entityType</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns>A list of search results containing packages that match the term.</returns>
+    Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the hierarchical structure of area groups.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
@@ -18,9 +18,10 @@ public interface IPackageService
     /// <param name="resourceProviderCodes">Resource.Provider.Code (brreg, digdir, skatt)</param>
     /// <param name="searchInResources">Indicate if term should filter on resource values</param>
     /// <param name="typeId">Filter for entityType</param>
+    /// <param name="useSimpleSearch">Use new simple search</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>A list of search results containing packages that match the term.</returns>
-    Task<IEnumerable<SearchObject<PackageDto>>> Search(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, CancellationToken cancellationToken = default);
+    Task<IEnumerable<SearchObject<PackageDto>>> Search(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, bool useSimpleSearch = true, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the hierarchical structure of area groups.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
@@ -18,9 +18,11 @@ public interface IPackageService
     /// <param name="resourceProviderCodes">Resource.Provider.Code (brreg, digdir, skatt)</param>
     /// <param name="searchInResources">Indicate if term should filter on resource values</param>
     /// <param name="typeId">Filter for entityType</param>
+    /// <param name="languageCode">Languagecode</param>
+    /// <param name="allowPartialTranslation">Allow partial translation</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>A list of search results containing packages that match the term.</returns>
-    Task<IEnumerable<SearchObject<PackageDto>>> FuzzySearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, CancellationToken cancellationToken = default);
+    Task<IEnumerable<SearchObject<PackageDto>>> FuzzySearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Searches for packages based on a search term.
@@ -29,9 +31,11 @@ public interface IPackageService
     /// <param name="resourceProviderCodes">Resource.Provider.Code (brreg, digdir, skatt)</param>
     /// <param name="searchInResources">Indicate if term should filter on resource values</param>
     /// <param name="typeId">Filter for entityType</param>
+    /// <param name="languageCode">Languagecode</param>
+    /// <param name="allowPartialTranslation">Allow partial translation</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>A list of search results containing packages that match the term.</returns>
-    Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, CancellationToken cancellationToken = default);
+    Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the hierarchical structure of area groups.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -75,13 +75,8 @@ public class PackageService : IPackageService
     }
 
     /// <inheritdoc/>
-    public async Task<IEnumerable<SearchObject<PackageDto>>> Search(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, bool useSimpleSearch = true, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<SearchObject<PackageDto>>> FuzzySearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, CancellationToken cancellationToken = default)
     {
-        if (useSimpleSearch)
-        {
-            return await SimpleSearch(term, resourceProviderCodes, searchInResources, typeId, cancellationToken);
-        }
-
         var data = await GetSearchData(resourceProviderCodes: resourceProviderCodes, typeId: typeId);
 
         if (string.IsNullOrEmpty(term))
@@ -104,7 +99,7 @@ public class PackageService : IPackageService
                 ////.AddCollection(pkg => pkg.Resources, r => r.Description, 0.7, FuzzynessLevel.Low, detailed);
         }
 
-        var results = FuzzySearch.PerformFuzzySearch(data, term, builder);
+        var results = Utils.FuzzySearch.PerformFuzzySearch(data, term, builder);
 
         foreach (var res in results.OrderByDescending(t => t.Score))
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -25,64 +25,89 @@ public class PackageService : IPackageService
         TranslationService = translationService;
     }
 
-    public async Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default)
+    private const StringComparison Ic = StringComparison.InvariantCultureIgnoreCase;
+
+    private record ScoringRule(
+        string FieldName,
+        Func<PackageDto, string> Field,
+        Func<string, string, bool> Match,
+        int Points);
+
+    private static readonly ScoringRule[] PackageRules =
+    [
+        new("name.prefix",      p => p.Name,             (f, t) => f.StartsWith(t, Ic), 100),
+        new("name",             p => p.Name,             (f, t) => f.Contains(t, Ic),    50),
+        new("description",      p => p.Description,      (f, t) => f.Contains(t, Ic),    10),
+        new("area.name.prefix", p => p.Area.Name,        (f, t) => f.StartsWith(t, Ic),  25),
+        new("area.description", p => p.Area.Description, (f, t) => f.Contains(t, Ic),     5),
+    ];
+
+    private static SearchObject<PackageDto> ScorePackage(
+    PackageDto package,
+    string term,
+    bool searchInResources)
     {
-        var data = await GetSearchData(resourceProviderCodes: resourceProviderCodes, typeId: typeId, languageCode: languageCode, allowPartialTranslation: allowPartialTranslation);
-        var scoredData = new List<SearchObject<PackageDto>>();
+        var totalScore = 0;
+        var fields = new List<SearchField>();
 
-        foreach (var package in data)
+        foreach (var rule in PackageRules)
         {
-            var scoredPackage = new SearchObject<PackageDto>() { Object = package, Score = 0, Fields = [] };
-
-            if (package.Name.StartsWith(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
+            var value = rule.Field(package);
+            if (rule.Match(value, term))
             {
-                scoredPackage.Score += 100;
-            }
-
-            if (package.Name.Contains(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
-            {
-                scoredPackage.Score += 50;
-            }
-
-            if (package.Description.Contains(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
-            {
-                scoredPackage.Score += 10;
-            }
-
-            if (package.Area.Name.StartsWith(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
-            {
-                scoredPackage.Score += 25;
-            }
-
-            if (package.Area.Description.Contains(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
-            {
-                scoredPackage.Score += 5;
-            }
-
-            if (searchInResources)
-            {
-                foreach (var resource in package.Resources)
+                totalScore += rule.Points;
+                fields.Add(new SearchField
                 {
-                    if (resource.Name.Contains(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        scoredPackage.Score += 2;
-                    }
-                }
-            }
-
-            if (scoredPackage.Score > 0)
-            {
-                scoredData.Add(scoredPackage);
+                    Field = rule.FieldName,
+                    Value = value,
+                    Score = rule.Points,
+                });
             }
         }
 
-        return scoredData.OrderByDescending(t => t.Score).ToList();
+        if (searchInResources)
+        {
+            foreach (var resource in package.Resources.Where(t => t.Name.Contains(term, Ic)))
+            {                
+                totalScore += 2;
+                fields.Add(new SearchField
+                {
+                    Field = "resources.name",
+                    Value = resource.Name,
+                    Score = 2,
+                });   
+            }
+        }
+
+        return new SearchObject<PackageDto>
+        {
+            Object = package,
+            Score = totalScore,
+            Fields = fields,
+        };
+    }
+
+    public async Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default)
+    {
+        var data = await GetSearchData(
+        resourceProviderCodes: resourceProviderCodes,
+        typeId: typeId,
+        languageCode: languageCode,
+        allowPartialTranslation: allowPartialTranslation,
+        cancellationToken: cancellationToken
+        );
+
+        return data
+            .Select(p => ScorePackage(p, term, searchInResources))
+            .Where(s => s.Score > 0)
+            .OrderByDescending(s => s.Score)
+            .ToList();
     }
 
     /// <inheritdoc/>
     public async Task<IEnumerable<SearchObject<PackageDto>>> FuzzySearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default)
     {
-        var data = await GetSearchData(resourceProviderCodes: resourceProviderCodes, typeId: typeId, languageCode: languageCode, allowPartialTranslation: allowPartialTranslation);
+        var data = await GetSearchData(resourceProviderCodes: resourceProviderCodes, typeId: typeId, languageCode: languageCode, allowPartialTranslation: allowPartialTranslation, cancellationToken: cancellationToken);
 
         if (string.IsNullOrEmpty(term))
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -20,9 +20,68 @@ public class PackageService : IPackageService
         DbContext = appDbContext;
     }
 
-    /// <inheritdoc/>
-    public async Task<IEnumerable<SearchObject<PackageDto>>> Search(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, CancellationToken cancellationToken = default)
     {
+        var data = await GetSearchData(resourceProviderCodes: resourceProviderCodes, typeId: typeId);
+        var scoredData = new List<SearchObject<PackageDto>>();
+
+        foreach (var package in data)
+        {
+            var scoredPackage = new SearchObject<PackageDto>() { Object = package, Score = 0, Fields = [] };
+
+            if (package.Name.StartsWith(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
+            {
+                scoredPackage.Score += 100;
+            }
+
+            if (package.Name.Contains(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
+            {
+                scoredPackage.Score += 50;
+            }
+
+            if (package.Description.Contains(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
+            {
+                scoredPackage.Score += 10;
+            }
+
+            if (package.Area.Name.StartsWith(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
+            {
+                scoredPackage.Score += 25;
+            }
+
+            if (package.Area.Description.Contains(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
+            {
+                scoredPackage.Score += 5;
+            }
+
+            if (searchInResources)
+            {
+                foreach (var resource in package.Resources)
+                {
+                    if (resource.Name.Contains(term, comparisonType: StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        scoredPackage.Score += 2;
+                    }
+                }
+            }
+
+            if (scoredPackage.Score > 0)
+            {
+                scoredData.Add(scoredPackage);
+            }
+        }
+
+        return scoredData.OrderByDescending(t => t.Score).ToList();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<SearchObject<PackageDto>>> Search(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, bool useSimpleSearch = true, CancellationToken cancellationToken = default)
+    {
+        if (useSimpleSearch)
+        {
+            return await SimpleSearch(term, resourceProviderCodes, searchInResources, typeId, cancellationToken);
+        }
+
         var data = await GetSearchData(resourceProviderCodes: resourceProviderCodes, typeId: typeId);
 
         if (string.IsNullOrEmpty(term))

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -1,9 +1,11 @@
-﻿using Altinn.AccessMgmt.Core.Services.Contracts;
+﻿using Altinn.AccessMgmt.Core.Extensions;
+using Altinn.AccessMgmt.Core.Services.Contracts;
 using Altinn.AccessMgmt.Core.Utils;
 using Altinn.AccessMgmt.Core.Utils.Models;
 using Altinn.AccessMgmt.PersistenceEF.Contexts;
 using Altinn.AccessMgmt.PersistenceEF.Extensions;
 using Altinn.AccessMgmt.PersistenceEF.Models;
+using Altinn.AccessMgmt.PersistenceEF.Utils;
 using Altinn.Authorization.Api.Contracts.AccessManagement;
 using Altinn.Authorization.Api.Contracts.AccessManagement.Request;
 using Microsoft.EntityFrameworkCore;
@@ -15,14 +17,17 @@ public class PackageService : IPackageService
 {
     public AppDbContext DbContext { get; set; }
 
-    public PackageService(AppDbContext appDbContext)
+    public ITranslationService TranslationService { get; set; }
+
+    public PackageService(AppDbContext appDbContext, ITranslationService translationService)
     {
         DbContext = appDbContext;
+        TranslationService = translationService;
     }
 
-    public async Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default)
     {
-        var data = await GetSearchData(resourceProviderCodes: resourceProviderCodes, typeId: typeId);
+        var data = await GetSearchData(resourceProviderCodes: resourceProviderCodes, typeId: typeId, languageCode: languageCode, allowPartialTranslation: allowPartialTranslation);
         var scoredData = new List<SearchObject<PackageDto>>();
 
         foreach (var package in data)
@@ -75,9 +80,9 @@ public class PackageService : IPackageService
     }
 
     /// <inheritdoc/>
-    public async Task<IEnumerable<SearchObject<PackageDto>>> FuzzySearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<SearchObject<PackageDto>>> FuzzySearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default)
     {
-        var data = await GetSearchData(resourceProviderCodes: resourceProviderCodes, typeId: typeId);
+        var data = await GetSearchData(resourceProviderCodes: resourceProviderCodes, typeId: typeId, languageCode: languageCode, allowPartialTranslation: allowPartialTranslation);
 
         if (string.IsNullOrEmpty(term))
         {
@@ -116,7 +121,7 @@ public class PackageService : IPackageService
         return results.OrderByDescending(t => t.Score).ToList();
     }
 
-    private async Task<List<PackageDto>> GetSearchData(List<string> resourceProviderCodes = null, Guid? typeId = null, CancellationToken cancellationToken = default)
+    private async Task<List<PackageDto>> GetSearchData(List<string> resourceProviderCodes = null, Guid? typeId = null, string languageCode = "nbNO", bool allowPartialTranslation = false, CancellationToken cancellationToken = default)
     {
         bool filterResourceProviders = resourceProviderCodes != null && resourceProviderCodes.Any();
 
@@ -141,6 +146,11 @@ public class PackageService : IPackageService
             }
 
             result.Add(DtoMapper.Convert(package, areas.First(t => t.Id == package.AreaId), packageResources.Where(t => t.PackageId == package.Id).Select(t => t.Resource)));
+        }
+
+        foreach (var t in result)
+        {
+            await t.TranslateDeepAsync(TranslationService, languageCode: languageCode, allowPartial: allowPartialTranslation);
         }
 
         return result;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -27,7 +27,7 @@ public class PackageService : IPackageService
 
     private const StringComparison Ic = StringComparison.InvariantCultureIgnoreCase;
 
-    private record ScoringRule(
+    private sealed record ScoringRule(
         string FieldName,
         Func<PackageDto, string> Field,
         Func<string, string, bool> Match,

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs
@@ -198,6 +198,79 @@ public class PackagesControllerIntegrationTests : IClassFixture<PostgresFixture>
         Assert.Equal(SearchTerm, hits.First().Object.Name);
     }
 
+    // ── New simple-search path (default) — scoring rules + filter behaviour ──
+    //
+    // SimpleSearch builds rule-based scores (prefix-match=100, contains=50, etc.)
+    // and orders by score descending while filtering out zero-score packages.
+    // These tests defend the "rules-and-filter" contract against named
+    // regressions: order direction flipping, the score>0 filter being dropped,
+    // and the empty-input semantics diverging from FuzzySearch (which returns
+    // all on empty term).
+
+    [Fact]
+    public async Task SimpleSearch_PrefixMatchOnPackageName_RanksMatchingPackageFirst()
+    {
+        // "Kunst" prefix-matches the package name "Kunst og underholdning",
+        // earning the highest single-rule score (100) plus a contains-match (50).
+        // Regression: OrderByDescending → OrderBy would push this package to
+        // the bottom; dropping the prefix rule would tie it with substring hits.
+        var result = await CreateController().Search("Kunst");
+
+        var hits = AssertOkEnumerable(result).ToList();
+        Assert.NotEmpty(hits);
+
+        var top = hits.First();
+        Assert.Equal(PackageKunstName, top.Object.Name);
+        Assert.True(top.Score >= 100, $"Top hit should include a name.prefix match (≥100). Actual score: {top.Score}.");
+        Assert.Contains(top.Fields, f => f.Field == "name.prefix");
+    }
+
+    [Fact]
+    public async Task SimpleSearch_NonMatchingTerm_ReturnsNoContent()
+    {
+        // SimpleSearch must filter out packages with score 0. A regression where
+        // the `Where(s => s.Score > 0)` filter is removed would return every
+        // package in the database for any (or no) term — a search-becomes-list bug.
+        var result = await CreateController().Search("zzzz_no_package_should_match_this_xyzzy");
+
+        Assert.IsType<NoContentResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task SimpleSearch_ResultsOrderedByScoreDescending()
+    {
+        // A more general guard than the prefix-match test: every adjacent pair
+        // in the result must be in non-increasing score order. Regression:
+        // OrderBy direction flipping or the sort being dropped entirely.
+        var result = await CreateController().Search("Kunst");
+
+        var hits = AssertOkEnumerable(result).ToList();
+        Assert.NotEmpty(hits);
+        for (var i = 1; i < hits.Count; i++)
+        {
+            Assert.True(
+                hits[i - 1].Score >= hits[i].Score,
+                $"SimpleSearch result not ordered by score desc: index {i - 1} has score {hits[i - 1].Score}, index {i} has {hits[i].Score}.");
+        }
+    }
+
+    [Fact]
+    public async Task FuzzySearch_StillReachableViaSimpleSearchFalse()
+    {
+        // The legacy fuzzy path remains opt-in via simpleSearch=false. A
+        // regression where the controller's ternary always picks one branch
+        // would either lose this path entirely or break the simple default —
+        // either way, this test fails distinctly from the SimpleSearch tests
+        // above and tells you which branch broke.
+        var result = await CreateController().Search(SearchTerm, simpleSearch: false);
+
+        var hits = AssertOkEnumerable(result).ToList();
+        Assert.NotEmpty(hits);
+        // FuzzySearch produces fractional scores (vs SimpleSearch's integer rule
+        // points). The exact match is included regardless of which scorer ran.
+        Assert.Contains(hits, h => h.Object.Name == SearchTerm);
+    }
+
     [Fact]
     public async Task GetHierarchy_ReturnsNonEmptyHierarchyWithAreasAndPackages()
     {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs
@@ -1,4 +1,4 @@
-using Altinn.AccessManagement.Api.Metadata.Controllers;
+﻿using Altinn.AccessManagement.Api.Metadata.Controllers;
 using Altinn.AccessManagement.Tests.Fixtures;
 using Altinn.AccessMgmt.Core.Services.Contracts;
 using Altinn.AccessMgmt.PersistenceEF.Contexts;
@@ -96,7 +96,7 @@ public class PackagesControllerIntegrationTests : IClassFixture<PostgresFixture>
         // Fully qualify: the namespace-less Persistence `PackageService` (six-arg
         // ctor) is in the global namespace, so an unqualified `PackageService(_db)`
         // would bind there.
-        _packageService = new Altinn.AccessMgmt.Core.Services.PackageService(_db);
+        _packageService = new Altinn.AccessMgmt.Core.Services.PackageService(_db, _translationService);
     }
 
     private PackagesController CreateController(string acceptLanguage = "nb-NO")

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
@@ -36,29 +36,10 @@ public class PackagesControllerTest
     // ── Search ──────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task Search_WhenResultsFound_Returns200Ok()
-    {
-        var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<SearchObject<PackageDto>>
-            {
-                new() { Object = new PackageDto { Id = Guid.NewGuid(), Name = "Tax" }, Score = 0.9 },
-            });
-
-        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
-
-        var result = await controller.Search("Tax");
-
-        var ok = Assert.IsType<OkObjectResult>(result.Result);
-        var items = Assert.IsAssignableFrom<IEnumerable<SearchObject<PackageDto>>>(ok.Value);
-        Assert.NotEmpty(items);
-    }
-
-    [Fact]
     public async Task Search_WhenNoResults_Returns204NoContent()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), "eng", true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<SearchObject<PackageDto>>());
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
@@ -72,7 +53,7 @@ public class PackagesControllerTest
     public async Task Search_WhenServiceReturnsNull_Returns204NoContent()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), "eng", true, It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<SearchObject<PackageDto>>)null);
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
@@ -93,23 +74,6 @@ public class PackagesControllerTest
         Assert.IsType<ObjectResult>(result.Result);
         var objectResult = (ObjectResult)result.Result;
         Assert.Equal(500, objectResult.StatusCode); // Problem() defaults to 500
-    }
-
-    [Fact]
-    public async Task Search_WithValidTypeName_CallsServiceWithTypeId()
-    {
-        Guid? capturedTypeId = null;
-        var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
-            .Callback<string, List<string>, bool, Guid?, CancellationToken>((_, __, ___, id, ____) => capturedTypeId = id)
-            .ReturnsAsync(new List<SearchObject<PackageDto>> { new() { Object = new PackageDto { Id = Guid.NewGuid() }, Score = 1.0 } });
-
-        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
-
-        // "organization" is a known type name in EntityTypeConstants
-        await controller.Search("Tax", typeName: "organization");
-
-        Assert.NotNull(capturedTypeId);
     }
 
     // ── GetHierarchy ────────────────────────────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
@@ -34,12 +34,141 @@ public class PackagesControllerTest
     }
 
     // ── Search ──────────────────────────────────────────────────────────────
+    //
+    // The action branches on the new `simpleSearch` query parameter (default
+    // true → SimpleSearch, false → FuzzySearch) and forwards the resolved
+    // language code + partial-translation flag from the request to the
+    // service. These tests guard the routing branch (calls the right method,
+    // never the other) and the parameter-forwarding contract — bug classes
+    // that no test covered after the FuzzySearch→SimpleSearch split.
 
     [Fact]
-    public async Task Search_WhenNoResults_Returns204NoContent()
+    public async Task Search_DefaultIsSimpleSearch_RoutesToSimpleSearchAndNotFuzzy()
     {
+        var serviceMock = new Mock<IPackageService>(MockBehavior.Strict);
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SearchObject<PackageDto>>
+            {
+                new() { Object = new PackageDto { Id = Guid.NewGuid(), Name = "Tax" }, Score = 100 },
+            });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.Search("Tax");
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var items = Assert.IsAssignableFrom<IEnumerable<SearchObject<PackageDto>>>(ok.Value);
+        Assert.NotEmpty(items);
+        // Strict mock would have thrown if FuzzySearch had been invoked.
+        serviceMock.Verify(
+            s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Search_SimpleSearchFalse_RoutesToFuzzySearchAndNotSimple()
+    {
+        var serviceMock = new Mock<IPackageService>(MockBehavior.Strict);
+        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SearchObject<PackageDto>>
+            {
+                new() { Object = new PackageDto { Id = Guid.NewGuid(), Name = "Tax" }, Score = 0.9 },
+            });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.Search("Tax", simpleSearch: false);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.IsAssignableFrom<IEnumerable<SearchObject<PackageDto>>>(ok.Value);
+        serviceMock.Verify(
+            s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Search_PassesAcceptLanguageMappedTo3LetterCodeToService()
+    {
+        // Accept-Language "nb-NO" must reach the service as the mapped 3-letter
+        // ISO 639-2 code "nob". A regression that hardcodes the default would
+        // silently degrade i18n.
+        string capturedLanguageCode = null;
+        bool? capturedAllowPartial = null;
+
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), "eng", true, It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<string>, bool, Guid?, string, bool, CancellationToken>(
+                (_, _, _, _, lang, allowPartial, _) =>
+                {
+                    capturedLanguageCode = lang;
+                    capturedAllowPartial = allowPartial;
+                })
+            .ReturnsAsync(new List<SearchObject<PackageDto>>
+            {
+                new() { Object = new PackageDto { Id = Guid.NewGuid() }, Score = 1 },
+            });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object, acceptLanguage: "nb-NO");
+
+        await controller.Search("anything");
+
+        Assert.Equal("nob", capturedLanguageCode);
+        Assert.True(capturedAllowPartial); // Default when X-Accept-Partial-Translation header absent
+    }
+
+    [Fact]
+    public async Task Search_FuzzySearchPath_AlsoForwardsLanguageContext()
+    {
+        // Same forwarding contract on the FuzzySearch branch; if the params get
+        // dropped on one branch but not the other, locales diverge silently.
+        string capturedLanguageCode = null;
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<string>, bool, Guid?, string, bool, CancellationToken>(
+                (_, _, _, _, lang, _, _) => capturedLanguageCode = lang)
+            .ReturnsAsync(new List<SearchObject<PackageDto>>
+            {
+                new() { Object = new PackageDto { Id = Guid.NewGuid() }, Score = 1 },
+            });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object, acceptLanguage: "nb-NO");
+
+        await controller.Search("anything", simpleSearch: false);
+
+        Assert.Equal("nob", capturedLanguageCode);
+    }
+
+    [Fact]
+    public async Task Search_WithValidTypeName_PassesResolvedTypeIdToService()
+    {
+        // Re-added after the FuzzySearch→SimpleSearch split removed the original test.
+        // Bug class: typeName lookup not wired through the new branch — search would
+        // silently ignore the type filter and return cross-type results.
+        Guid? capturedTypeId = null;
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<string>, bool, Guid?, string, bool, CancellationToken>(
+                (_, _, _, id, _, _, _) => capturedTypeId = id)
+            .ReturnsAsync(new List<SearchObject<PackageDto>>
+            {
+                new() { Object = new PackageDto { Id = Guid.NewGuid() }, Score = 1 },
+            });
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        // "organization" is a known type name in EntityTypeConstants
+        await controller.Search("Tax", typeName: "organization");
+
+        Assert.NotNull(capturedTypeId);
+        Assert.NotEqual(Guid.Empty, capturedTypeId.Value);
+    }
+
+    [Fact]
+    public async Task Search_DefaultPath_WhenNoResults_Returns204NoContent()
+    {
+        // Default (simpleSearch=true) hits SimpleSearch — empty maps to NoContent.
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<SearchObject<PackageDto>>());
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
@@ -50,15 +179,31 @@ public class PackagesControllerTest
     }
 
     [Fact]
-    public async Task Search_WhenServiceReturnsNull_Returns204NoContent()
+    public async Task Search_DefaultPath_WhenServiceReturnsNull_Returns204NoContent()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), "eng", true, It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<SearchObject<PackageDto>>)null);
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
 
         var result = await controller.Search("x");
+
+        Assert.IsType<NoContentResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Search_FuzzyPath_WhenNoResults_Returns204NoContent()
+    {
+        // Mirror of the SimpleSearch empty-result test, but explicitly on the
+        // FuzzySearch branch — both paths must collapse empty/null to NoContent.
+        var serviceMock = new Mock<IPackageService>();
+        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<SearchObject<PackageDto>>());
+
+        var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
+
+        var result = await controller.Search("nothing", simpleSearch: false);
 
         Assert.IsType<NoContentResult>(result.Result);
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
@@ -39,7 +39,7 @@ public class PackagesControllerTest
     public async Task Search_WhenResultsFound_Returns200Ok()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<SearchObject<PackageDto>>
             {
                 new() { Object = new PackageDto { Id = Guid.NewGuid(), Name = "Tax" }, Score = 0.9 },
@@ -58,7 +58,7 @@ public class PackagesControllerTest
     public async Task Search_WhenNoResults_Returns204NoContent()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<SearchObject<PackageDto>>());
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
@@ -72,7 +72,7 @@ public class PackagesControllerTest
     public async Task Search_WhenServiceReturnsNull_Returns204NoContent()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<SearchObject<PackageDto>>)null);
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
@@ -100,7 +100,7 @@ public class PackagesControllerTest
     {
         Guid? capturedTypeId = null;
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.FuzzySearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .Callback<string, List<string>, bool, Guid?, CancellationToken>((_, __, ___, id, ____) => capturedTypeId = id)
             .ReturnsAsync(new List<SearchObject<PackageDto>> { new() { Object = new PackageDto { Id = Guid.NewGuid() }, Score = 1.0 } });
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
@@ -39,7 +39,7 @@ public class PackagesControllerTest
     public async Task Search_WhenResultsFound_Returns200Ok()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<SearchObject<PackageDto>>
             {
                 new() { Object = new PackageDto { Id = Guid.NewGuid(), Name = "Tax" }, Score = 0.9 },
@@ -58,7 +58,7 @@ public class PackagesControllerTest
     public async Task Search_WhenNoResults_Returns204NoContent()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<SearchObject<PackageDto>>());
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
@@ -72,7 +72,7 @@ public class PackagesControllerTest
     public async Task Search_WhenServiceReturnsNull_Returns204NoContent()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<SearchObject<PackageDto>>)null);
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
@@ -100,7 +100,7 @@ public class PackagesControllerTest
     {
         Guid? capturedTypeId = null;
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.Search(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), true, It.IsAny<CancellationToken>()))
             .Callback<string, List<string>, bool, Guid?, CancellationToken>((_, __, ___, id, ____) => capturedTypeId = id)
             .ReturnsAsync(new List<SearchObject<PackageDto>> { new() { Object = new PackageDto { Id = Guid.NewGuid() }, Score = 1.0 } });
 


### PR DESCRIPTION
## Description

Replaces the fuzzy package search with a deterministic rule-based scorer to fix the relevance regressions reported in the linked issues — exact name matches not ranking first, package-name hits losing to resource hits, and apparently random ordering for common terms like "Lønn" or "Pensjon".

**New `SimpleSearch` (default)** — case-insensitive, integer-scored matches over a fixed rule set on the package + its area:

| Field | Match | Points |
| --- | --- | --- |
| `name` | prefix | 100 |
| `name` | contains | 50 |
| `area.name` | prefix | 25 |
| `description` | contains | 10 |
| `area.description` | contains | 5 |
| `resources.name` | contains (when `searchInResources=true`) | 2 each |

Packages with score 0 are filtered out and results are ordered by score descending. So `"Kunst"` puts "Kunst og underholdning" first (150) ahead of any package that only mentions kunst in its description (10), and `"Lønn"` lifts the "Lønn" package to the top instead of burying it under partial matches in unrelated areas.

**`FuzzySearch` (opt-in)** — the previous implementation is preserved verbatim and reachable by passing `simpleSearch=false` on the search endpoint, so consumers that depended on the old behaviour can opt out while we monitor adoption.

**Translation moved from controller to service** — `GetSearchData` now calls `TranslateDeepAsync` on each result before returning, so both search variants get the same translated DTOs and the controller no longer has a per-result translation loop. `languageCode` and `allowPartialTranslation` are forwarded from the request to the service via the new method signatures.

## API change

`GET /accessmanagement/api/v1/meta/info/accesspackages/search` gains a `simpleSearch` query parameter (default `true`). All other parameters and the response shape are unchanged.

## Tests

- Controller-level unit tests cover the routing branch (`simpleSearch=true`→`SimpleSearch`, `false`→`FuzzySearch` — strict mocks ensure the other method is never called), language-code propagation (`Accept-Language: nb-NO` → `nob` reaches the service on both branches), `typeName` resolution, and empty/null result mapping on both paths.
- Integration tests against the seeded Postgres testcontainer verify the prefix-match-ranks-first contract, the score-ordering direction, the score-zero filter (a non-matching term returns 204 rather than the whole catalogue), and that the legacy fuzzy path remains reachable via `simpleSearch=false`.

## Related Issue(s)

- #2904 — Forbedre søkealgoritmen for tilgangspakker
- #1935 — Søkefelt for søk i tilgangspakker
- #1823 — Search in tilgangspakker returns inaccurate ranking for exact name matches

## Verification

- [x] Code builds clean
- [x] All tests run green (1243 passing locally, including the new unit and integration tests)
- [ ] Manual testing in TT

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs](https://github.com/Altinn/altinn-studio-docs) (if applicable)