### PR TITLE
chore: dotnet format whitespace pass (warnings cleanup, part 1)

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/AccessManagementEnduserHost.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/AccessManagementEnduserHost.cs
@@ -52,7 +52,7 @@ public static partial class AccessManagementEnduserHost
             });
             options.OperationFilter<SecurityRequirementsOperationFilter>();
             options.EnableAnnotations();
-            
+
             var originalIdSelector = options.SchemaGeneratorOptions.SchemaIdSelector;
             options.SchemaGeneratorOptions.SchemaIdSelector = (Type t) =>
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ConnectionsController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ConnectionsController.cs
@@ -400,7 +400,7 @@ public class ConnectionsController(
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [FeatureGate(AccessMgmtFeatureFlags.Altinn2RoleRevoke)]    
+    [FeatureGate(AccessMgmtFeatureFlags.Altinn2RoleRevoke)]
     public async Task<IActionResult> RemoveRole(
         [Required][FromQuery(Name = "party")] Guid party,
         [Required][FromQuery(Name = "from")] Guid from,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/ConnectionValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/ConnectionValidation.cs
@@ -71,7 +71,7 @@ internal static class ConnectionValidation
             ConnectionCombinationRules.ExclusivePackageReference(packageId, packageUrn),
             ConnectionCombinationRules.PartyEqualsFrom(party, from)
         );
-    
+
     /// <summary>
     /// Validation rule for removing an existing rightholder connection.
     /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/ParameterValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/ParameterValidation.cs
@@ -116,14 +116,14 @@ internal static class ParameterValidation
         if (to.HasValue && toInput != null)
         {
             return (ref ValidationErrorBuilder errors) =>
-                errors.Add(ValidationErrors.InvalidQueryParameter, "$QUERY/to", 
+                errors.Add(ValidationErrors.InvalidQueryParameter, "$QUERY/to",
                     [new("to", ValidationErrorMessageTexts.ToParameterConflict)]);
         }
 
         if (!to.HasValue && toInput == null)
         {
             return (ref ValidationErrorBuilder errors) =>
-                errors.Add(ValidationErrors.InvalidQueryParameter, "$QUERY/to", 
+                errors.Add(ValidationErrors.InvalidQueryParameter, "$QUERY/to",
                     [new("to", ValidationErrorMessageTexts.ToParameterRequired)]);
         }
 
@@ -131,7 +131,7 @@ internal static class ParameterValidation
         if (to.HasValue && to.Value == Guid.Empty)
         {
             return (ref ValidationErrorBuilder errors) =>
-                errors.Add(ValidationErrors.InvalidQueryParameter, "$QUERY/to", 
+                errors.Add(ValidationErrors.InvalidQueryParameter, "$QUERY/to",
                     [new("to", ValidationErrorMessageTexts.InvalidPartyValue)]);
         }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
@@ -167,7 +167,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
             }
 
             List<ConsentStatusChange> changes = result.Value;
-            
+
             // Convert to DTOs
             List<ConsentStatusChangeDto> dtos = changes.Select(c => c.ToDto()).ToList();
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Extensions/ConsentRequestEventExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Extensions/ConsentRequestEventExtensions.cs
@@ -7,7 +7,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Extensions
     /// <summary>
     /// Provides extension methods for transforming ConsentRequestDetails to ConsentRequestDetailsBFF.
     /// </summary>
-    public static class ConsentRequestEventExtensions   
+    public static class ConsentRequestEventExtensions
     {
         /// <summary>
         /// Converts a ConsentRequestEvent object to a ConsentRequestEventExternal object.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Controllers/Bff/ConsentController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Controllers/Bff/ConsentController.cs
@@ -37,7 +37,7 @@ namespace Altinn.AccessManagement.Api.Internal.Controllers.Bff
         /// </summary>
         [HttpGet]
         [Authorize(Policy = AuthzConstants.SCOPE_PORTAL_ENDUSER)]
-        [Route("consentrequests/{requestId}", Name ="bffgetconsentrequest")]
+        [Route("consentrequests/{requestId}", Name = "bffgetconsentrequest")]
         public async Task<IActionResult> GetConsentRequest([FromRoute] Guid requestId, CancellationToken cancellationToken = default)
         {
             Guid? performedBy = UserUtil.GetUserUuid(User);
@@ -309,7 +309,7 @@ namespace Altinn.AccessManagement.Api.Internal.Controllers.Bff
             return Ok(result.Value);
         }
 
-        private async Task<bool> AuthorizeResourceAccess(string resource, Guid resourceParty, ClaimsPrincipal userPrincipal,  string action)
+        private async Task<bool> AuthorizeResourceAccess(string resource, Guid resourceParty, ClaimsPrincipal userPrincipal, string action)
         {
             XacmlJsonRequestRoot request = DecisionHelper.CreateDecisionRequestForResourceRegistryResource(resource, resourceParty, userPrincipal, action);
             XacmlJsonResponse response = await Pdp.GetDecisionForRequest(request);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Controllers/InternalConnectionsController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Controllers/InternalConnectionsController.cs
@@ -98,7 +98,7 @@ public class InternalConnectionsController(IConnectionService connectionService)
     #endregion
 
     #region Packages
-    
+
     /// <summary>
     /// Lists all packages assigned from to / systemuser and organization. 
     /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Controllers/SystemUserClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Controllers/SystemUserClientDelegationController.cs
@@ -20,8 +20,8 @@ namespace Altinn.AccessManagement.Api.Internal.Controllers;
 [ApiExplorerSettings(IgnoreApi = false)]
 public class SystemUserClientDelegationController(
         IAssignmentService assignmentService
-        ,IConnectionService connectionService
-        ,IDelegationService delegationService
+        , IConnectionService connectionService
+        , IDelegationService delegationService
     ) : ControllerBase
 {
     private readonly string[] validClientRoles = [RoleConstants.Accountant.Entity.Code, RoleConstants.Auditor.Entity.Code, RoleConstants.BusinessManager.Entity.Code, RoleConstants.Rightholder.Entity.Code];

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Extensions/ConsentRequestEventExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Extensions/ConsentRequestEventExtensions.cs
@@ -7,7 +7,7 @@ namespace Altinn.AccessManagement.Api.Internal.Extensions
     /// <summary>
     /// Provides extension methods for transforming ConsentRequestDetails to ConsentRequestDetailsBFF.
     /// </summary>
-    public static class ConsentRequestEventExtensions   
+    public static class ConsentRequestEventExtensions
     {
         /// <summary>
         /// Converts a ConsentRequestEvent object to a ConsentRequestEventExternal object.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Utils/UserUtil.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Utils/UserUtil.cs
@@ -22,6 +22,6 @@ namespace Altinn.AccessManagement.Api.Internal.Utils
             }
 
             return null;
-        }    
+        }
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
@@ -55,11 +55,11 @@ public class PackagesController : ControllerBase
 
         var res = simpleSearch
             ? await packageService.SimpleSearch(
-                term: term, 
-                resourceProviderCodes: resourceProviderCode, 
-                searchInResources: searchInResources, 
-                typeId: typeId, 
-                languageCode: this.GetLanguageCode(), 
+                term: term,
+                resourceProviderCodes: resourceProviderCode,
+                searchInResources: searchInResources,
+                typeId: typeId,
+                languageCode: this.GetLanguageCode(),
                 allowPartialTranslation: this.AllowPartialTranslation()
                 )
             : await packageService.FuzzySearch(
@@ -201,7 +201,7 @@ public class PackagesController : ControllerBase
             translationService,
             this.GetLanguageCode(),
             this.AllowPartialTranslation());
-        
+
         return Ok(translated);
     }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/RolesController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/RolesController.cs
@@ -45,8 +45,8 @@ namespace Altinn.AccessManagement.Api.Metadata.Controllers
 
             // Translate the collection with deep translation for nested Provider
             var translated = await res.TranslateDeepAsync(
-                translationService, 
-                this.GetLanguageCode(), 
+                translationService,
+                this.GetLanguageCode(),
                 this.AllowPartialTranslation());
 
             return Ok(translated.ToList());
@@ -81,7 +81,7 @@ namespace Altinn.AccessManagement.Api.Metadata.Controllers
         [HttpGet("packages")]
         [ProducesResponseType(typeof(PackageDto), StatusCodes.Status200OK)]
         public async ValueTask<ActionResult<IEnumerable<PackageDto>>> GetPackages([Required][FromQuery] string role, [Required][FromQuery] string variant, [FromQuery] bool includeResources = false)
-        {            
+        {
             if (!RoleConstants.TryGetByCode(string.IsNullOrEmpty(role) ? "_" : role, out var roleDef))
             {
                 return NotFound($"Role '{role}' not found");
@@ -93,7 +93,7 @@ namespace Altinn.AccessManagement.Api.Metadata.Controllers
             }
 
             var packages = await roleService.GetRolePackages(roleDef.Id, variantDef.Id, includeResources);
-            
+
             // Translate the packages with deep translation for nested Area and Resources
             var translated = await packages.TranslateDeepAsync(
                 translationService,
@@ -121,7 +121,7 @@ namespace Altinn.AccessManagement.Api.Metadata.Controllers
             }
 
             var resources = await roleService.GetRoleResources(roleDef.Id, variantDef.Id, includePackageResources);
-            
+
             // Translate the resources with deep translation for nested Provider and Type
             var translated = await resources.TranslateDeepAsync(
                 translationService,
@@ -145,7 +145,7 @@ namespace Altinn.AccessManagement.Api.Metadata.Controllers
             }
 
             var packages = await roleService.GetRolePackages(id, variantDef.Id, includeResources);
-            
+
             // Translate the packages with deep translation for nested Area and Resources
             var translated = await packages.TranslateDeepAsync(
                 translationService,
@@ -168,7 +168,7 @@ namespace Altinn.AccessManagement.Api.Metadata.Controllers
             }
 
             var resources = await roleService.GetRoleResources(id, variantDef.Id, includePackageResources);
-            
+
             // Translate the resources with deep translation for nested Provider and Type
             var translated = await resources.TranslateDeepAsync(
                 translationService,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.ServiceOwner/Controllers/ConnectionsController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.ServiceOwner/Controllers/ConnectionsController.cs
@@ -183,7 +183,7 @@ namespace Altinn.AccessManagement.Api.ServiceOwner.Controllers
 
         private bool IsServiceOwnerAuthorizedForPackage(string packageIdentifier, out OrganizationNumber? organizationNumber)
         {
-            var consumerParty = OrgUtil.GetAuthenticatedParty(User);            
+            var consumerParty = OrgUtil.GetAuthenticatedParty(User);
             if (consumerParty is null || !consumerParty.IsOrganizationId(out organizationNumber))
             {
                 organizationNumber = null;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.ServiceOwner/Controllers/RequestController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.ServiceOwner/Controllers/RequestController.cs
@@ -254,8 +254,8 @@ public class RequestController(
             errorBuilder.Add(ValidationErrorDescriptors.RequestedResourceNotFound, paramName, [new(paramName, $"Resource with reference ID '{resourceRef.ReferenceId}' was not found.")]);
         }
 
-        try 
-        { 
+        try
+        {
             var serviceResource = await resourceRegistryClient.GetResource(resourceRef.ReferenceId, ct);
 
             if (!serviceResource.Delegable)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Clients/Interfaces/IResourceRegistryClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Clients/Interfaces/IResourceRegistryClient.cs
@@ -44,7 +44,7 @@ namespace Altinn.AccessManagement.Core.Clients.Interfaces
         /// <summary>
         /// Returns a consent template by its id and version
         /// </summary>
-        Task<ConsentTemplate> GetConsentTemplate(string templateId,int? version, CancellationToken cancellationToken = default);
+        Task<ConsentTemplate> GetConsentTemplate(string templateId, int? version, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Fetch resource policy rights for a given resource from the Resource Registry. This includes decomposing the resource's policy rules and returning the rights in a structured format that can be used for access management decisions.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Configuration/AppsInstanceDelegationSettings.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Configuration/AppsInstanceDelegationSettings.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// Sets the maximum policy files to handle under revoke all calls
         /// </summary>
-        public int MaxPolicyFilesToRevoke { get; set; } 
+        public int MaxPolicyFilesToRevoke { get; set; }
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Configuration/CacheConfig.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Configuration/CacheConfig.cs
@@ -43,6 +43,6 @@ namespace Altinn.AccessManagement.Core.Configuration
         /// <summary>
         /// Gets or sets the cache timeout (in minutes) for lookup of a rights
         /// </summary>
-        public int RightsCacheTimeout { get; set; }        
+        public int RightsCacheTimeout { get; set; }
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Constants/AltinnCoreClaimTypes.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Constants/AltinnCoreClaimTypes.cs
@@ -9,7 +9,7 @@
         /// AuthenticationLevel.
         /// </summary>
         public const string AuthenticationLevel = "urn:altinn:authlevel";
-        
+
         /// <summary>
         /// User id.
         /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Constants/AltinnXacmlConstants.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Constants/AltinnXacmlConstants.cs
@@ -226,6 +226,6 @@
             /// The minimum authentication level for organization category
             /// </summary>
             public const string MinimumAuthenticationLevelOrg = "urn:altinn:minimum-authenticationlevel-org";
-        }        
+        }
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Constants/XacmlRequestAttribute.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Constants/XacmlRequestAttribute.cs
@@ -44,7 +44,7 @@
         /// xacml string that represents organization number 
         /// </summary>
         public const string OrganizationNumberAttribute = "urn:altinn:organizationnumber";
-        
+
         /// <summary>
         /// xacml string that represents user
         /// </summary>
@@ -54,7 +54,7 @@
         /// xacml string that represents role
         /// </summary>
         public const string RoleAttribute = "urn:altinn:rolecode";
-        
+
         /// <summary>
         /// xacml string that represents resource
         /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Enums/ResourceAttributeMatchType.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Enums/ResourceAttributeMatchType.cs
@@ -9,12 +9,12 @@
         /// Default value
         /// </summary>
         None = 0,
-        
+
         /// <summary>
         /// Resource registered in the Altinn Resource Registry
         /// </summary>
-        ResourceRegistry = 1, 
-        
+        ResourceRegistry = 1,
+
         /// <summary>
         /// Legacy App resource identified by org owner and app name
         /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Enums/ResourceRegistry/ReferenceSource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Enums/ResourceRegistry/ReferenceSource.cs
@@ -7,7 +7,7 @@ namespace Altinn.AccessManagement.Core.Models.ResourceRegistry
     /// </summary>
     public enum ReferenceSource : int
     {
-        [EnumMember(Value = "Default")]    
+        [EnumMember(Value = "Default")]
         Default = 0,
 
         [EnumMember(Value = "Altinn1")]

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/DelegationHelper.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/DelegationHelper.cs
@@ -614,7 +614,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                 }
 
                 bool matchingActionFound = MatchingActionFound(policyRule.Target.AnyOf, rule, out List<List<AttributeMatch>> policyResourceMatches);
-                
+
                 if (policyResourceMatches.Exists(resourceMatch => GetAttributeMatchKey(resourceMatch) == ruleResourceKey) && matchingActionFound)
                 {
                     rule.RuleId = policyRule.RuleId;
@@ -663,7 +663,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                 foreach (XacmlAllOf allOf in anyOf.AllOf)
                 {
                     matchingActionFound = GetResourceMatch(allOf.Matches, rule, out List<AttributeMatch> resourceMatch);
-                    
+
                     if (resourceMatch.Count > 0)
                     {
                         policyResourceMatches.Add(resourceMatch);
@@ -784,7 +784,7 @@ namespace Altinn.AccessManagement.Core.Helpers
             if (performer == null)
             {
                 return false;
-            }   
+            }
 
             foreach (AttributeMatch match in performer)
             {
@@ -862,7 +862,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                 type = UuidType.EnterpriseUser;
                 return true;
             }
-            
+
             if (org == null && app == null && person == null && organization == null && enterpriseUser == null && systemUser != null && counter == 1)
             {
                 id = systemUser;
@@ -1136,7 +1136,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                     return UuidType.Party;
             }
         }
-            
+
         public static UuidType GetUuidTypeFromEntityType(Guid entityType)
         {
             if (entityType == EntityTypeConstants.Person.Id)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/Extensions/EnumExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/Extensions/EnumExtensions.cs
@@ -41,7 +41,7 @@ namespace Altinn.AccessManagement.Core.Helpers.Extensions
         {
             string[] names = Enum.GetNames(typeof(T));
             string name = Array.Find(names, name => EnumMemberAttributeValueOrName((Enum)Enum.Parse(typeof(T), name)).Equals(value));
-            
+
             if (name != null)
             {
                 enumValue = (T)Enum.Parse(typeof(T), name);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/Extensions/StringExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/Extensions/StringExtensions.cs
@@ -25,7 +25,7 @@ namespace Altinn.AccessManagement.Core.Helpers.Extensions
             if (throwExceptionOnInvalidCharacters)
             {
                 if (illegalFileNameCharacters.Any(ic => input.Any(i => ic == i)))
-                {                    
+                {
                     throw new ArgumentOutOfRangeException(nameof(input));
                 }
 
@@ -66,15 +66,15 @@ namespace Altinn.AccessManagement.Core.Helpers.Extensions
         {
             string normalizedText;
 
-            // Å is not a special character in Norwegian hence handling this character differently
-            if (text.ToUpper().Contains('Å'))
+            // Ã… is not a special character in Norwegian hence handling this character differently
+            if (text.ToUpper().Contains('Ã…'))
             {
                 StringBuilder firstPassBuilder = new();
                 foreach (char ch in text)
                 {
-                    if (ch == 'Å' || ch == 'å')
+                    if (ch == 'Ã…' || ch == 'Ã¥')
                     {
-                        // NormalizationForm C doesn't convert Å to A
+                        // NormalizationForm C doesn't convert Ã… to A
                         firstPassBuilder.Append(ch.ToString().Normalize(NormalizationForm.FormC));
                     }
                     else

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/PolicyHelper.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/PolicyHelper.cs
@@ -18,7 +18,7 @@ namespace Altinn.AccessManagement.Core.Helpers
     public static class PolicyHelper
     {
         private const string CoveredByNotDefined = "CoveredBy was not defined";
-        
+
         /// <summary>
         /// Extracts a list of all roles codes mentioned in a permit rule in a policy. 
         /// </summary>
@@ -142,7 +142,7 @@ namespace Altinn.AccessManagement.Core.Helpers
 
             return rule;
         }
-        
+
         /// <summary>
         /// Builds the delegation policy path based on org and app names, as well as identifiers for the delegating and receiving entities
         /// </summary>
@@ -318,7 +318,7 @@ namespace Altinn.AccessManagement.Core.Helpers
 
             return (coveredBy, coveredByType);
         }
-        
+
         /// <summary>
         /// Builds a XacmlPolicy <see cref="XacmlPolicy"/> representation based on the DelegationPolicy input
         /// </summary>
@@ -366,7 +366,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                 PerformedById = rules.PerformedBy,
                 PerformedByType = rules.PerformedByType.EnumMemberAttributeValueOrName()
             };
-            
+
             return result;
         }
 
@@ -401,7 +401,7 @@ namespace Altinn.AccessManagement.Core.Helpers
         public static XacmlRule BuildDelegationInstanceRule(PolicyParameters policyData, InstanceRule rule)
         {
             rule.RuleId = Guid.NewGuid().ToString();
-            
+
             XacmlRule delegationRule = new XacmlRule(rule.RuleId, XacmlEffectType.Permit)
             {
                 Description = $"Delegation of a right/action from {policyData.FromType}:{policyData.FromId} to {policyData.ToType}:{policyData.ToId}, for the resourceId: {policyData.ResourceId} instanceId: {policyData.InstanceId}, by: {policyData.PerformedByType}:{policyData.PerformedById}",
@@ -424,7 +424,7 @@ namespace Altinn.AccessManagement.Core.Helpers
         public static XacmlRule BuildDelegationInstanceRule(string resourceId, string fromId, string fromType, string toId, string toType, string performedById, string performedByType, InstanceRule rule)
         {
             rule.RuleId = Guid.NewGuid().ToString();
-            
+
             XacmlRule delegationRule = new XacmlRule(rule.RuleId, XacmlEffectType.Permit)
             {
                 Description = $"Delegation of a right/action from {fromType}:{fromId} to {toType}:{toId}, for the resource: {resourceId}, by: {performedByType}:{performedById}",
@@ -444,7 +444,7 @@ namespace Altinn.AccessManagement.Core.Helpers
         public static XacmlRule BuildDelegationRule(string resourceId, int offeredByPartyId, string coveredBy, string toType, Rule rule)
         {
             rule.RuleId = Guid.NewGuid().ToString();
-            
+
             XacmlRule delegationRule = new XacmlRule(rule.RuleId, XacmlEffectType.Permit)
             {
                 Description = $"Delegation of a right/action from {offeredByPartyId} to {coveredBy}, for the resource: {resourceId}, by user; {rule.DelegatedByUserId}",
@@ -465,7 +465,7 @@ namespace Altinn.AccessManagement.Core.Helpers
 
             // Build Subject
             List<XacmlAllOf> subjectAllOfs = new List<XacmlAllOf>();
-            
+
             subjectAllOfs.Add(new XacmlAllOf(new List<XacmlMatch>
             {
                 new XacmlMatch(
@@ -473,7 +473,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                     new XacmlAttributeValue(new Uri(XacmlConstants.DataTypes.XMLString), coveredBy),
                     new XacmlAttributeDesignator(new Uri(XacmlConstants.MatchAttributeCategory.Subject), new Uri(toType), new Uri(XacmlConstants.DataTypes.XMLString), false))
             }));
-            
+
             // Build Resource
             List<XacmlMatch> resourceMatches = new List<XacmlMatch>();
             foreach (AttributeMatch resourceMatch in rule.Resource)
@@ -821,7 +821,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                     {
                         ruleAttributeMatches.Add(anyOfAttributeMatches);
                     }
-                }                
+                }
             }
 
             return ruleAttributeMatches;
@@ -865,7 +865,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                     Id = xacmlMatch.AttributeDesignator.AttributeId.OriginalString,
                     Value = xacmlMatch.AttributeValue.Value
                 });
-            }     
+            }
 
             return attributeMatches;
         }
@@ -939,7 +939,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                     if (action != null)
                     {
                         return new AttributeMatch { Id = action.AttributeDesignator.AttributeId.OriginalString, Value = action.AttributeValue.Value };
-                    }                    
+                    }
                 }
             }
 
@@ -955,7 +955,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                 {
                     foreach (XacmlMatch xacmlMatch in allOf.Matches.Where(m => m.AttributeDesignator.Category.Equals(XacmlConstants.MatchAttributeCategory.Resource)))
                     {
-                        result.Add(new AttributeMatch { Id = xacmlMatch.AttributeDesignator.AttributeId.OriginalString, Value = xacmlMatch.AttributeValue.Value });                        
+                        result.Add(new AttributeMatch { Id = xacmlMatch.AttributeDesignator.AttributeId.OriginalString, Value = xacmlMatch.AttributeValue.Value });
                     }
                 }
             }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/AccessManagementResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/AccessManagementResource.cs
@@ -9,12 +9,12 @@ namespace Altinn.AccessManagement.Core.Models
     /// </summary>
     public class AccessManagementResource
     {
-        #nullable enable
+#nullable enable
         /// <summary>
         /// Primary key created when inserted in Access management
         /// </summary>
         public int? ResourceId { get; set; }
-        #nullable disable
+#nullable disable
 
         /// <summary>
         /// The resource registry id

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/Consent/ConsentRequestEvent.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/Consent/ConsentRequestEvent.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// When the event was created.
         /// </summary>
-        public DateTimeOffset Created { get; set; } 
+        public DateTimeOffset Created { get; set; }
 
         /// <summary>
         /// Who made the event happen

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/Consent/ConsentRight.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/Consent/ConsentRight.cs
@@ -36,7 +36,7 @@
                 {
                     Metadata.Add(item.Key, item.Value);
                 }
-            }   
+            }
         }
-     }
+    }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ConsentMigrationResult.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ConsentMigrationResult.cs
@@ -5,23 +5,23 @@
 /// </summary>
 public record ConsentMigrationResult
 {
-  /// <summary>
-  /// Indicates if the migration was successful
-  /// </summary>
-  public bool Success { get; init; }
+    /// <summary>
+    /// Indicates if the migration was successful
+    /// </summary>
+    public bool Success { get; init; }
 
-  /// <summary>
-  /// Error message if migration failed
-  /// </summary>
-  public string? ErrorMessage { get; init; }
+    /// <summary>
+    /// Error message if migration failed
+    /// </summary>
+    public string? ErrorMessage { get; init; }
 
-  /// <summary>
-  /// Creates a successful result
-  /// </summary>
-  public static ConsentMigrationResult Succeeded { get; } = new() { Success = true };
+    /// <summary>
+    /// Creates a successful result
+    /// </summary>
+    public static ConsentMigrationResult Succeeded { get; } = new() { Success = true };
 
-  /// <summary>
-  /// Creates a failed result with error message
-  /// </summary>
-  public static ConsentMigrationResult Failed(string errorMessage) => new() { Success = false, ErrorMessage = errorMessage };
+    /// <summary>
+    /// Creates a failed result with error message
+    /// </summary>
+    public static ConsentMigrationResult Failed(string errorMessage) => new() { Success = false, ErrorMessage = errorMessage };
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/PolicyWriteOutput.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/PolicyWriteOutput.cs
@@ -11,7 +11,7 @@ namespace Altinn.AccessManagement.Core.Models
         /// The path the policy is written to
         /// </summary>
         public string PolicyPath { get; set; }
-        
+
         /// <summary>
         /// The Version id of the written Policy file
         /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/Register/PartyUrn.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/Register/PartyUrn.cs
@@ -24,5 +24,5 @@ public abstract partial record PartyUrn
     /// <param name="organizationNumber">The resulting organization number.</param>
     /// <returns><see langword="true"/> if this party reference is an organization number, otherwise <see langword="false"/>.</returns>
     [UrnKey("altinn:organization:identifier-no")]
-    public partial bool IsOrganizationIdentifier(out OrganizationNumber organizationNumber);        
+    public partial bool IsOrganizationIdentifier(out OrganizationNumber organizationNumber);
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ResourceRegistry/Keyword.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ResourceRegistry/Keyword.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The key word
         /// </summary>
-        public string Word { get; set; } 
+        public string Word { get; set; }
 
         /// <summary>
         /// Language of the key word

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ResourceRegistry/SubjectResources.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ResourceRegistry/SubjectResources.cs
@@ -9,7 +9,7 @@ public class SubjectResources
     /// <summary>
     /// The subject
     /// </summary>
-    public required BaseAttribute Subject { get; set; }    
+    public required BaseAttribute Subject { get; set; }
 
     /// <summary>
     /// List of resources that the given subject has access to

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/AMPartyService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/AMPartyService.cs
@@ -16,7 +16,7 @@ namespace Altinn.AccessManagement.Core.Services
         /// <inheritdoc />
         public async Task<MinimalParty> GetByOrgNo(Authorization.Api.Contracts.Register.OrganizationNumber orgNo, CancellationToken cancellationToken = default)
         {
-           return await _amPartyRepository.GetByOrgNo(orgNo, cancellationToken);
+            return await _amPartyRepository.GetByOrgNo(orgNo, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/AppsInstanceDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/AppsInstanceDelegationService.cs
@@ -227,7 +227,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
             });
         }
 
-        return await Task.FromResult(result);        
+        return await Task.FromResult(result);
     }
 
     private async Task<MinimalParty> GetMinimalParty(PartyUrn urn, CancellationToken cancellationToken)
@@ -254,7 +254,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
             // Create instance urn and use it for the internal processing but reset it for response as we should not change the contract
             MinimalParty party = await GetMinimalParty(request.From, cancellationToken);
 
-            if (party == null) 
+            if (party == null)
             {
                 ValidationErrorBuilder errors = default;
                 errors.Add(ValidationErrors.InvalidPartyUrn, "From");
@@ -296,7 +296,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
     public async Task<Result<List<AppsInstanceRevokeResponse>>> RevokeAll(AppsInstanceGetRequest request, CancellationToken cancellationToken = default)
     {
         ValidationErrorBuilder errors = default;
-        
+
         // Fetch rights valid for delegation
         ServiceResource resource = (await _resourceRegistryClient.GetResourceList(cancellationToken)).Find(r => r.Identifier == request.ResourceId);
         List<Right> delegableRights = null;
@@ -306,7 +306,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
             errors.Add(ValidationErrors.InvalidResource, "ResourceId");
         }
         else
-        {        
+        {
             RightsQuery rightsQueryForApp = new RightsQuery
             {
                 Type = RightsQueryType.AltinnApp,
@@ -333,7 +333,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
         // Fetch all existing delegations
         List<AppsInstanceDelegationResponse> delegations;
         try
-        { 
+        {
             delegations = await _pip.GetInstanceDelegations(request, cancellationToken);
         }
         catch (ValidationException)
@@ -358,7 +358,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
         if (rightsToRevoke.Count == 0)
         {
             errors.Add(ValidationErrors.MissingDelegableRights, "ResourceId");
-        
+
             if (errors.TryBuild(out errorResult))
             {
                 return errorResult;
@@ -523,7 +523,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
         {
             return errorResult;
         }
-        
+
         request.InstanceId = instanceId;
 
         AppsInstanceRevokeResponse result = new()
@@ -538,7 +538,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
         List<InstanceRightRevokeResult> rights = await RevokeRights(input.RulesToHandle, input.RightsAppCantHandle, cancellationToken);
         result.Rights = rights;
         result = RemoveInstanceIdFromResourceForRevokeResponse(result);
-        
+
         return result;
     }
 
@@ -722,10 +722,10 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
         }
 
         List<AppsInstanceDelegationResponse> result;
-        try 
+        try
         {
             result = await _pip.GetInstanceDelegations(request, cancellationToken);
-        } 
+        }
         catch (ValidationException)
         {
             errors.Add(ValidationErrors.InvalidInstanceId, "request.InstanceId");
@@ -780,7 +780,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
         }
 
         return input;
-    }    
+    }
 
     private static List<AppsInstanceDelegationResponse> RemoveInstanceIdFromResourceForDelegationResponseList(List<AppsInstanceDelegationResponse> input)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
@@ -302,7 +302,7 @@ namespace Altinn.AccessManagement.Core.Services
             if (altinn2ConsentRequest != null)
             {
                 ConsentRequest mappedConsentFromA2 = await MapA2ConsentToA3Consent(altinn2ConsentRequest, cancellationToken);
-                
+
                 start = _timeProvider.GetTimestamp();
                 Result<ConsentRequestDetailsWrapper> result = await CreateRequest(mappedConsentFromA2, mappedConsentFromA2.From, true, cancellationToken);
                 dur = _timeProvider.GetElapsedTime(start).TotalSeconds;
@@ -1072,7 +1072,7 @@ namespace Altinn.AccessManagement.Core.Services
             return result.Value;
         }
 
-        private List<ConsentRequestEvent> AddExpiredEventIfConsentIsExpired(List<ConsentRequestEvent> consentRequestEvents, DateTimeOffset validTo,  ConsentPartyUrn to)
+        private List<ConsentRequestEvent> AddExpiredEventIfConsentIsExpired(List<ConsentRequestEvent> consentRequestEvents, DateTimeOffset validTo, ConsentPartyUrn to)
         {
             if (validTo < _timeProvider.GetUtcNow() && !consentRequestEvents.Exists(r => r.EventType.Equals(ConsentRequestEventType.Expired)))
             {
@@ -1084,7 +1084,7 @@ namespace Altinn.AccessManagement.Core.Services
                 };
                 return [.. consentRequestEvents, newEvent];
             }
-            
+
             return consentRequestEvents;
         }
 
@@ -1138,7 +1138,7 @@ namespace Altinn.AccessManagement.Core.Services
                 else
                 {
                     resourceDetails = await _resourceRegistryClient.GetResources(cancellationToken, searchParam);
-                    
+
                     if (resourceDetails != null && resourceDetails.Count > 0)
                     {
                         _memoryCache.Set(cacheKey, resourceDetails, TimeSpan.FromHours(24));

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ContextRetrievalService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ContextRetrievalService.cs
@@ -215,7 +215,7 @@ public class ContextRetrievalService : IContextRetrievalService
         return parties;
     }
 
- /// <inheritdoc/>
+    /// <inheritdoc/>
     public async Task<Party> GetPartyForOrganization(string organizationNumber, CancellationToken cancellationToken = default)
     {
         string cacheKey = $"orgNo:{organizationNumber}";

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyAdministrationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyAdministrationPoint.cs
@@ -380,7 +380,7 @@ namespace Altinn.AccessManagement.Core.Services
                 catch (Exception)
                 {
                 }
-                
+
                 if (useEF)
                 {
                     validPath = DelegationHelper.TryGetNewDelegationPolicyPathFromInstanceRule(rules, out path);
@@ -1073,6 +1073,6 @@ namespace Altinn.AccessManagement.Core.Services
             return currentRules;
         }
 
-        
+
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs
@@ -313,7 +313,7 @@ namespace Altinn.AccessManagement.Core.Services
             {
                 throw new ValidationException($"Multiple from parties found for instance delegations: {string.Join(", ", fromParties)}");
             }
-            
+
             foreach (InstanceDelegationChange delegation in delegations)
             {
                 AppsInstanceDelegationResponse appsInstanceDelegationResponse = new AppsInstanceDelegationResponse
@@ -341,7 +341,7 @@ namespace Altinn.AccessManagement.Core.Services
             {
                 result.Add(GetInstanceRightDelegationResultFromPolicyRule(xacmlRule));
             }
-            
+
             return result;
         }
 
@@ -489,22 +489,22 @@ namespace Altinn.AccessManagement.Core.Services
         {
             IEnumerable<InstanceDelegationChange> instanceDelegations = await _delegationRepository.GetActiveInstanceDelegations(resourceIds, from, to, cancellationToken);
             return from InstanceDelegationChange instanceDelegation in instanceDelegations
-                    let delegationChange = new DelegationChange
-                    {
-                        ResourceId = instanceDelegation.ResourceId,
-                        InstanceId = instanceDelegation.InstanceId,
-                        FromUuidType = instanceDelegation.FromUuidType,
-                        FromUuid = instanceDelegation.FromUuid,
-                        ToUuidType = instanceDelegation.ToUuidType,
-                        ToUuid = instanceDelegation.ToUuid,
-                        PerformedByUuidType = instanceDelegation.PerformedByType,
-                        PerformedByUuid = instanceDelegation.PerformedBy,
-                        DelegationChangeType = instanceDelegation.DelegationChangeType,
-                        BlobStoragePolicyPath = instanceDelegation.BlobStoragePolicyPath,
-                        BlobStorageVersionId = instanceDelegation.BlobStorageVersionId,
-                        Created = instanceDelegation.Created
-                    }
-                    select delegationChange;
+                   let delegationChange = new DelegationChange
+                   {
+                       ResourceId = instanceDelegation.ResourceId,
+                       InstanceId = instanceDelegation.InstanceId,
+                       FromUuidType = instanceDelegation.FromUuidType,
+                       FromUuid = instanceDelegation.FromUuid,
+                       ToUuidType = instanceDelegation.ToUuidType,
+                       ToUuid = instanceDelegation.ToUuid,
+                       PerformedByUuidType = instanceDelegation.PerformedByType,
+                       PerformedByUuid = instanceDelegation.PerformedBy,
+                       DelegationChangeType = instanceDelegation.DelegationChangeType,
+                       BlobStoragePolicyPath = instanceDelegation.BlobStoragePolicyPath,
+                       BlobStorageVersionId = instanceDelegation.BlobStorageVersionId,
+                       Created = instanceDelegation.Created
+                   }
+                   select delegationChange;
         }
 
         private static List<Rule> GetRulesFromPolicyAndDelegationChange(ICollection<XacmlRule> xacmlRules, DelegationChange delegationChange)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
@@ -203,7 +203,7 @@ namespace Altinn.AccessManagement.Core.Services
                     DelegatedByUserId = performedBy.UserId,
                     DelegatedByPartyId = performedBy.PartyId
                 });
-            }            
+            }
 
             return rules;
         }
@@ -276,7 +276,7 @@ namespace Altinn.AccessManagement.Core.Services
             foreach (AttributeDto resource in rightDto.Resource)
             {
                 // Check if this is an app resource that needs splitting
-                if (resource.Type.Equals(AltinnXacmlConstants.MatchAttributeIdentifiers.ResourceRegistryAttribute, StringComparison.InvariantCultureIgnoreCase) 
+                if (resource.Type.Equals(AltinnXacmlConstants.MatchAttributeIdentifiers.ResourceRegistryAttribute, StringComparison.InvariantCultureIgnoreCase)
                     && DelegationHelper.IsAppResourceId(resource.Value, out string org, out string app))
                 {
                     // Split app resource into org and app URNs
@@ -329,7 +329,7 @@ namespace Altinn.AccessManagement.Core.Services
                     Id = AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute,
                     Value = entity.UserId.Value.ToString()
                 });
-            }            
+            }
             else if (entity.PartyId.HasValue) // Party
             {
                 matches.Add(new AttributeMatch
@@ -475,7 +475,7 @@ namespace Altinn.AccessManagement.Core.Services
                 }
 
                 if (partyIdentifier.Type != UuidType.NotSpecified)
-                { 
+                {
                     if (coveredByUuid != null)
                     {
                         coveredByUuid.Id = partyIdentifier.Type.EnumMemberAttributeValueOrName();
@@ -530,7 +530,7 @@ namespace Altinn.AccessManagement.Core.Services
                         {
                             rule.PerformedBy = [new AttributeMatch { Id = AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, Value = rule.DelegatedByPartyId.Value.ToString() }];
                         }
-                    }                    
+                    }
                 }
 
                 // Handle OfferedBy/From
@@ -549,13 +549,13 @@ namespace Altinn.AccessManagement.Core.Services
                         partyIds[rule.OfferedByPartyId] = partyIdentifier;
                         rule.OfferedByPartyType = partyIdentifier.Type;
                         rule.OfferedByPartyUuid = partyIdentifier.Uuid;
-                    }    
-                }                                
+                    }
+                }
             }
 
             return rules;
         }
-        
+
         /// <inheritdoc/>
         public async Task<List<Rule>> EnrichAndTryDeleteDelegationPolicyRules(List<RequestToDelete> rulesToDelete, CancellationToken cancellationToken = default)
         {
@@ -616,7 +616,7 @@ namespace Altinn.AccessManagement.Core.Services
                         if (userProfile != null)
                         {
                             partyIdentifier = DelegationHelper.GetUserUuidFromUserProfile(userProfile);
-                            userIds[userId] = partyIdentifier;                            
+                            userIds[userId] = partyIdentifier;
                         }
                         else
                         {
@@ -651,7 +651,7 @@ namespace Altinn.AccessManagement.Core.Services
                 }
 
                 if (partyIdentifier.Type != UuidType.NotSpecified)
-                {                
+                {
                     if (coveredByUuid != null)
                     {
                         coveredByUuid.Id = partyIdentifier.Type.EnumMemberAttributeValueOrName();
@@ -680,8 +680,8 @@ namespace Altinn.AccessManagement.Core.Services
                     else
                     {
                         request.PerformedBy = [new AttributeMatch { Id = AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, Value = request.DeletedByUserId.ToString() }];
-                    }                    
-                }                
+                    }
+                }
 
                 // Handle OfferedBy/From
                 if (partyIds.ContainsKey(request.PolicyMatch.OfferedByPartyId))
@@ -700,7 +700,7 @@ namespace Altinn.AccessManagement.Core.Services
                         request.PolicyMatch.FromUuidType = partyIdentifier.Type;
                         request.PolicyMatch.FromUuid = partyIdentifier.Uuid;
                     }
-                }                
+                }
             }
 
             return requestToDelete;
@@ -823,7 +823,7 @@ namespace Altinn.AccessManagement.Core.Services
 
             var fromAttribute = await _resolver.Resolve(delegation.From, [AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationUuid, AltinnXacmlConstants.MatchAttributeIdentifiers.PersonUuid], cancellationToken);
             var toAttribute = await _resolver.Resolve(delegation.To, BaseUrn.RevokeInternalToIds, cancellationToken);
-                        
+
             var to = FilterRequiredAttributeMatchesFromAttributeMatchList(toAttribute);
             DelegationHelper.TryGetUuidFromAttributeMatch(fromAttribute.ToList(), out Guid fromUuid, out UuidType fromUuidType);
 
@@ -866,12 +866,12 @@ namespace Altinn.AccessManagement.Core.Services
                 attributeMatchList.Add(new AttributeMatch(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, attributeMatches.First(p => p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute).Value));
                 userSet = true;
             }
-            
+
             if (attributeMatches.Any(p => p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute) && !userSet)
             {
                 attributeMatchList.Add(new AttributeMatch(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, attributeMatches.First(p => p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute).Value));
             }
-            
+
             if (attributeMatches.Any(p => p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.SystemUserUuid))
             {
                 attributeMatchList.Add(new AttributeMatch(AltinnXacmlConstants.MatchAttributeIdentifiers.SystemUserUuid, attributeMatches.First(p => p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.SystemUserUuid).Value));

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/Altinn2RightsClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/Altinn2RightsClient.cs
@@ -48,7 +48,7 @@ public class Altinn2RightsClient : IAltinn2RightsClient
     public async Task<DelegationCheckResponse> PostDelegationCheck(int authenticatedUserId, int reporteePartyId, string serviceCode, string serviceEditionCode)
     {
         UriBuilder uriBuilder = new UriBuilder($"{_sblBridgeSettings.BaseApiUrl}authorization/api/rights/delegation/userdelegationcheck?userId={authenticatedUserId}&partyId={reporteePartyId}&serviceCode={serviceCode}&serviceEditionCode={serviceEditionCode}");
-            
+
         HttpResponseMessage response = await _client.GetAsync(uriBuilder.Uri);
         string responseContent = await response.Content.ReadAsStringAsync();
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/PartiesClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/PartiesClient.cs
@@ -40,10 +40,10 @@ public class PartiesClient : IPartiesClient
     /// <param name="platformSettings">the platform setttings</param>
     /// <param name="accessTokenGenerator">An instance of the AccessTokenGenerator service.</param>
     public PartiesClient(
-        HttpClient httpClient, 
-        IOptions<SblBridgeSettings> sblBridgeSettings, 
-        ILogger<PartiesClient> logger, 
-        IHttpContextAccessor httpContextAccessor, 
+        HttpClient httpClient,
+        IOptions<SblBridgeSettings> sblBridgeSettings,
+        ILogger<PartiesClient> logger,
+        IHttpContextAccessor httpContextAccessor,
         IOptions<PlatformSettings> platformSettings,
         IAccessTokenGenerator accessTokenGenerator)
     {
@@ -74,7 +74,7 @@ public class PartiesClient : IPartiesClient
             {
                 return JsonSerializer.Deserialize<Party>(responseContent, _serializerOptions);
             }
-            
+
             _logger.LogError("AccessManagement // PartiesClient // GetPartyAsync // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
             return null;
         }
@@ -94,7 +94,7 @@ public class PartiesClient : IPartiesClient
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
             var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "access-management");
             StringContent requestBody = new StringContent(JsonSerializer.Serialize(partyIds), Encoding.UTF8, "application/json");
-            
+
             HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, requestBody, accessToken, cancellationToken);
             string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/ProfileClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/ProfileClient.cs
@@ -53,7 +53,7 @@ namespace Altinn.AccessManagement.Integration.Clients
 
             StringContent requestBody = new StringContent(JsonSerializer.Serialize(userProfileLookup), Encoding.UTF8, "application/json");
             HttpResponseMessage response = await _client.PostAsync(endpoint.Uri, requestBody, cancellationToken);
-            
+
             if (!response.IsSuccessStatusCode)
             {
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
@@ -211,6 +211,6 @@ namespace Altinn.AccessManagement.Integration.Clients
             {
                 throw new Exception($"Something went wrong when retrieving consent templates", ex);
             }
-        }        
+        }
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Configuration/PlatformSettings.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Configuration/PlatformSettings.cs
@@ -40,7 +40,7 @@
         /// Gets or sets the SubscriptionKeyHeaderName
         /// </summary>
         public string? SubscriptionKeyHeaderName { get; set; }
-        
+
         /// <summary>
         /// Endpoint for authentication
         /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Services/KeyVaultService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Services/KeyVaultService.cs
@@ -23,7 +23,7 @@ public class KeyVaultService : IKeyVaultService
         {
             if (certificateProperties.Enabled == true &&
                 (certificateProperties.ExpiresOn == null || certificateProperties.ExpiresOn >= DateTime.UtcNow))
-            {                    
+            {
                 SecretClient secretClient = new SecretClient(new Uri(vaultUri), new DefaultAzureCredential());
 
                 KeyVaultSecret secret = await secretClient.GetSecretAsync(certificateProperties.Name, certificateProperties.Version);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
@@ -307,7 +307,7 @@ namespace Altinn.AccessManagement.Persistence.Consent
                 await eventCommand.PrepareAsync(cancellationToken);
                 await eventCommand.ExecuteNonQueryAsync(cancellationToken);
             }
-            
+
             await tx.CommitAsync(cancellationToken);
 
             return await GetRequest(consentRequest.Id, cancellationToken);
@@ -586,9 +586,9 @@ namespace Altinn.AccessManagement.Persistence.Consent
 
             return consentContext;
         }
-        
+
         public async Task<Result<List<ConsentStatusChange>>> GetConsentStatusChangesForParty(Guid partyUuid, string? continuationToken, int pageSize, CancellationToken cancellationToken)
-        {          
+        {
             // Parse continuation token to get cursor UUID
             Guid cursorEventId = default;
             DateTimeOffset cursorCreated = default;
@@ -602,7 +602,7 @@ namespace Altinn.AccessManagement.Persistence.Consent
                     {
                         throw new FormatException("Invalid continuation token format.");
                     }
-                        
+
                     cursorCreated = DateTimeOffset.Parse(parts[0], null, DateTimeStyles.RoundtripKind);
                     cursorEventId = Guid.Parse(parts[1]);
                 }
@@ -613,7 +613,7 @@ namespace Altinn.AccessManagement.Persistence.Consent
             }
 
             var consentStatusChanges = new List<ConsentStatusChange>();
-            
+
             string consentChangesQuery = $@"WITH latest_events AS (
                                 SELECT
                                 ce.consenteventid,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/DelegationMetadataEF.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/DelegationMetadataEF.cs
@@ -114,19 +114,19 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
         {
             ToUuidType = ConvertEntityTypeToUuidType(assignmentInstance.Assignment.To.TypeId),
             ToUuid = assignmentInstance.Assignment.ToId,
-            
+
             PerformedBy = assignmentInstance.Audit_ChangedBy.ToString(),
             PerformedByType = UuidType.NotSpecified,
 
             FromUuid = assignmentInstance.Assignment.FromId,
             FromUuidType = ConvertEntityTypeToUuidType(assignmentInstance.Assignment.From.TypeId),
-            
+
             BlobStoragePolicyPath = assignmentInstance.PolicyPath,
             BlobStorageVersionId = assignmentInstance.PolicyVersion,
-            
+
             ResourceId = assignmentInstance.Resource.RefId,
             InstanceId = assignmentInstance.InstanceId,
-            
+
             InstanceDelegationMode = InstanceDelegationMode.ParallelSigning,
             InstanceDelegationChangeId = assignmentInstance.DelegationChangeId,
 
@@ -197,10 +197,10 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
 
     /// <inheritdoc/>
     public async Task<List<DelegationChange>> GetAllCurrentAppDelegationChanges(
-        List<int> offeredByPartyIds, 
-        List<string> altinnAppIds, 
-        List<int> coveredByPartyIds = null, 
-        List<int> coveredByUserIds = null, 
+        List<int> offeredByPartyIds,
+        List<string> altinnAppIds,
+        List<int> coveredByPartyIds = null,
+        List<int> coveredByUserIds = null,
         CancellationToken cancellationToken = default
         )
     {
@@ -237,10 +237,10 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
 
     /// <inheritdoc/>
     public async Task<List<DelegationChange>> GetAllCurrentAppDelegationChanges(
-        List<string> altinnAppIds, 
-        List<int> fromPartyIds, 
-        UuidType toUuidType, 
-        Guid toUuid, 
+        List<string> altinnAppIds,
+        List<int> fromPartyIds,
+        UuidType toUuidType,
+        Guid toUuid,
         CancellationToken cancellationToken = default
         )
     {
@@ -298,7 +298,7 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
         }
 
         var from = await DbContext.Entities.AsNoTracking().FirstOrDefaultAsync(t => t.PartyId == offeredByPartyId, cancellationToken);
-        
+
         if (from == null)
         {
             throw new Exception($"OfferedBy not found with partyId '{offeredByPartyId}'");
@@ -316,7 +316,7 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
             .WhereIf(toUuid.HasValue, t => t.Assignment.ToId == toUuid.Value)
             .SingleOrDefaultAsync(cancellationToken);
 
-        return result == null 
+        return result == null
             ? null
             : Convert(result);
     }
@@ -487,8 +487,8 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
         {
             return null;
         }
-            
-        return Convert(result);                
+
+        return Convert(result);
     }
 
     /// <inheritdoc />
@@ -575,7 +575,7 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
             }
 
             return dummyResultForRevokeLast; // Must emulate that a 'revoke last' row still exists, as it no longer exists after revoke last is performed.
-        }        
+        }
 
         return await GetAssignmentInstance(assignmentInstance.Id);
     }
@@ -672,7 +672,7 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
                 }
 
                 var assignmentInstance = await DbContext.AssignmentInstances.FirstOrDefaultAsync(t => t.AssignmentId == assignment.Id && t.ResourceId == resource.Id && t.InstanceId == policy.Rules.InstanceId, cancellationToken);
-                
+
                 if (assignmentInstance is null)
                 {
                     assignmentInstance = new AssignmentInstance()

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepo.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepo.cs
@@ -1810,8 +1810,8 @@ namespace Altinn.AccessManagement.Persistence
                 {
                     DelegationChangeId = await reader.GetFieldValueAsync<int>("delegationchangeid"),
                     DelegationChangeType = await reader.GetFieldValueAsync<DelegationChangeType>(DelegationChangeType),
-                    ResourceId = mapAppResourceId 
-                        ? MapAppIdToResourceId(await reader.GetFieldValueAsync<string>("altinnappid")) 
+                    ResourceId = mapAppResourceId
+                        ? MapAppIdToResourceId(await reader.GetFieldValueAsync<string>("altinnappid"))
                         : await reader.GetFieldValueAsync<string>("altinnappid"),
                     ResourceType = ResourceAttributeMatchType.AltinnAppId.ToString(),
                     OfferedByPartyId = await reader.GetFieldValueAsync<int>("offeredbypartyid"),

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
@@ -106,11 +106,11 @@ internal static partial class AccessManagementHost
             options.AppConnectionString = connectionStrings.AppSource;
             options.MigrationConnectionString = connectionStrings.MigrationSource;
             options.Source = appsettings.RunInitOnly ? SourceType.Migration : SourceType.App;
-            
+
             // Request
             options.AddOutboxHandler<RequestReviewedNotificationHandler>(RequestReviewedNotification.Handler);
             options.AddOutboxHandler<RequestPendingNotificationHandler>(RequestPendingNotification.Handler);
-            
+
             // Connections
             options.AddOutboxHandler<RightholderAddedNotificationHandler>(RightholderAddedNotification.Handler);
             options.AddOutboxHandler<RightholderRemovedNotificationHandler>(RightholderRemovedNotification.Handler);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/ResourceOwnerAPI/AppsInstanceDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/ResourceOwnerAPI/AppsInstanceDelegationController.cs
@@ -170,7 +170,7 @@ public class AppsInstanceDelegationController : ControllerBase
 
         AppsInstanceGetRequest request = new()
         {
-            InstanceDelegationSource = Core.Enums.InstanceDelegationSource.App,            
+            InstanceDelegationSource = Core.Enums.InstanceDelegationSource.App,
             PerformingResourceId = performer,
             ResourceId = resourceId,
             InstanceId = instanceId,
@@ -271,8 +271,8 @@ public class AppsInstanceDelegationController : ControllerBase
             return Forbid();
         }
 
-        AppsInstanceGetRequest request = new AppsInstanceGetRequest 
-        { 
+        AppsInstanceGetRequest request = new AppsInstanceGetRequest
+        {
             ResourceId = resourceId,
             InstanceId = instanceId,
             PerformingResourceId = performer,
@@ -291,7 +291,7 @@ public class AppsInstanceDelegationController : ControllerBase
 
         Paginated<AppsInstanceRevokeResponseDto> result = new(links, items);
 
-        return Ok(result);        
+        return Ok(result);
     }
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/ResourceOwnerAPI/ResourceOwnerAuthorizedPartiesController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/ResourceOwnerAPI/ResourceOwnerAuthorizedPartiesController.cs
@@ -87,7 +87,7 @@ public class ResourceOwnerAuthorizedPartiesController(
             if (orgCode != null)
             {
                 orgCode = orgCode.Trim().ToLower();
-                if (! await IsAuthorizedForOrgCode(orgCode, cancellationToken))
+                if (!await IsAuthorizedForOrgCode(orgCode, cancellationToken))
                 {
                     ModelState.AddModelError(orgCode, $"Authenticated service owner organization is not authorized/owner of org code: {orgCode}.");
                     return new ObjectResult(ProblemDetailsFactory.CreateValidationProblemDetails(HttpContext, ModelState));

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/RightsInternalController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/RightsInternalController.cs
@@ -577,9 +577,9 @@ namespace Altinn.AccessManagement.Controllers
                 }
 
                 // Delegation performed
-                return Created();                
+                return Created();
             }
-            catch (Exception ex) 
+            catch (Exception ex)
             {
                 _logger.LogError(StatusCodes.Status500InternalServerError, ex, "Internal exception occurred during Instance Right Import");
                 var problem = new ProblemDetails
@@ -589,7 +589,7 @@ namespace Altinn.AccessManagement.Controllers
                     Status = StatusCodes.Status500InternalServerError
                 };
                 return problem.ToActionResult();
-            }            
+            }
         }
 
         /// <summary>
@@ -640,5 +640,5 @@ namespace Altinn.AccessManagement.Controllers
                 return problem.ToActionResult();
             }
         }
-    }    
+    }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Enums/ResourceRegistry/ReferenceSourceExternal.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Enums/ResourceRegistry/ReferenceSourceExternal.cs
@@ -7,7 +7,7 @@ namespace Altinn.AccessManagement.Enums.ResourceRegistry
     /// </summary>
     public enum ReferenceSourceExternal : int
     {
-        [EnumMember(Value = "Default")]    
+        [EnumMember(Value = "Default")]
         Default = 0,
 
         [EnumMember(Value = "Altinn1")]

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Utilities/IdentifierUtil.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Utilities/IdentifierUtil.cs
@@ -12,12 +12,12 @@ public static class IdentifierUtil
 {
     private const string PersonHeaderTrigger = "person";
     private const string OrganizationHeaderTrigger = "organization";
-        
+
     /// <summary>
     /// Default HTTP header for SSN input
     /// </summary>
     public const string PersonHeader = "Altinn-Party-SocialSecurityNumber";
-        
+
     /// <summary>
     /// Default HTTP header for Organization number input
     /// </summary>
@@ -105,7 +105,7 @@ public static class IdentifierUtil
 
             return new AttributeMatch { Id = AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationNumberAttribute, Value = context.Request.Headers[OrganizationNumberHeader] };
         }
-            
+
         if (party.Equals(PersonHeaderTrigger))
         {
             if (!context.Request.Headers.ContainsKey(PersonHeader))
@@ -120,7 +120,7 @@ public static class IdentifierUtil
 
             return new AttributeMatch { Id = AltinnXacmlConstants.MatchAttributeIdentifiers.PersonId, Value = context.Request.Headers[PersonHeader] };
         }
-            
+
         if (int.TryParse(party, out int partyId) && partyId != 0)
         {
             return new AttributeMatch { Id = AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, Value = partyId.ToString() };

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Authorization/DefaultAuthorizationScopeProvider.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Authorization/DefaultAuthorizationScopeProvider.cs
@@ -8,7 +8,7 @@ namespace Altinn.AccessMgmt.Core.Authorization;
 /// <remarks>
 /// https://github.com/Altinn/altinn-authorization-utils/blob/main/src/Altinn.Authorization.ServiceDefaults/src/ServiceDefaults.Authorization/Scopes/DefaultAuthorizationScopeProvider.cs"
 /// </remarks>
-internal sealed class DefaultAuthorizationScopeProvider: IAuthorizationScopeProvider
+internal sealed class DefaultAuthorizationScopeProvider : IAuthorizationScopeProvider
 {
     /// <inheritdoc/>
     public IEnumerable<string> GetScopeStrings(AuthorizationHandlerContext context)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Constants/InstanceUrnConstants.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Constants/InstanceUrnConstants.cs
@@ -22,9 +22,9 @@ public static class InstanceUrnConstants
     public const string CorrespondencePrefix = "urn:altinn:correspondence-id:";
 
     /// <summary>
-/// URN prefix for Dialog instance identifiers.
-/// Format: urn:altinn:dialog-id:{id}
-/// </summary>
+    /// URN prefix for Dialog instance identifiers.
+    /// Format: urn:altinn:dialog-id:{id}
+    /// </summary>
     public const string DialogPrefix = "urn:altinn:dialog-id:";
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Extensions/ControllerExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Extensions/ControllerExtensions.cs
@@ -17,7 +17,7 @@ public static class ControllerExtensions
     public static string GetLanguageCode(this ControllerBase controller)
     {
         // First, try to get the language code set by TranslationMiddleware
-        if (controller.HttpContext.Items.TryGetValue(TranslationConstants.LanguageCodeKey, out var languageCode) 
+        if (controller.HttpContext.Items.TryGetValue(TranslationConstants.LanguageCodeKey, out var languageCode)
             && languageCode is string code && !string.IsNullOrEmpty(code))
         {
             return code;
@@ -37,7 +37,7 @@ public static class ControllerExtensions
                 return MapLanguageCode(firstLanguage);
             }
         }
-        
+
         return TranslationConstants.DefaultLanguageCode;
     }
 
@@ -56,7 +56,7 @@ public static class ControllerExtensions
             }
 
             return true; // Default to allowing partial translations
-        } 
+        }
         catch
         {
             return true;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Extensions/DeepTranslationExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Extensions/DeepTranslationExtensions.cs
@@ -66,7 +66,7 @@ public static class DeepTranslationExtensions
             var translated = await package.TranslateDeepAsync(translationService, languageCode, allowPartial);
             result.Add(translated);
         }
-        
+
         return result;
     }
 
@@ -101,7 +101,7 @@ public static class DeepTranslationExtensions
             {
                 // Translate package but avoid re-translating the area (circular reference)
                 var translatedPackage = await translationService.TranslateAsync(package, languageCode, allowPartial);
-                
+
                 // Translate nested Type
                 if (translatedPackage.Type != null)
                 {
@@ -143,7 +143,7 @@ public static class DeepTranslationExtensions
             var translated = await area.TranslateDeepAsync(translationService, languageCode, allowPartial);
             result.Add(translated);
         }
-        
+
         return result;
     }
 
@@ -193,7 +193,7 @@ public static class DeepTranslationExtensions
             var translated = await areaGroup.TranslateDeepAsync(translationService, languageCode, allowPartial);
             result.Add(translated);
         }
-        
+
         return result;
     }
 
@@ -249,7 +249,7 @@ public static class DeepTranslationExtensions
             var translated = await resource.TranslateDeepAsync(translationService, languageCode, allowPartial);
             result.Add(translated);
         }
-        
+
         return result;
     }
 
@@ -351,7 +351,7 @@ public static class DeepTranslationExtensions
             var translated = await role.TranslateDeepAsync(translationService, languageCode, allowPartial);
             result.Add(translated);
         }
-        
+
         return result;
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/AltinnRoleHostedServices.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/AltinnRoleHostedServices.cs
@@ -93,7 +93,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices
 
                     await SyncPrivateTaxAffairRoles(lease, cancellationToken);
                 }
-            
+
                 if (await _featureManager.IsEnabledAsync(AccessMgmtFeatureFlags.HostedServicesAltinnBankruptcyEstateRoleSync))
                 {
                     await using var lease = await _leaseService.TryAcquireNonBlocking("access_management_altinnbankruptcyestaterole_sync", cancellationToken);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/ConsentMigrationHostedService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/ConsentMigrationHostedService.cs
@@ -62,7 +62,7 @@ public partial class ConsentMigrationHostedService : BackgroundService
                 if (lease is null)
                 {
                     Log.LeaseUnavailable(_logger);
-                    
+
                     // Add jitter to avoid thundering herd when multiple pods retry simultaneously
                     var delayWithJitter = TimeSpan.FromMilliseconds(migrationSettings.EmptyFeedDelayMs) + RandomJitter();
                     await _timeProvider.Delay(delayWithJitter, stoppingToken);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AllAltinnRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AllAltinnRoleSyncService.cs
@@ -76,7 +76,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                     foreach (var item in page.Content.Data)
                     {
                         if (item.ToUserType != UserType.EnterpriseIdentified && item.RoleTypeCode == RoleConstants.Eckeyrole.Entity.Code)
-                        {                             
+                        {
                             // Skip ECKEYROLE for non-enterprise users
                             continue;
                         }
@@ -175,7 +175,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                     RoleId = role.Id,
                     Audit_ValidFrom = model.DelegationChangeDateTime?.UtcDateTime ?? DateTime.UtcNow
                 };
-                
+
                 AuditValues options = new AuditValues(model.PerformedByPartyUuid ?? model.PerformedByUserUuid ?? SystemEntityConstants.Altinn2RoleImportSystem, SystemEntityConstants.Altinn2RoleImportSystem, batchId, model.DelegationChangeDateTime ?? DateTimeOffset.UtcNow);
 
                 return (assignment, options);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnAdminRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnAdminRoleSyncService.cs
@@ -174,7 +174,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                     {
                         packages.Add("urn:altinn:accesspackage:tilgangsstyrer");
                     }
-                    
+
                     break;
                 case "APIADM":
                     packages.Add("urn:altinn:accesspackage:maskinporten-administrator");

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnBankruptcyEstateRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnBankruptcyEstateRoleSyncService.cs
@@ -35,7 +35,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
 
         public async Task SyncBankruptcyEstateRoles(ILease lease, CancellationToken cancellationToken)
         {
-            
+
             var leaseData = await lease.Get<AltinnBankruptcyEstateRoleLease>(cancellationToken);
             var adminDelegations = await _role.StreamRoles("13", leaseData.AltinnBankruptcyEstateRoleStreamNextPageLink, cancellationToken);
 
@@ -105,7 +105,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                     ErrorMessage = $"The delegation is missing ToUserPartyUuid so it is not a valid bankruptcy estate delegation {item.FromPartyUuid}, ToParty: {item.ToUserPartyUuid}, PackageUrns: {string.Join(", ", packageUrns)}"
                                 };
                                 await errorQueueService.AddErrorQueue(error, values, cancellationToken);
-                                continue;                                
+                                continue;
                             }
 
                             int revokes = await assignmentService.RevokeImportedAssignmentPackages(
@@ -140,7 +140,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                     ErrorItem = JsonSerializer.Serialize(item),
                                     ErrorMessage = $"The delegation is missing ToUserPartyUuid so it is not a valid admin delegation {item.FromPartyUuid}, ToParty: {item.ToUserPartyUuid}, PackageUrns: {string.Join(", ", packageUrns)}"
                                 };
-                                await errorQueueService.AddErrorQueue(error, values, cancellationToken);                                 
+                                await errorQueueService.AddErrorQueue(error, values, cancellationToken);
                                 continue;
                             }
 
@@ -155,7 +155,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                     ErrorMessage = $"Failed to import delegation for FromParty: {item.FromPartyUuid}, ToParty: {item.ToUserPartyUuid}, PackageUrns: {string.Join(", ", packageUrns)}"
                                 };
                                 await errorQueueService.AddErrorQueue(error, values, cancellationToken);
-                                continue;                                
+                                continue;
                             }
                         }
 
@@ -175,7 +175,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
         private List<string> GetBankruptcyEstatePackageFromRoleTypeCode(string roleTypeCode, CancellationToken cancellationToken = default)
         {
             List<string> packages = new List<string>();
-            
+
             switch (roleTypeCode.ToUpper())
             {
                 case "BOBEL":
@@ -183,7 +183,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                     break;
                 case "BOBES":
                     packages.Add(PackageConstants.BankruptcyEstateWriteAccess.Entity.Urn);
-                    break;                
+                    break;
             }
 
             return packages;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnClientRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnClientRoleSyncService.cs
@@ -42,7 +42,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
         {
             var leaseData = await lease.Get<AltinnClientRoleLease>(cancellationToken);
             var clientDelegations = await _role.StreamRoles("12", leaseData.AltinnClientRoleStreamNextPageLink, cancellationToken);
-            
+
             await foreach (var page in clientDelegations)
             {
                 if (cancellationToken.IsCancellationRequested)
@@ -67,7 +67,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                         // Do not process client roles for EC-Users
                         if (item.ToUserType == UserType.EnterpriseIdentified)
                         {
-                           continue;
+                            continue;
                         }
 
                         await using var scope = _serviceProivider.CreateAsyncScope();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/PartySyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/PartySyncService.cs
@@ -145,7 +145,7 @@ public class PartySyncService : BaseSyncService, IPartySyncService
                 {
                     foreach (Guid refId in seenDeadPeople)
                     {
-                        await assignmentService.ClearAssignmentsInAfterLife(refId, options,  cancellationToken);
+                        await assignmentService.ClearAssignmentsInAfterLife(refId, options, cancellationToken);
                     }
                 }
 
@@ -160,7 +160,7 @@ public class PartySyncService : BaseSyncService, IPartySyncService
                 }
 
                 var mergedEntities = await ingestService.MergeTempData<Entity>(batchIdEntity, options, matchColumns: ["id"], ignoreColumnsToUpdate: ["parentid"], cancellationToken: cancellationToken);
-                int mergedAssignments = await ingestService.MergeTempData<Assignment>(batchIdAssignment, options, matchColumns: ["fromid","toid","roleid"], ignoreColumnsToUpdate: ["id", "audit_validfrom"], cancellationToken: cancellationToken);
+                int mergedAssignments = await ingestService.MergeTempData<Assignment>(batchIdAssignment, options, matchColumns: ["fromid", "toid", "roleid"], ignoreColumnsToUpdate: ["id", "audit_validfrom"], cancellationToken: cancellationToken);
 
                 _logger.LogInformation("Merge complete: Entity ({0}/{1})", mergedEntities, ingestedEntities);
                 return mergedEntities;
@@ -260,7 +260,7 @@ public class PartySyncService : BaseSyncService, IPartySyncService
                 { IsNull: true } => EntityVariantConstants.SI,
                 { IsUnset: true } => throw new UnreachableException("Missing selfidentfiedUserType from register. Should never happen."),
                 { Value.IsUnknown: true } => throw new InvalidOperationException("..."),
-                { Value.Value: SelfIdentifiedUserType rrr } => rrr switch 
+                { Value.Value: SelfIdentifiedUserType rrr } => rrr switch
                 {
                     SelfIdentifiedUserType.Legacy => EntityVariantConstants.SI,
                     SelfIdentifiedUserType.Educational => EntityVariantConstants.SI_EDU,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/PrivateTaxAffairRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/PrivateTaxAffairRoleSyncService.cs
@@ -116,7 +116,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                     ErrorMessage = $"Failed to delete assignmentpackages for FromParty: {item.FromPartyUuid}, ToParty: {item.ToUserPartyUuid}, PackageUrns: {string.Join(", ", packageUrns)}"
                                 };
                                 await errorQueueService.AddErrorQueue(error, values, cancellationToken);
-                                continue;                                
+                                continue;
                             }
                         }
                         else
@@ -133,7 +133,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                 await errorQueueService.AddErrorQueue(error, values, cancellationToken);
                                 continue;
                             }
-                            
+
                             if (item.ToUserPartyUuid == null)
                             {
                                 ErrorQueue error = new ErrorQueue

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/RoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/RoleSyncService.cs
@@ -123,7 +123,7 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
                 var result = 0;
                 result += await SetParents(appDbContextFactory, addParent, cancellationToken);
                 result += await IngestAssigments(ingestService, addAssignments, options, cancellationToken);
-                
+
                 result += await RemoveParents(appDbContextFactory, removeParent, cancellationToken);
                 result += await RemoveAssignments(appDbContextFactory, removeAssignments, cancellationToken);
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleAppRightSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleAppRightSyncService.cs
@@ -281,6 +281,6 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                     await errorQueueService.UpdateErrorMessage(item.Id, values, errorMessage, cancellationToken);
                 }
             }
-        }        
+        }
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleInstanceRightSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleInstanceRightSyncService.cs
@@ -127,7 +127,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                     };
 
                                     await errorQueueService.AddErrorQueue(error, values, cancellationToken);
-                                    continue;                                    
+                                    continue;
                                 }
                             }
                             else
@@ -155,7 +155,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                     };
 
                                     await errorQueueService.AddErrorQueue(error, values, cancellationToken);
-                                    continue;                                    
+                                    continue;
                                 }
                             }
 
@@ -280,7 +280,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                         if (adds == 0)
                         {
                             await errorQueueService.UpdateErrorMessage(item.Id, values, $"Failed to import delegation for FromParty: {element.FromUuid}, ToParty: {element.ToUuid}, Resource: {element.ResourceId}, Instance: {element.InstanceId}", cancellationToken);
-                            continue;                            
+                            continue;
                         }
                     }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleResourceRegistryRightSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleResourceRegistryRightSyncService.cs
@@ -68,7 +68,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                         try
                         {
                             await using var scope = _serviceProvider.CreateAsyncScope();
-                            IAssignmentService assignmentService = scope.ServiceProvider.GetRequiredService<IAssignmentService>();                            
+                            IAssignmentService assignmentService = scope.ServiceProvider.GetRequiredService<IAssignmentService>();
                             IRightImportProgressService rightImportProgressService = scope.ServiceProvider.GetRequiredService<IRightImportProgressService>();
 
                             bool alreadyProcessed = await rightImportProgressService.IsImportAlreadyProcessed(item.ResourceRegistryDelegationChangeId, "ResourceRegistry", cancellationToken);
@@ -98,7 +98,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                 SystemEntityConstants.SingleRightImportSystem.Id,
                                 batchId.ToString(),
                                 item.Created?.ToUniversalTime() ?? DateTime.UtcNow);
-                        
+
                             if (item.DelegationChangeType == AccessManagement.Core.Models.DelegationChangeType.RevokeLast)
                             {
                                 int revokes = await assignmentService.RevokeImportedAssignmentResource(
@@ -175,7 +175,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                             {
                                 _logger.LogError(ex, "Error processing single resource registry right delegation from {FromParty} to {ToParty} for resource {ResourceId}", item.FromUuid, item.ToUuid, item.ResourceId);
                                 throw;
-                            }                                
+                            }
                         }
                     }
                 }
@@ -186,7 +186,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                 }
 
                 await lease.Update<SingleResourceRegistryRightLease>(d => d.SingleResourceRegistryRightStreamNextPageLink = page.Content.Links.Next, cancellationToken);
-            }            
+            }
         }
 
         public async Task SyncFailedSingleResourceRegistryRights(CancellationToken cancellationToken)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Notifications/RightholderAddedNotification.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Notifications/RightholderAddedNotification.cs
@@ -123,7 +123,7 @@ public static class RightholderAddedNotification
         var processAfter = DateTime.UtcNow.Add(TimeSpan.FromSeconds(notifyInSeconds));
         msg.Schedule = processAfter;
         msg.Timeout = TimeSpan.FromMinutes(1);
-        
+
         return new()
         {
             FromId = fromId,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AssignmentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AssignmentService.cs
@@ -176,7 +176,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         }
 
         // Fetch client assignments
-        var clientAssignmentResult = 
+        var clientAssignmentResult =
             await db.Assignments.AsNoTracking()
                 .Include(t => t.From)
                 .Where(t => t.ToId == toId && filterRoleIds.Contains(t.RoleId))
@@ -315,7 +315,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         var result = await db.Assignments.AsNoTracking()
             .Where(t => t.FromId == fromId && t.RoleId == roleResult.First().Id)
             .ToListAsync(cancellationToken);
-        
+
         if (result == null)
         {
             return new List<Assignment>();
@@ -407,10 +407,10 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
             {
                 AssignmentId = assignmentId,
                 PackageId = packageId
-            }, 
+            },
             cancellationToken
             );
-        
+
         var result = await db.SaveChangesAsync(cancellationToken);
         if (result == 0)
         {
@@ -438,7 +438,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         {
             throw new Exception(string.Format("User '{0}' does not have resource '{1}' for '{2}'", user.Name, resource.Name, assignment.FromId));
         }
-       
+
         db.AssignmentResources.Add(new AssignmentResource()
         {
             Id = Guid.CreateVersion7(),
@@ -614,7 +614,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         var resource = await db.Resources.AsNoTracking().SingleAsync(t => t.Id == resourceId, cancellationToken);
 
         var res = await db.AssignmentInstances.AsTracking().FirstOrDefaultAsync(t => t.AssignmentId == assignmentId && t.ResourceId == resource.Id && t.InstanceId == instanceId, cancellationToken);
-        
+
         if (res != null)
         {
             res.PolicyPath = policyPath;
@@ -766,7 +766,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
 
         var fromEntity = await db.Entities.FirstOrDefaultAsync(t => t.Id == fromEntityId, cancellationToken);
         var toEntity = await db.Entities.FirstOrDefaultAsync(t => t.Id == toEntityId, cancellationToken);
-        
+
         if (toEntity is null || fromEntity is null)
         {
             return null;
@@ -787,7 +787,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
                 return errorResult;
             }
         }
-        
+
         var existingAssignment = await GetAssignment(fromEntityId, toEntityId, role.Id, cancellationToken: cancellationToken);
         if (existingAssignment == null)
         {
@@ -1026,7 +1026,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
             RoleId = role.Id,
             Audit_ValidFrom = audit?.ValidFrom ?? DateTimeOffset.UtcNow,
         };
-        
+
         await db.Assignments.AddAsync(assignment, cancellationToken);
         int result;
 
@@ -1409,7 +1409,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
             {
                 db.Assignments.Remove(assignment);
                 await db.SaveChangesAsync(audit, cancellationToken);
-            }   
+            }
         }
         finally
         {
@@ -1711,7 +1711,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         catch (Exception)
         {
         }
-        
+
         if (newPath == null)
         {
             throw new InvalidOperationException($"Failed to generate new policy path for instance assignment. fromId: {fromId}, toId: {toId}, resourceName: {resourceName}, instanceId: {instanceId}, partyId: {partyId}");
@@ -1742,7 +1742,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
                 using (MemoryStream emptyStream = new MemoryStream())
                 {
                     await newPolicyClient.WritePolicyAsync(emptyStream, cancellationToken);
-                }                
+                }
             }
 
             newLeaseId = await newPolicyClient.TryAcquireBlobLease(cancellationToken);
@@ -1788,7 +1788,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
             {
                 await originalPolicyClient.ReleaseBlobLease(originalLeaseId, cancellationToken);
             }
-        }        
+        }
     }
 
     /// <inheritdoc />

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -321,7 +321,7 @@ public class AuthorizedPartiesServiceEf(
             a2Task = Task.Run(async () =>
             {
                 var a2AuthorizedParties = await altinnRolesClient.GetAuthorizedPartiesWithRoles(userSubject.UserId.Value, filter.IncludePartiesViaKeyRoles == AuthorizedPartiesIncludeFilter.True, cancellationToken);
-                
+
                 if (filter.PartyFilter?.Count > 0)
                 {
                     a2AuthorizedParties = GetFilteredA2Parties(a2AuthorizedParties, filter);
@@ -669,7 +669,7 @@ public class AuthorizedPartiesServiceEf(
                 {
                     continue;
                 }
-                
+
                 subunits.Add(subunit);
             }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
@@ -29,14 +29,14 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
             .FirstOrDefaultAsync(ct);
 
     /// <inheritdoc/>
-    public async Task<Entity?> GetEntityByOrganizationId(string organizationId, CancellationToken ct = default) => 
+    public async Task<Entity?> GetEntityByOrganizationId(string organizationId, CancellationToken ct = default) =>
         await db.Entities
             .AsNoTracking()
             .Where(e => e.OrganizationIdentifier == organizationId)
             .FirstOrDefaultAsync(ct);
 
     /// <inheritdoc/>
-    public async Task<Entity?> GetEntityByPersonId(string personId, CancellationToken ct = default) => 
+    public async Task<Entity?> GetEntityByPersonId(string personId, CancellationToken ct = default) =>
         await db.Entities
             .AsNoTracking()
             .Where(e => e.PersonIdentifier == personId)
@@ -181,7 +181,7 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
             .Select(rr => new { rr.Role.Code, rr.Role.LegacyCode })
             .Distinct()
             .ToListAsync(ct);
-        
+
         return results.SelectMany(r => new[] { r.Code, r.LegacyCode })
             .Where(code => !string.IsNullOrEmpty(code))
             .Distinct()

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
@@ -2379,7 +2379,7 @@ public partial class ConnectionService
         {
             return false;
         }
-        
+
         // Remove and save revoked assignment
         dbContext.Remove(existingAssignment);
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IAssignmentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IAssignmentService.cs
@@ -101,7 +101,7 @@ public interface IAssignmentService
     /// </summary>
     /// <returns></returns>
     Task<bool> RemoveAssignmentPackage(Guid userId, Guid assignmentId, Guid packageId, CancellationToken cancellationToken = default);
-   
+
     /// <summary>
     /// Adds a resource to the delegation
     /// </summary>
@@ -182,7 +182,7 @@ public interface IAssignmentService
     /// </summary>
     /// <returns></returns>
     Task<IEnumerable<AssignmentInstance>> GetAssignmentInstances(Guid assignmentId, Guid resourceId, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Revokes access to an imported assignment resource for a specified from, to and audit info.
     /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
@@ -149,11 +149,11 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
             {
                 DelegationId = delegationId,
                 ResourceId = resourceId
-            }, 
+            },
             cancellationToken
         );
         var result = await db.SaveChangesAsync(cancellationToken);
-        
+
         return result > 0;
     }
 
@@ -208,7 +208,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
     private async Task<int> RevokeImportedClientDelegations(ImportClientDelegationRequestDto request, Entity client, Entity facilitator, AuditValues audit, bool onlyRemoveA2Packages = true, CancellationToken cancellationToken = default)
     {
         int packagesRevoked = 0;
-        
+
         // Find Agent Role
         var agentRole = await db.Roles.AsNoTracking().FirstOrDefaultAsync(t => string.Equals(t.Code.ToLower(), request.AgentRole.ToLower()), cancellationToken) ?? throw new Exception(string.Format("Role not found '{0}'", request.AgentRole));
 
@@ -275,20 +275,20 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
                 await assignmentService.DeleteAssignment(agentAssignment.Id, false, audit, cancellationToken);
             }
         }
-        
+
         return packagesRevoked;
     }
 
     private async Task<bool> RevokeDelegationPackage(Guid delegationId, Guid packageId, AuditValues audit, bool onlyRemoveA2, CancellationToken cancellationToken = default)
     {
         DelegationPackage delegationPackage = null;
-        
+
         delegationPackage = await db.DelegationPackages
             .AsTracking()
             .Where(t => t.DelegationId == delegationId && t.PackageId == packageId)
             .Where(t => !onlyRemoveA2 || t.Audit_ChangedBySystem == SystemEntityConstants.Altinn2RoleImportSystem.Id) // Remove only A2 packages if flag is set
             .FirstOrDefaultAsync(cancellationToken);
-        
+
         if (delegationPackage != null)
         {
             db.DelegationPackages.Remove(delegationPackage);
@@ -538,7 +538,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
                 },
                 cancellationToken
             );
-            
+
             if (audit == null)
             {
                 await db.SaveChangesAsync(cancellationToken);
@@ -623,7 +623,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
         else
         {
             var roleProvider = await db.Providers.AsNoTracking().FirstOrDefaultAsync(t => t.Id == role.ProviderId);
-            
+
             // Get system from token
             if (roleProvider.Code != "sys-altinn3")
             {
@@ -632,5 +632,5 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
 
             return await assignmentService.GetOrCreateAssignment(from.Id, to.Id, role.Id, audit, cancellationToken);
         }
-    }    
+    }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/EntityService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/EntityService.cs
@@ -88,7 +88,7 @@ public class EntityService : IEntityService
             .FirstOrDefaultAsync(cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<Entity> GetByPersNo(string persNo, CancellationToken cancellationToken = default) => await 
+    public async Task<Entity> GetByPersNo(string persNo, CancellationToken cancellationToken = default) => await
         Db.Entities
             .AsNoTracking()
             .Where(e => e.PersonIdentifier == persNo)
@@ -100,7 +100,7 @@ public class EntityService : IEntityService
             .AsNoTracking()
             .Where(e => e.PartyId == partyId)
             .FirstOrDefaultAsync(ct);
-    
+
     /// <inheritdoc/>
     public async Task<Entity> GetByPartyId(string partyId, CancellationToken cancellationToken = default)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ErrorQueueService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ErrorQueueService.cs
@@ -23,7 +23,7 @@ namespace Altinn.AccessMgmt.Core.Services
             .Where(t => t.OriginType == type && t.ReProcess && !t.Processed)
             .OrderBy(t => t.Id)
             .ToListAsync(cancellationToken);
-            
+
             return items;
         }
 
@@ -39,7 +39,7 @@ namespace Altinn.AccessMgmt.Core.Services
 
             var result = await db.SaveChangesAsync(values, cancellationToken);
 
-            return result > 0;            
+            return result > 0;
         }
 
         /// <inheritdoc />

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -68,14 +68,14 @@ public class PackageService : IPackageService
         if (searchInResources)
         {
             foreach (var resource in package.Resources.Where(t => t.Name.Contains(term, Ic)))
-            {                
+            {
                 totalScore += 2;
                 fields.Add(new SearchField
                 {
                     Field = "resources.name",
                     Value = resource.Name,
                     Score = 2,
-                });   
+                });
             }
         }
 
@@ -125,13 +125,13 @@ public class PackageService : IPackageService
             .Add(pkg => pkg.Name, 2.0, FuzzynessLevel.High)
             .Add(pkg => pkg.Description, 0.8, FuzzynessLevel.Low)
             .Add(pkg => pkg.Area.Name, 1.5, FuzzynessLevel.Medium);
-            ////.Add(pkg => pkg.Area.Group.Name, 1.3, FuzzynessLevel.Medium);
+        ////.Add(pkg => pkg.Area.Group.Name, 1.3, FuzzynessLevel.Medium);
 
         if (searchInResources)
         {
             builder
                 .AddCollection(pkg => pkg.Resources, r => r.Name, 1.2, FuzzynessLevel.High, detailed);
-                ////.AddCollection(pkg => pkg.Resources, r => r.Description, 0.7, FuzzynessLevel.Low, detailed);
+            ////.AddCollection(pkg => pkg.Resources, r => r.Description, 0.7, FuzzynessLevel.Low, detailed);
         }
 
         var results = Utils.FuzzySearch.PerformFuzzySearch(data, term, builder);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ProviderService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ProviderService.cs
@@ -26,7 +26,7 @@ public class ProviderService : IProviderService
         {
             throw new ArgumentException("Organization ID cannot be null or empty.", nameof(organizationId));
         }
-        
+
         return await Db.Providers.AsNoTracking().SingleOrDefaultAsync(p => p.RefId == organizationId, cancellationToken);
     }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/RequestService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/RequestService.cs
@@ -31,7 +31,7 @@ public class RequestService(AppDbContext db, IOptions<CoreAppsettings> appsettin
             .Include(r => r.Resource)
             .FirstOrDefaultAsync(t => t.Id == requestId, ct);
 
-        if (requestResource != null)    
+        if (requestResource != null)
         {
             return DtoMapper.Convert(requestResource);
         }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/RightImportProgressService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/RightImportProgressService.cs
@@ -27,7 +27,7 @@ namespace Altinn.AccessMgmt.Core.Services
 
             db.RightImportProgress.Add(processed);
             var res = await db.SaveChangesAsync(audit, cancellationToken);
-            return res > 0; 
+            return res > 0;
         }
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/RoleService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/RoleService.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Altinn.AccessMgmt.Core.Services;
 
 /// <inheritdoc />
-public class RoleService: IRoleService
+public class RoleService : IRoleService
 {
     public RoleService(AppDbContext appDbContext)
     {
@@ -114,7 +114,7 @@ public class RoleService: IRoleService
         {
             return roleResources;
         }
-        
+
         return roleResources.Concat(packageResources).DistinctBy(t => t.Id);
     }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ServiceOwnerConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ServiceOwnerConnectionService.cs
@@ -127,7 +127,7 @@ namespace Altinn.AccessMgmt.Core.Services
 
             // Remove assignment if we now deleted the last connection to the assignment.
             await RemoveAssignment(assignment, false, cancellationToken);
-            
+
             return true;
         }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Helper/DelegationCheckHelper.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Helper/DelegationCheckHelper.cs
@@ -91,7 +91,7 @@ namespace Altinn.AccessMgmt.Core.Utils.Helper
                     current.ResourceAllowAccess = [];
 
                     result.Add(current);
-                }                
+                }
             }
 
             return result;
@@ -354,7 +354,7 @@ namespace Altinn.AccessMgmt.Core.Utils.Helper
                 else if (urn.StartsWith(AltinnXacmlConstants.MatchAttributeIdentifiers.AccessPackageAttribute))
                 {
                     result.Add(urn);
-                }                
+                }
             }
 
             return result;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/IngestService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/IngestService.cs
@@ -11,7 +11,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Utils;
 public class IngestService : IIngestService
 {
     public AppDbContext DbContext { get; set; }
-    
+
     public IngestService(AppDbContext dbContext)
     {
         DbContext = dbContext;
@@ -119,7 +119,7 @@ public class IngestService : IIngestService
             sb.AppendLine($"WHEN MATCHED AND ({mergeUpdateUnMatchStatement}) THEN ");
             sb.AppendLine($"UPDATE SET {mergeUpdateStatement}");
         }
-        
+
         sb.AppendLine($"WHEN NOT MATCHED THEN ");
         //// sb.AppendLine($"INSERT ({insertColumns}) VALUES ({insertValues});");
         sb.AppendLine($"INSERT ({insertColumns},audit_changedby,audit_changedbysystem,audit_changeoperation) VALUES ({insertValues},'{auditValues.ChangedBy}','{auditValues.ChangedBySystem}','{auditValues.OperationId}');");
@@ -216,25 +216,25 @@ public class IngestService : IIngestService
         var table = GetTableName<T>(entityModel);
 
         var entityTypes = entityModel.GetEntityTypes();
-        if (entityTypes is null || !entityTypes.Any()) 
-        { 
-            return null; 
+        if (entityTypes is null || !entityTypes.Any())
+        {
+            return null;
         }
 
         var et = entityTypes.FirstOrDefault(x => x.GetTableName() == table.TableName && x.GetSchema() == BaseConfiguration.BaseSchema);
         var storeObject = StoreObjectIdentifier.Table(table.TableName, BaseConfiguration.BaseSchema);
 
-        if (et is null) 
-        { 
-            return null; 
+        if (et is null)
+        {
+            return null;
         }
 
         return et.GetProperties()
             .Where(n => (!n.Name.StartsWith("audit_", StringComparison.OrdinalIgnoreCase)) || n.Name.Equals("audit_validfrom", StringComparison.OrdinalIgnoreCase))
-            .Select(p => new IngestColumnDefinition() 
-            { 
-                Name = p.GetColumnName(storeObject), 
-                Property = p.PropertyInfo, 
+            .Select(p => new IngestColumnDefinition()
+            {
+                Name = p.GetColumnName(storeObject),
+                Property = p.PropertyInfo,
                 DbTypeName = p.GetColumnType(),
                 IsFK = p.IsForeignKey(),
                 IsPK = p.IsPrimaryKey()
@@ -247,7 +247,7 @@ public class IngestService : IIngestService
     {
         return (typeof(T).Name.ToLower(), BaseConfiguration.BaseSchema);
     }
-    
+
     private static string GetAuditVariables(AuditValues auditValues)
     {
         return string.Format("SET LOCAL app.changed_by = '{0}'; SET LOCAL app.changed_by_system = '{1}'; SET LOCAL app.change_operation_id = '{2}';", auditValues.ChangedBy, auditValues.ChangedBySystem, auditValues.OperationId);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/QueryWrapper.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/QueryWrapper.cs
@@ -7,8 +7,8 @@ internal static class QueryWrapper
     public static QueryResponse<T> WrapQueryResponse<T>(IEnumerable<T> data)
     {
         var resultCount = data.Count();
-        return new QueryResponse<T> 
-        { 
+        return new QueryResponse<T>
+        {
             Data = data,
             Page = new QueryPageInfo()
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/TranslationMiddleware.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/TranslationMiddleware.cs
@@ -50,7 +50,7 @@ public class TranslationMiddleware
         }
 
         var languages = ParseAcceptLanguageHeader(acceptLanguage.ToString());
-        
+
         // Try to normalize each language code in order of preference
         foreach (var lang in languages)
         {
@@ -73,7 +73,7 @@ public class TranslationMiddleware
         var languages = new List<(string Language, double Quality)>();
 
         var parts = acceptLanguageHeader.Split(',', StringSplitOptions.RemoveEmptyEntries);
-        
+
         foreach (var part in parts)
         {
             var segments = part.Trim().Split(';');
@@ -145,7 +145,7 @@ public class TranslationMiddleware
         }
 
         var value = headerValue.ToString().ToLowerInvariant();
-        
+
         return value switch
         {
             "true" or "1" or "yes" => true,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/EntityTypeValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/EntityTypeValidation.cs
@@ -28,7 +28,7 @@ public static class EntityTypeValidation
         {
             entityTypeName = e.Entity.Name;
         }
-        
+
         return (ref ValidationErrorBuilder errors) => errors.Add(ValidationErrors.DisallowedEntityType, $"QUERY/{paramName}", [new("type", $"Got '{entityTypeName}', expected one of: '{allowedEntityTypes}'.")]);
     };
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/RoleValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Validation/RoleValidation.cs
@@ -12,7 +12,7 @@ public static class RoleValidation
     internal static RuleExpression RoleExists(Role party, string paramName) => () =>
     {
         if (party is { })
-        { 
+        {
             return null;
         }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/Definitions/DbCrossRelationDefinition.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/Definitions/DbCrossRelationDefinition.cs
@@ -52,11 +52,11 @@ public class DbCrossRelationDefinition
     public DbCrossRelationDefinition(
         Type crossType,
         Type crossExtendedType,
-        Type AType, 
-        string AIdentityProperty, 
+        Type AType,
+        string AIdentityProperty,
         string AReferenceProperty,
-        Type BType, 
-        string BIdentityProperty, 
+        Type BType,
+        string BIdentityProperty,
         string BReferenceProperty)
     {
         this.CrossType = crossType;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/Definitions/DbDefinition.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/Definitions/DbDefinition.cs
@@ -91,20 +91,20 @@ public class DbDefinition(Type type)
 /// <summary>
 /// Type of definition
 /// </summary>
-public enum DbDefinitionType 
+public enum DbDefinitionType
 {
     /// <summary>
     /// Standard database table
     /// </summary>
-    Table, 
+    Table,
 
     /// <summary>
     /// Database view. Query contains create view script
     /// </summary>
-    View, 
+    View,
 
     /// <summary>
     /// Query to be run, Query contains query
     /// </summary>
-    Query 
+    Query
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/Models/QueryResponse.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/Models/QueryResponse.cs
@@ -12,7 +12,7 @@ public class QueryResponse<T> : IEnumerable<T>
     /// Rows converted to objects
     /// </summary>
     public IEnumerable<T> Data { get; set; }
-    
+
     /// <summary>
     /// Page information
     /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/QueryBuilders/PostgresQueryBuilder.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/QueryBuilders/PostgresQueryBuilder.cs
@@ -891,8 +891,8 @@ public class PostgresQueryBuilder : IDbQueryBuilder
             string idxQuery =
                 $"CREATE UNIQUE INDEX IF NOT EXISTS {idxName}" +
                 $" ON {tableName} ({columnsList})" +
-                $"{(constraint.IncludedProperties.Any() 
-                    ? $" INCLUDE ({string.Join(',', constraint.IncludedProperties.Keys)})" 
+                $"{(constraint.IncludedProperties.Any()
+                    ? $" INCLUDE ({string.Join(',', constraint.IncludedProperties.Keys)})"
                     : string.Empty)}" +
                 $" WHERE {whereClause};";
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/Services/IMigrationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence.Core/Services/IMigrationService.cs
@@ -34,7 +34,7 @@ public interface IMigrationService
     /// </summary>
     /// <returns></returns>
     bool NeedAnyMigration(Dictionary<Type, List<string>> typeKeys);
-    
+
     /// <summary>
     /// Check if any key for type is needed
     /// </summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Data/DbDataMigrationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Data/DbDataMigrationService.cs
@@ -844,7 +844,7 @@ public class DbDataMigrationService(
 
             new RoleLookup() { RoleId = roles.First(t => t.Code == "privatperson").Id, Key = "Urn", Value = "urn:altinn:role:privatperson" },
             new RoleLookup() { RoleId = roles.First(t => t.Code == "selvregistrert").Id, Key = "Urn", Value = "urn:altinn:role:selvregistrert" },
-            
+
             new RoleLookup() { RoleId = roles.First(t => t.Code == "A0212").Id, Key = "Urn", Value = "urn:altinn:rolecode:A0212" },
             new RoleLookup() { RoleId = roles.First(t => t.Code == "A0236").Id, Key = "Urn", Value = "urn:altinn:rolecode:A0236" },
             new RoleLookup() { RoleId = roles.First(t => t.Code == "A0237").Id, Key = "Urn", Value = "urn:altinn:rolecode:A0237" },
@@ -957,7 +957,7 @@ public class DbDataMigrationService(
 
             new RoleLookup() { RoleId = roles.First(t => t.Code == "privatperson").Id, Key = "LegacyCode", Value = "PRIV" },
             new RoleLookup() { RoleId = roles.First(t => t.Code == "selvregistrert").Id, Key = "LegacyCode", Value = "SELN" },
-            
+
             new RoleLookup() { RoleId = roles.First(t => t.Code == "A0212").Id, Key = "LegacyCode", Value = "A0212" },
             new RoleLookup() { RoleId = roles.First(t => t.Code == "A0236").Id, Key = "LegacyCode", Value = "A0236" },
             new RoleLookup() { RoleId = roles.First(t => t.Code == "A0237").Id, Key = "LegacyCode", Value = "A0237" },
@@ -1067,7 +1067,7 @@ public class DbDataMigrationService(
         var roleSens = (await roleService.Get(t => t.Urn, "urn:altinn:rolecode:SENS")).FirstOrDefault()?.Id ?? throw new KeyNotFoundException(string.Format("Role not found '{0}'", "Sensitive-tjenester"));
         /*SREVA*/
         var roleSreva = (await roleService.Get(t => t.Urn, "urn:altinn:external-role:ccr:kontaktperson-revisor")).FirstOrDefault()?.Id ?? throw new KeyNotFoundException(string.Format("Role not found '{0}'", "kontaktperson-revisor"));
-        
+
         /*A0212*/
         var roleA0212 = (await roleService.Get(t => t.Urn, "urn:altinn:rolecode:A0212")).FirstOrDefault()?.Id ?? throw new KeyNotFoundException(string.Format("Role not found '{0}'", "A0212"));
         /*A0236*/

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Data/Mock/MockDataService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Data/Mock/MockDataService.cs
@@ -233,7 +233,7 @@ public class MockDataService
                             RefId = resourceId.ToString().ToLower(),
                             TypeId = resourceTypes.OrderBy(t => Guid.NewGuid()).First().Id,
                             ProviderId = provider.Id
-                        }, 
+                        },
                         options: options
                     );
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Models/Connection.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Models/Connection.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Generated view for assignments and delegations
 /// </summary>
-public class Connection 
+public class Connection
 {
     /// <summary>
     /// Identity, either assignment og delegation

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Models/DelegationResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Models/DelegationResource.cs
@@ -43,7 +43,7 @@ public class DelegationResource
     /// Resource identifier
     /// </summary>
     public Guid ResourceId { get; set; }
-    
+
     //// public Guid DependencyId { get; set; }
 }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Models/Entity.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Models/Entity.cs
@@ -106,7 +106,7 @@ public class CompactEntity
     /// <summary>
     /// Values from entityLoookup
     /// </summary>
-    public Dictionary<string,string> KeyValues { get; set; }
+    public Dictionary<string, string> KeyValues { get; set; }
 
     /// <summary>
     /// Parent

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Models/ProviderType.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Models/ProviderType.cs
@@ -19,7 +19,7 @@ public class ProviderType
 /// <summary>
 /// Define the types of Providers
 /// </summary>
-public class ExtProviderType: ProviderType { }
+public class ExtProviderType : ProviderType { }
 
 /// <summary>
 /// Define the types of Providers

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Repositories/Contracts/IRelationPermissionRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Repositories/Contracts/IRelationPermissionRepository.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.Persistence.Models;
 namespace Altinn.AccessMgmt.Persistence.Repositories.Contracts;
 
 /// <inheritdoc/>
-public interface IRelationPermissionRepository : IDbExtendedRepository<Relation, ExtRelation> 
+public interface IRelationPermissionRepository : IDbExtendedRepository<Relation, ExtRelation>
 {
     Task<IEnumerable<PackageDelegationCheck>> GetAssignableAccessPackages(Guid fromId, Guid toId, IEnumerable<Guid> packageIds, CancellationToken cancellationToken = default);
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Repositories/Contracts/IRelationRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Repositories/Contracts/IRelationRepository.cs
@@ -4,6 +4,6 @@ using Altinn.AccessMgmt.Persistence.Models;
 namespace Altinn.AccessMgmt.Persistence.Repositories.Contracts;
 
 /// <inheritdoc/>
-public interface IRelationRepository : IDbExtendedRepository<CompactRelation, ExtCompactRelation> 
+public interface IRelationRepository : IDbExtendedRepository<CompactRelation, ExtCompactRelation>
 {
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/AMPartyService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/AMPartyService.cs
@@ -67,7 +67,7 @@ namespace Altinn.AccessMgmt.Persistence.Services
             Guid partyType = extEntityLookup.Entity.TypeId;
             string personId = null;
             string organizationId = null;
-            
+
             if (partyType == Guid.Parse("bfe09e70-e868-44b3-8d81-dfe0e13e058a"))
             {
                 personId = extEntityLookup.Entity.RefId;
@@ -176,12 +176,12 @@ namespace Altinn.AccessMgmt.Persistence.Services
             ExtEntityLookup extEntityLookup = res.First();
             Guid partyType = extEntityLookup.Entity.TypeId;
             string personId = null;
-            
-            if (partyType == Guid.Parse("bfe09e70-e868-44b3-8d81-dfe0e13e058a")) 
+
+            if (partyType == Guid.Parse("bfe09e70-e868-44b3-8d81-dfe0e13e058a"))
             {
                 personId = extEntityLookup.Entity.RefId;
             }
-            
+
             return new MinimalParty()
             {
                 Name = extEntityLookup.Entity.Name,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/AssignmentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/AssignmentService.cs
@@ -283,7 +283,7 @@ public class AssignmentService(
             cancellationToken: cancellationToken
         );
 
-        return true;        
+        return true;
     }
 
     /// <inheritdoc/>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/DelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/DelegationService.cs
@@ -74,7 +74,7 @@ public class DelegationService(
         var toAssignment = await assignmentRepository.GetExtended(toAssignmentId);
 
         // Sjekk om from og to deler en felles entitet
-        if (fromAssignment.ToId != toAssignment.FromId) 
+        if (fromAssignment.ToId != toAssignment.FromId)
         {
             throw new InvalidOperationException("Assignments are not connected. FromAssignment.ToId != ToAssignment.FromId");
         }
@@ -120,14 +120,14 @@ public class DelegationService(
         var assignmentPackages = await assignmentPackageRepository.GetB(fromAssignment.Id);
         var rolePackages = await rolePackageRepository.Get(t => t.RoleId, fromAssignment.RoleId);
 
-        if (assignmentPackages.Count(t => t.Id == packageId) == 0 && rolePackages.Count(t => t.Id == packageId) == 0) 
+        if (assignmentPackages.Count(t => t.Id == packageId) == 0 && rolePackages.Count(t => t.Id == packageId) == 0)
         {
             throw new Exception($"The source assignment does not have the package '{package.Name}'");
         }
 
         var res = await delegationPackageRepository.Create(
-            new DelegationPackage() 
-            { 
+            new DelegationPackage()
+            {
                 DelegationId = delegationId,
                 PackageId = packageId
             },
@@ -167,7 +167,7 @@ public class DelegationService(
             rolePackageResources.Add(package.Id, [.. await roleResourceRepository.GetB(resourceId)]);
         }
 
-        if (assignmentResources.Count(t => t.Id == resourceId) == 0 
+        if (assignmentResources.Count(t => t.Id == resourceId) == 0
             && roleResources.Count(t => t.Id == resourceId) == 0
             && rolePackageResources.SelectMany(t => t.Value).Count(t => t.Id == resourceId) == 0
             )
@@ -270,7 +270,7 @@ public class DelegationService(
 
                     // Revoke DelegationPackage
                     var revoked = await RevokeDelegationPackage(delegation.Id, package.Id, options, cancellationToken);
-                    
+
                     if (revoked)
                     {
                         packagesRevoked++;
@@ -616,7 +616,7 @@ public class DelegationService(
         delegationFilter.Equal(t => t.FromId, from.Id);
         delegationFilter.Equal(t => t.ToId, to.Id);
         delegationFilter.Equal(t => t.FacilitatorId, facilitator.Id);
-        return (await delegationRepository.Get(delegationFilter)).FirstOrDefault();        
+        return (await delegationRepository.Get(delegationFilter)).FirstOrDefault();
     }
 
     private async Task<Entity> GetOrCreateEntity(Guid id, string name, string refId, string type, string variant, ChangeRequestOptions options)
@@ -627,7 +627,7 @@ public class DelegationService(
         variantFilter.Equal(t => t.TypeId, entityType.Id);
         variantFilter.Equal(t => t.Name, variant);
         var entityVariant = (await entityVariantRepository.Get(variantFilter)).First() ?? throw new Exception(string.Format("Variant not found '{0}'", type));
-        
+
         var entity = await entityRepository.Get(id);
         if (entity != null)
         {
@@ -702,7 +702,7 @@ public class DelegationService(
         else
         {
             var roleProvider = await providerRepository.Get(role.ProviderId);
-            
+
             // Get system from token
             if (roleProvider.Code != "sys-altinn3")
             {
@@ -715,7 +715,7 @@ public class DelegationService(
                     FromId = from.Id,
                     ToId = to.Id,
                     RoleId = role.Id
-                }, 
+                },
                 options: options
             );
         }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/Models/PackageDto.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/Models/PackageDto.cs
@@ -56,7 +56,7 @@ public class PackageDto
     /// Construct from Package
     /// </summary>
     /// <param name="package"><see cref="Package"/>Package</param>
-    public PackageDto(Package package) 
+    public PackageDto(Package package)
     {
         Id = package.Id;
         Name = package.Name;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/PackageService.cs
@@ -44,7 +44,7 @@ public class PackageService(
         {
             builder
                 .AddCollection(pkg => pkg.Resources, r => r.Name, 1.2, FuzzynessLevel.High, detailed);
-                //// .AddCollection(pkg => pkg.Resources, r => r.Description, 0.7, FuzzynessLevel.Low, detailed);
+            //// .AddCollection(pkg => pkg.Resources, r => r.Description, 0.7, FuzzynessLevel.Low, detailed);
         }
 
         var results = FuzzySearch.PerformFuzzySearch(data, term, builder);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/PartyService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Services/PartyService.cs
@@ -62,9 +62,9 @@ namespace Altinn.AccessMgmt.Persistence.Services
                 if (res > 0)
                 {
                     result.PartyCreated = true;
-                }                
+                }
             }
-            
+
             return result;
         }
     }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/AreaConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/AreaConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class AreaConfiguration : IEntityTypeConfiguration<Area> 
+public class AreaConfiguration : IEntityTypeConfiguration<Area>
 {
     public void Configure(EntityTypeBuilder<Area> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/AssignmentInstanceConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/AssignmentInstanceConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class AssignmentInstanceConfiguration : IEntityTypeConfiguration<AssignmentInstance> 
+public class AssignmentInstanceConfiguration : IEntityTypeConfiguration<AssignmentInstance>
 {
     public void Configure(EntityTypeBuilder<AssignmentInstance> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/AssignmentPackageConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/AssignmentPackageConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class AssignmentPackageConfiguration : IEntityTypeConfiguration<AssignmentPackage> 
+public class AssignmentPackageConfiguration : IEntityTypeConfiguration<AssignmentPackage>
 {
     public void Configure(EntityTypeBuilder<AssignmentPackage> builder)
     {
@@ -18,7 +18,7 @@ public class AssignmentPackageConfiguration : IEntityTypeConfiguration<Assignmen
 
         builder.PropertyWithReference(navKey: t => t.Assignment, foreignKey: t => t.AssignmentId, principalKey: t => t.Id, deleteBehavior: DeleteBehavior.Cascade);
         builder.PropertyWithReference(navKey: t => t.Package, foreignKey: t => t.PackageId, principalKey: t => t.Id, deleteBehavior: DeleteBehavior.Restrict);
-        
+
         builder
             .HasMany(b => b.DelegationPackages)
             .WithOne(b => b.AssignmentPackage)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/AssignmentResourceConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/AssignmentResourceConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class AssignmentResourceConfiguration : IEntityTypeConfiguration<AssignmentResource> 
+public class AssignmentResourceConfiguration : IEntityTypeConfiguration<AssignmentResource>
 {
     public void Configure(EntityTypeBuilder<AssignmentResource> builder)
     {
@@ -17,7 +17,7 @@ public class AssignmentResourceConfiguration : IEntityTypeConfiguration<Assignme
         builder.HasKey(p => p.Id);
 
         builder.PropertyWithReference(navKey: t => t.Assignment, foreignKey: t => t.AssignmentId, principalKey: t => t.Id, deleteBehavior: DeleteBehavior.Cascade);
-        builder.PropertyWithReference(navKey: t => t.Resource, foreignKey: t => t.ResourceId, principalKey: t => t.Id, deleteBehavior: DeleteBehavior.Restrict);        
+        builder.PropertyWithReference(navKey: t => t.Resource, foreignKey: t => t.ResourceId, principalKey: t => t.Id, deleteBehavior: DeleteBehavior.Restrict);
 
         builder
           .HasOne(x => x.ChangedBy)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/DelegationResourceConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/DelegationResourceConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class DelegationResourceConfiguration : IEntityTypeConfiguration<DelegationResource> 
+public class DelegationResourceConfiguration : IEntityTypeConfiguration<DelegationResource>
 {
     public void Configure(EntityTypeBuilder<DelegationResource> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/EntityConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/EntityConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class EntityConfiguration : IEntityTypeConfiguration<Entity> 
+public class EntityConfiguration : IEntityTypeConfiguration<Entity>
 {
     public void Configure(EntityTypeBuilder<Entity> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/EntityLookupConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/EntityLookupConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class EntityLookupConfiguration : IEntityTypeConfiguration<EntityLookup> 
+public class EntityLookupConfiguration : IEntityTypeConfiguration<EntityLookup>
 {
     public void Configure(EntityTypeBuilder<EntityLookup> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/EntityVariantConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/EntityVariantConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class EntityVariantConfiguration : IEntityTypeConfiguration<EntityVariant> 
+public class EntityVariantConfiguration : IEntityTypeConfiguration<EntityVariant>
 {
     public void Configure(EntityTypeBuilder<EntityVariant> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/EntityVariantRoleConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/EntityVariantRoleConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class EntityVariantRoleConfiguration : IEntityTypeConfiguration<EntityVariantRole> 
+public class EntityVariantRoleConfiguration : IEntityTypeConfiguration<EntityVariantRole>
 {
     public void Configure(EntityTypeBuilder<EntityVariantRole> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/ErrorQueueConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/ErrorQueueConfiguration.cs
@@ -10,7 +10,7 @@ public class ErrorQueueConfiguration : IEntityTypeConfiguration<ErrorQueue>
     public void Configure(EntityTypeBuilder<ErrorQueue> builder)
     {
         builder.ToDefaultTable();
-        
+
         builder.HasKey(p => p.Id);
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/OutboxMessageLogConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/OutboxMessageLogConfiguration.cs
@@ -10,11 +10,11 @@ public class OutboxMessageLogConfiguration : IEntityTypeConfiguration<OutboxMess
     public void Configure(EntityTypeBuilder<OutboxMessageLog> builder)
     {
         builder.ToDefaultTable();
-        
+
         builder.HasKey(p => p.Id);
         builder.Property(p => p.Attempt);
         builder.Property(p => p.Log);
-        
+
         builder.Property(p => p.CreatedAt)
             .IsRequired()
             .HasDefaultValueSql("NOW()")

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/PackageResourceConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/PackageResourceConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class PackageResourceConfiguration : IEntityTypeConfiguration<PackageResource> 
+public class PackageResourceConfiguration : IEntityTypeConfiguration<PackageResource>
 {
     public void Configure(EntityTypeBuilder<PackageResource> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/ProviderConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/ProviderConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class ProviderConfiguration : IEntityTypeConfiguration<Provider> 
+public class ProviderConfiguration : IEntityTypeConfiguration<Provider>
 {
     public void Configure(EntityTypeBuilder<Provider> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/ProviderTypeConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/ProviderTypeConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class ProviderTypeConfiguration : IEntityTypeConfiguration<ProviderType> 
+public class ProviderTypeConfiguration : IEntityTypeConfiguration<ProviderType>
 {
     public void Configure(EntityTypeBuilder<ProviderType> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/ResourceConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/ResourceConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class ResourceConfiguration : IEntityTypeConfiguration<Resource> 
+public class ResourceConfiguration : IEntityTypeConfiguration<Resource>
 {
     public void Configure(EntityTypeBuilder<Resource> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/ResourceTypeConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/ResourceTypeConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class ResourceTypeConfiguration : IEntityTypeConfiguration<ResourceType> 
+public class ResourceTypeConfiguration : IEntityTypeConfiguration<ResourceType>
 {
     public void Configure(EntityTypeBuilder<ResourceType> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/RoleConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/RoleConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class RoleConfiguration : IEntityTypeConfiguration<Role> 
+public class RoleConfiguration : IEntityTypeConfiguration<Role>
 {
     public void Configure(EntityTypeBuilder<Role> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/RoleMapConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/RoleMapConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class RoleMapConfiguration : IEntityTypeConfiguration<RoleMap> 
+public class RoleMapConfiguration : IEntityTypeConfiguration<RoleMap>
 {
     public void Configure(EntityTypeBuilder<RoleMap> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/RoleResourceConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/RoleResourceConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Configurations;
 
-public class RoleResourceConfiguration : IEntityTypeConfiguration<RoleResource> 
+public class RoleResourceConfiguration : IEntityTypeConfiguration<RoleResource>
 {
     public void Configure(EntityTypeBuilder<RoleResource> builder)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/EntityTypeConstants.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/EntityTypeConstants.cs
@@ -50,7 +50,7 @@ public static class EntityTypeConstants
     /// <summary>
     /// Get all constants as a read-only collection.
     /// </summary>
-    public static IReadOnlyCollection<ConstantDefinition<EntityType>> AllEntities() 
+    public static IReadOnlyCollection<ConstantDefinition<EntityType>> AllEntities()
         => ConstantLookup.AllEntities<EntityType>(typeof(EntityTypeConstants));
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/InstanceSourceTypeConstants.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/InstanceSourceTypeConstants.cs
@@ -99,5 +99,5 @@ public static class InstanceSourceTypeConstants
         },
         EN = TranslationEntryList.Create(KeyValuePair.Create("Name", "End User")),
         NN = TranslationEntryList.Create(KeyValuePair.Create("Name", "Sluttbrukar")),
-    };    
+    };
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/ProviderConstants.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/ProviderConstants.cs
@@ -44,13 +44,13 @@ public static class ProviderConstants
     /// <summary>
     /// Get all constants as a read-only collection.
     /// </summary>
-    public static IReadOnlyCollection<ConstantDefinition<Provider>> AllEntities() 
+    public static IReadOnlyCollection<ConstantDefinition<Provider>> AllEntities()
         => ConstantLookup.AllEntities<Provider>(typeof(ProviderConstants));
 
     /// <summary>
     /// Get all translations as read-only collection.
     /// </summary>
-    public static IReadOnlyCollection<TranslationEntry> AllTranslations() 
+    public static IReadOnlyCollection<TranslationEntry> AllTranslations()
         => ConstantLookup.AllTranslations<Provider>(typeof(ProviderConstants));
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/ProviderTypeConstants.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/ProviderTypeConstants.cs
@@ -9,7 +9,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Constants;
 /// Each constant represents a type of provider (e.g., system provider or service owner)
 /// with a fixed unique identifier (GUID), name, and multilingual translations.
 /// </summary>
-public static class ProviderTypeConstants 
+public static class ProviderTypeConstants
 {
     /// <summary>
     /// Try to get <see cref="ProviderType"/> by any identifier: Name or Guid.
@@ -44,13 +44,13 @@ public static class ProviderTypeConstants
     /// <summary>
     /// Get all constants as a read-only collection.
     /// </summary>
-    public static IReadOnlyCollection<ConstantDefinition<ProviderType>> AllEntities() 
+    public static IReadOnlyCollection<ConstantDefinition<ProviderType>> AllEntities()
         => ConstantLookup.AllEntities<ProviderType>(typeof(ProviderTypeConstants));
 
     /// <summary>
     /// Get all translations as read-only collection.
     /// </summary>
-    public static IReadOnlyCollection<TranslationEntry> AllTranslations() 
+    public static IReadOnlyCollection<TranslationEntry> AllTranslations()
         => ConstantLookup.AllTranslations<ProviderType>(typeof(ProviderTypeConstants));
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestRoleMap.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestRoleMap.cs
@@ -8,7 +8,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Data;
 /// <summary>
 /// Partial StaticDataIngest
 /// </summary>
-public static partial class StaticDataIngest 
+public static partial class StaticDataIngest
 {
     /// <summary>
     /// Ingest RoleMap data

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/AuditExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/AuditExtensions.cs
@@ -6,7 +6,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Extensions;
 public static class AuditExtensions
 {
     public const string AnnotationName = "Altinn:AuditVersion";
-    
+
     public static EntityTypeBuilder EnableAudit(this EntityTypeBuilder builder)
     {
         /*

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/AuditValues.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/AuditValues.cs
@@ -13,8 +13,8 @@ public record AuditValues(Guid ChangedBy, Guid ChangedBySystem, string Operation
 
     public AuditValues(Guid changedBy, Guid changedBySystem)
         : this(changedBy, changedBySystem, Activity.Current?.TraceId.ToString() ?? Guid.CreateVersion7().ToString(), DateTimeOffset.UtcNow) { }
-    
-    public AuditValues(Guid changedBy) 
+
+    public AuditValues(Guid changedBy)
         : this(changedBy, changedBy, Activity.Current?.TraceId.ToString() ?? Guid.CreateVersion7().ToString(), DateTimeOffset.UtcNow) { }
 }
 
@@ -66,9 +66,9 @@ public class ReadOnlyInterceptor : SaveChangesInterceptor
 
     private void ThrowIfHasChanges(DbContext? context)
     {
-        if (context == null) 
+        if (context == null)
         {
-            return;        
+            return;
         }
 
         var hasModifications = context.ChangeTracker.Entries()

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/BuilderExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/BuilderExtensions.cs
@@ -199,7 +199,7 @@ public static class BuilderExtensions
     public static EntityTypeBuilder<T> ConfigureAsView<T>(
         this EntityTypeBuilder<T> builder,
         string viewName,
-        string schema = "dbo") 
+        string schema = "dbo")
         where T : class
     {
         builder.ToTable(viewName, schema, t => t.ExcludeFromMigrations());

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/ViewEntityBuilderExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/ViewEntityBuilderExtensions.cs
@@ -9,7 +9,7 @@ public static class ViewEntityBuilderExtensions
     public static EntityTypeBuilder<T> ConfigureAsView<T>(
         this EntityTypeBuilder<T> builder,
         string viewName,
-        string schema = "dbo") 
+        string schema = "dbo")
         where T : class
     {
         builder.ToTable(viewName, schema, t => t.ExcludeFromMigrations());

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditArea.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditArea.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditArea : BaseArea, IAudit 
+public class AuditArea : BaseArea, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAreaGroup.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAreaGroup.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditAreaGroup : BaseAreaGroup, IAudit 
+public class AuditAreaGroup : BaseAreaGroup, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentInstance.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentInstance.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditAssignmentInstance : BaseAssignmentInstance, IAudit 
+public class AuditAssignmentInstance : BaseAssignmentInstance, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentPackage.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentPackage.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditAssignmentPackage : BaseAssignmentPackage, IAudit 
+public class AuditAssignmentPackage : BaseAssignmentPackage, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentResource.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditAssignmentResource : BaseAssignmentResource, IAudit 
+public class AuditAssignmentResource : BaseAssignmentResource, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegation.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditDelegation : BaseDelegation, IAudit 
+public class AuditDelegation : BaseDelegation, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegationPackage.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegationPackage.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditDelegationPackage : BaseDelegationPackage, IAudit 
+public class AuditDelegationPackage : BaseDelegationPackage, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegationResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegationResource.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditDelegationResource : BaseDelegationResource, IAudit 
+public class AuditDelegationResource : BaseDelegationResource, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntity.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntity.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditEntity : BaseEntity, IAudit 
+public class AuditEntity : BaseEntity, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityLookup.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityLookup.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditEntityLookup : BaseEntityLookup, IAudit 
+public class AuditEntityLookup : BaseEntityLookup, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityType.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityType.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditEntityType : BaseEntityType, IAudit 
+public class AuditEntityType : BaseEntityType, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityVariant.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityVariant.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditEntityVariant : BaseEntityVariant, IAudit 
+public class AuditEntityVariant : BaseEntityVariant, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityVariantRole.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityVariantRole.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditEntityVariantRole : BaseEntityVariantRole, IAudit 
+public class AuditEntityVariantRole : BaseEntityVariantRole, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditPackage.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditPackage.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditPackage : BasePackage, IAudit 
+public class AuditPackage : BasePackage, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditPackageResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditPackageResource.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditPackageResource : BasePackageResource, IAudit 
+public class AuditPackageResource : BasePackageResource, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditProvider.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditProvider.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditProvider : BaseProvider, IAudit 
+public class AuditProvider : BaseProvider, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditProviderType.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditProviderType.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditProviderType : BaseProviderType, IAudit 
+public class AuditProviderType : BaseProviderType, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditResource.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditResource : BaseResource, IAudit 
+public class AuditResource : BaseResource, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditResourceType.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditResourceType.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditResourceType : BaseResourceType, IAudit 
+public class AuditResourceType : BaseResourceType, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRole.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRole.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditRole : BaseRole, IAudit 
+public class AuditRole : BaseRole, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRoleMap.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRoleMap.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditRoleMap : BaseRoleMap, IAudit 
+public class AuditRoleMap : BaseRoleMap, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRolePackage.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRolePackage.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditRolePackage : BaseRolePackage, IAudit 
+public class AuditRolePackage : BaseRolePackage, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRoleResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRoleResource.cs
@@ -4,7 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models.Base;
 namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 
 /// <inheritdoc />
-public class AuditRoleResource : BaseRoleResource, IAudit 
+public class AuditRoleResource : BaseRoleResource, IAudit
 {
     /// <inheritdoc />
     public DateTimeOffset Audit_ValidFrom { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Base/BaseEntity.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Base/BaseEntity.cs
@@ -61,5 +61,5 @@ public class BaseEntity : BaseAudit, IEntityId, IEntityName
 
     public DateTimeOffset? DeletedAt { get; set; }
 
-    public bool IsDeleted { get; set; } 
+    public bool IsDeleted { get; set; }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -56,7 +56,7 @@ public class ConnectionQuery(AppDbContext db)
         {
             var assignments = db.Assignments.AsNoTracking()
                 .Where(t => t.FromId == fromId && t.ToId == toId);
-        
+
             if (await assignments.AnyAsync())
             {
                 return (true, ConnectionReason.Assignment);
@@ -122,7 +122,7 @@ public class ConnectionQuery(AppDbContext db)
                 delayFromFilter = false;
             }
 
-            var baseQuery = direction == ConnectionQueryDirection.FromOthers 
+            var baseQuery = direction == ConnectionQueryDirection.FromOthers
                 ? useNewQuery ? BuildBaseQueryFromOthersNew(
                         db,
                         filter,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/Models/ConnectionQueryBaseRecord.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/Models/ConnectionQueryBaseRecord.cs
@@ -21,7 +21,7 @@ public class ConnectionQueryBaseRecord
     /// Connection role identity
     /// </summary>
     public Guid RoleId { get; init; }
-    
+
     /// <summary>
     /// Connection Assignment Identity
     /// </summary>
@@ -159,11 +159,11 @@ public static class ConnectionDiffHelper
     private static readonly ConnectionCoreComparer Comparer = new();
 
     public static (
-        List<ConnectionQueryBaseRecord> OnlyInA, 
+        List<ConnectionQueryBaseRecord> OnlyInA,
         List<ConnectionQueryBaseRecord> OnlyInB
-        ) 
+        )
             Diff(
-                IEnumerable<ConnectionQueryBaseRecord> a, 
+                IEnumerable<ConnectionQueryBaseRecord> a,
                 IEnumerable<ConnectionQueryBaseRecord> b
             )
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Utils/TranslationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Utils/TranslationService.cs
@@ -41,7 +41,7 @@ public class TranslationService : ITranslationService
     public async ValueTask<T> TranslateAsync<T>(T source, string languageCode, bool allowPartial = true)
     {
         var (success, result) = await TryTranslateAsync(source, languageCode);
-        
+
         if (!success && !allowPartial)
         {
             return source;
@@ -88,12 +88,12 @@ public class TranslationService : ITranslationService
         // Constants only provide translations for English (eng) and Norwegian Nynorsk (nno)
         if (effectiveLanguageCode == "nob")
         {
-            _logger.LogTrace("Language code is 'nob' (base language), returning original {TypeName} with ID {EntityId}", 
+            _logger.LogTrace("Language code is 'nob' (base language), returning original {TypeName} with ID {EntityId}",
                 typeName, entityId);
             return (true, source); // Return original, it's already in Norwegian Bokmål
         }
 
-        _logger.LogDebug("Attempting to translate {TypeName} with ID {EntityId} to language {LanguageCode}", 
+        _logger.LogDebug("Attempting to translate {TypeName} with ID {EntityId} to language {LanguageCode}",
             typeName, entityId, effectiveLanguageCode);
 
         // Try to get translations from Constants first (for eng and nno only)
@@ -103,7 +103,7 @@ public class TranslationService : ITranslationService
 
         if (constantTranslations != null && constantTranslations.Any())
         {
-            _logger.LogDebug("Found {Count} constant translations for {TypeName} with ID {EntityId} in language {LanguageCode}", 
+            _logger.LogDebug("Found {Count} constant translations for {TypeName} with ID {EntityId} in language {LanguageCode}",
                 constantTranslations.Count, typeName, entityId, effectiveLanguageCode);
             transMap = constantTranslations;
         }
@@ -111,40 +111,40 @@ public class TranslationService : ITranslationService
         {
             // Fall back to database with caching
             var cacheKey = $"translation_{typeName}_{entityId}_{effectiveLanguageCode}";
-            
+
             _logger.LogTrace("Checking cache for translation key: {CacheKey}", cacheKey);
-            
+
             transMap = await _cache.GetOrCreateAsync(cacheKey, async entry =>
             {
                 entry.AbsoluteExpirationRelativeToNow = CacheDuration;
-                
-                _logger.LogDebug("Cache miss for {TypeName} with ID {EntityId}, querying database for language {LanguageCode}", 
+
+                _logger.LogDebug("Cache miss for {TypeName} with ID {EntityId}, querying database for language {LanguageCode}",
                     typeName, entityId, effectiveLanguageCode);
-                
+
                 var dbTranslations = await _db.TranslationEntries
                     .Where(t => t.Type == typeName &&
                                 t.Id == entityId &&
                                 t.LanguageCode == effectiveLanguageCode)
                     .ToDictionaryAsync(t => t.FieldName, t => t.Value ?? string.Empty);
-                
+
                 if (dbTranslations.Any())
                 {
-                    _logger.LogDebug("Found {Count} database translations for {TypeName} with ID {EntityId} in language {LanguageCode}", 
+                    _logger.LogDebug("Found {Count} database translations for {TypeName} with ID {EntityId} in language {LanguageCode}",
                         dbTranslations.Count, typeName, entityId, effectiveLanguageCode);
                 }
                 else
                 {
-                    _logger.LogInformation("No database translations found for {TypeName} with ID {EntityId} in language {LanguageCode}", 
+                    _logger.LogInformation("No database translations found for {TypeName} with ID {EntityId} in language {LanguageCode}",
                         typeName, entityId, effectiveLanguageCode);
                 }
-                
+
                 return dbTranslations;
             });
         }
 
         if (transMap == null || !transMap.Any())
         {
-            _logger.LogWarning("No translations available for {TypeName} with ID {EntityId} in language {LanguageCode}", 
+            _logger.LogWarning("No translations available for {TypeName} with ID {EntityId} in language {LanguageCode}",
                 typeName, entityId, effectiveLanguageCode);
             return (false, source);
         }
@@ -159,19 +159,19 @@ public class TranslationService : ITranslationService
             {
                 prop.SetValue(source, val);
                 translatedFields++;
-                _logger.LogTrace("Translated field {FieldName} for {TypeName} with ID {EntityId}", 
+                _logger.LogTrace("Translated field {FieldName} for {TypeName} with ID {EntityId}",
                     prop.Name, typeName, entityId);
             }
         }
 
         if (translatedFields > 0)
         {
-            _logger.LogDebug("Successfully translated {TranslatedFields} fields for {TypeName} with ID {EntityId} to language {LanguageCode}", 
+            _logger.LogDebug("Successfully translated {TranslatedFields} fields for {TypeName} with ID {EntityId} to language {LanguageCode}",
                 translatedFields, typeName, entityId, effectiveLanguageCode);
         }
         else
         {
-            _logger.LogWarning("No fields were translated for {TypeName} with ID {EntityId} in language {LanguageCode} (found {TranslationCount} translations but none matched writable string properties)", 
+            _logger.LogWarning("No fields were translated for {TypeName} with ID {EntityId} in language {LanguageCode} (found {TranslationCount} translations but none matched writable string properties)",
                 typeName, entityId, effectiveLanguageCode, transMap.Count);
         }
 
@@ -183,7 +183,7 @@ public class TranslationService : ITranslationService
     public async ValueTask<IEnumerable<T>> TranslateCollectionAsync<T>(IEnumerable<T> sources, string languageCode, bool allowPartial = true)
     {
         var result = new List<T>();
-        
+
         foreach (var source in sources)
         {
             var translated = await TranslateAsync(source, languageCode, allowPartial);
@@ -196,25 +196,25 @@ public class TranslationService : ITranslationService
     /// <inheritdoc />
     public async Task UpsertTranslationAsync(TranslationEntry translationEntry, Guid changedBy, Guid changedBySystem, CancellationToken cancellationToken = default)
     {
-        _logger.LogDebug("Upserting translation for {Type} with ID {Id}, field {FieldName} in language {LanguageCode}", 
+        _logger.LogDebug("Upserting translation for {Type} with ID {Id}, field {FieldName} in language {LanguageCode}",
             translationEntry.Type, translationEntry.Id, translationEntry.FieldName, translationEntry.LanguageCode);
-        
+
         var entry = await _db.TranslationEntries.SingleOrDefaultAsync(
-            t => t.Id == translationEntry.Id && 
-                 t.Type == translationEntry.Type && 
-                 t.LanguageCode == translationEntry.LanguageCode && 
-                 t.FieldName == translationEntry.FieldName, 
+            t => t.Id == translationEntry.Id &&
+                 t.Type == translationEntry.Type &&
+                 t.LanguageCode == translationEntry.LanguageCode &&
+                 t.FieldName == translationEntry.FieldName,
             cancellationToken);
 
         if (entry == null)
         {
-            _logger.LogInformation("Creating new translation entry for {Type} with ID {Id}, field {FieldName} in language {LanguageCode}", 
+            _logger.LogInformation("Creating new translation entry for {Type} with ID {Id}, field {FieldName} in language {LanguageCode}",
                 translationEntry.Type, translationEntry.Id, translationEntry.FieldName, translationEntry.LanguageCode);
             _db.Add(translationEntry);
         }
         else
         {
-            _logger.LogDebug("Updating existing translation entry for {Type} with ID {Id}, field {FieldName} in language {LanguageCode}", 
+            _logger.LogDebug("Updating existing translation entry for {Type} with ID {Id}, field {FieldName} in language {LanguageCode}",
                 translationEntry.Type, translationEntry.Id, translationEntry.FieldName, translationEntry.LanguageCode);
             entry.Value = translationEntry.Value;
             _db.Update(entry);
@@ -226,7 +226,7 @@ public class TranslationService : ITranslationService
             changedBy: changedBy,
             changedBySystem: changedBySystem
         );
-        
+
         await _db.SaveChangesAsync(systemAudit, cancellationToken);
 
         // Invalidate cache
@@ -259,7 +259,7 @@ public class TranslationService : ITranslationService
                 return null;
             }
 
-            _logger.LogTrace("Attempting to get constant translations from {ConstantsType} for {TypeName} with ID {EntityId} in language {LanguageCode}", 
+            _logger.LogTrace("Attempting to get constant translations from {ConstantsType} for {TypeName} with ID {EntityId} in language {LanguageCode}",
                 constantsType.Name, typeName, entityId, languageCode);
 
             // Get all translations from the Constants class
@@ -284,13 +284,13 @@ public class TranslationService : ITranslationService
 
             if (relevantTranslations.Any())
             {
-                _logger.LogDebug("Found {Count} constant translations for {TypeName} with ID {EntityId} in language {LanguageCode}", 
+                _logger.LogDebug("Found {Count} constant translations for {TypeName} with ID {EntityId} in language {LanguageCode}",
                     relevantTranslations.Count, typeName, entityId, languageCode);
                 return relevantTranslations;
             }
             else
             {
-                _logger.LogTrace("No constant translations found for {TypeName} with ID {EntityId} in language {LanguageCode}", 
+                _logger.LogTrace("No constant translations found for {TypeName} with ID {EntityId} in language {LanguageCode}",
                     typeName, entityId, languageCode);
                 return null;
             }
@@ -298,7 +298,7 @@ public class TranslationService : ITranslationService
         catch (Exception ex)
         {
             // If anything fails, fall back to database
-            _logger.LogError(ex, "Error retrieving constant translations for {TypeName} with ID {EntityId} in language {LanguageCode}, falling back to database", 
+            _logger.LogError(ex, "Error retrieving constant translations for {TypeName} with ID {EntityId} in language {LanguageCode}, falling back to database",
                 typeName, entityId, languageCode);
             return null;
         }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
@@ -536,7 +536,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
             await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
-            await repositgo.RejectConsentRequest(requestId,performedBy, default);
+            await repositgo.RejectConsentRequest(requestId, performedBy, default);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, performedBy, AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
@@ -622,7 +622,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
             {
                 Language = "nb",
             };
-            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext()); 
+            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext());
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
@@ -757,7 +757,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
             string responseContent = await response.Content.ReadAsStringAsync();
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             ConsentRequestDetailsBffDto consentInfo = JsonSerializer.Deserialize<ConsentRequestDetailsBffDto>(responseContent, _jsonOptions);
-            Assert.Equal(3,consentInfo.ConsentRequestEvents.Count);
+            Assert.Equal(3, consentInfo.ConsentRequestEvents.Count);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestEventType.Created, consentInfo.ConsentRequestEvents[0].EventType);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), consentInfo.ConsentRequestEvents[0].PerformedBy);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestEventType.Accepted, consentInfo.ConsentRequestEvents[1].EventType);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/DelegationsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/DelegationsControllerTest.cs
@@ -1627,5 +1627,5 @@ namespace Altinn.AccessManagement.Tests.Controllers
             return delegations;
         }
 
-            }
-        }
+    }
+}

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterprise.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterprise.cs
@@ -88,7 +88,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequest_Valid()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -119,7 +119,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
                 {
                     { "en", "Please approve this consent request" }
                 },
-                RedirectUrl = "https://www.dnb.no"   
+                RedirectUrl = "https://www.dnb.no"
             };
 
             HttpClient client = GetTestClient();
@@ -224,7 +224,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequestByOrg_Valid()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -293,7 +293,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequestByOrg_InvalidUrl()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -404,7 +404,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequestDuplicatePost_Valid()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -483,7 +483,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequestDuplicatePost_InvalidDifferentFrom()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -556,7 +556,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequest_AndCheckStatus_Valid()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -598,7 +598,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
 
             HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
             string responseContent = await response.Content.ReadAsStringAsync();
-            string location = response.Headers.Location.ToString();   
+            string location = response.Headers.Location.ToString();
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.NotNull(responseContent);
             ConsentRequestDetailsDto consentInfo = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(responseContent, _jsonOptions);
@@ -637,7 +637,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequestRequiredDelegator_AndCheckStatus_Valid()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -719,7 +719,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequestHandledByParty_AndCheckStatus_Valid()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -805,7 +805,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequest_ValidWithoutMetadata()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -867,7 +867,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequest_IncompatibleTemplates()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -942,7 +942,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequest_MissingMetadata()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -995,7 +995,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequest_WrongNamingMetadata()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -1072,7 +1072,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequest_UnknownMetadata()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -1132,7 +1132,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequest_MissingRights()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -1171,7 +1171,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequest_MissingAction()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -1230,7 +1230,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         public async Task CreateConsentRequest_FromIsNonExistingPerson()
         {
             SetupMockPartyRepository();
-            
+
             Guid requestID = Guid.CreateVersion7();
             ConsentRequestDto consentRequest = new ConsentRequestDto
             {
@@ -1261,7 +1261,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
                 {
                     { "en", "Please approve this consent request" }
                 },
-                RedirectUrl = "https://www.dnb.no"  
+                RedirectUrl = "https://www.dnb.no"
             };
 
             HttpClient client = GetTestClient();
@@ -1282,7 +1282,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             Assert.Empty(problemDetails.Errors);
             Assert.Single(problemDetails.Extensions);
         }
-    
+
         private HttpClient GetTestClient()
         {
             HttpClient client = _fixture.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
@@ -189,7 +189,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         }
 
         public async ValueTask InitializeAsync()
-        {            
+        {
             _fixture = new LegacyApiFixture();
             _fixture.ConfigureServices(services =>
             {
@@ -327,7 +327,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
                 // All returned events should be the latest for their consentrequest
                 var allItems = resultPage1.Items.Concat(resultPage2.Items).ToList();
                 Assert.Equal(numberOfConsents, allItems.Count);
-                
+
                 Assert.Equal(revoked, allItems.FindAll(i => i.EventType.Equals("revoked", StringComparison.OrdinalIgnoreCase)).Count());
                 Assert.Equal(rejected, allItems.FindAll(i => i.EventType.Equals("rejected", StringComparison.OrdinalIgnoreCase)).Count());
                 Assert.Equal(accepted - revoked, allItems.FindAll(i => i.EventType.Equals("accepted", StringComparison.OrdinalIgnoreCase)).Count());
@@ -561,14 +561,14 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
                 if (acceptedConsentIdsToBeRevoked.Count < 3)
                 {
                     acceptedConsentIdsToBeRevoked.Add(consentId);
-                }                   
+                }
             }
 
             foreach (var consentId in createdConsentIds.Skip(skip).Take(rejectTake))
             {
                 HttpClient rejectClient = GetTestClient();
                 IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-               
+
                 string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
                 rejectClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 HttpResponseMessage rejectResponse = await rejectClient.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{consentId}/reject/", null);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinportenSchemaControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinportenSchemaControllerTest.cs
@@ -596,7 +596,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
         public async Task GetMaskinportenDelegations_ServiceOwnerLookup_UnauthorizedScope()
         {
             // Arrange
-            string token = PrincipalUtil.GetOrgToken("SKD", "974761076", "altinn:maskinporten/delegations", null,  consumerPrefix: new[] { "skd" });
+            string token = PrincipalUtil.GetOrgToken("SKD", "974761076", "altinn:maskinporten/delegations", null, consumerPrefix: new[] { "skd" });
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             string expected = "Not authorized for lookup of delegations for the scope: altinn:instances.read";
@@ -622,7 +622,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
         public async Task GetMaskinportenDelegations_ServiceOwnerLookup_WithoutScope()
         {
             // Arrange
-            string token = PrincipalUtil.GetOrgToken("SKD", "974761076", "altinn:maskinporten/delegations", null,  new[] { "skd" });
+            string token = PrincipalUtil.GetOrgToken("SKD", "974761076", "altinn:maskinporten/delegations", null, new[] { "skd" });
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             string expected = "Not authorized for lookup of delegations without specifying parameter: scope";
@@ -649,7 +649,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
         {
             // Arrange
             string token = string.Empty;
-            
+
             // Trying to move this line
             token = PrincipalUtil.GetOrgToken("DIGDIR", "991825827", "altinn:maskinporten/delegations.admin", null, null);
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
@@ -1335,7 +1335,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             string toParty = "50004221";
             DelegationMetadataRepositoryMock delegationMetadataRepositoryMock = new DelegationMetadataRepositoryMock { MetadataChanges = new Dictionary<string, List<DelegationChange>>() };
             HttpClient client = GetTestClient(delegationMetadataRepositoryMock: delegationMetadataRepositoryMock);
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(20001337, 50001337, userPartyUuid: new Guid("f200a9cb-31ce-4ed6-aad3-ed08b3cbbeee") ));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(20001337, 50001337, userPartyUuid: new Guid("f200a9cb-31ce-4ed6-aad3-ed08b3cbbeee")));
 
             StreamContent requestContent = GetRequestContent("RevokeReceivedMaskinportenScopeDelegation", "jks_undelegable", $"p50005545", $"p{toParty}");
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/MetadataTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/MetadataTests.cs
@@ -105,7 +105,7 @@ public class MetadataTests : IClassFixture<PostgresFixture>
         {
             await db.SaveChangesAsync(new Altinn.AccessMgmt.PersistenceEF.Extensions.AuditValues(SystemEntityConstants.StaticDataIngest, SystemEntityConstants.StaticDataIngest));
         }
-        catch (Exception ex) 
+        catch (Exception ex)
         {
             Console.WriteLine(ex.ToString());
         }
@@ -410,11 +410,11 @@ public class MetadataTests : IClassFixture<PostgresFixture>
     private RolesController CreateController(IRoleService roleService, string acceptLanguage = "nb-NO")
     {
         var controller = new RolesController(roleService, _translationService);
-        
+
         // Create a mock HTTP context with Accept-Language header
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Headers["Accept-Language"] = acceptLanguage;
-        
+
         controller.ControllerContext = new ControllerContext()
         {
             HttpContext = httpContext

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceControllerTest.cs
@@ -91,7 +91,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
             List<AccessManagementResource> actual = JsonSerializer.Deserialize<List<AccessManagementResource>>(responseContent, options);
-            
+
             // Assert
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             AssertionUtil.ListAccessManagementResourceAreEqual(expected, actual);
@@ -106,7 +106,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
         {
             // Arrange
             _client.DefaultRequestHeaders.Remove("Authorization");
-            
+
             Stream dataStream = File.OpenRead("Data/Json/InsertAccessManagementResource/input1.json");
             StreamContent content = new StreamContent(dataStream);
 
@@ -136,7 +136,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
 
             // Act
             HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-            
+
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
@@ -164,7 +164,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             // Act
             HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
             string actual = await response.Content.ReadAsStringAsync();
-            
+
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.Equal(expected, actual);
@@ -192,7 +192,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             // Act
             HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
             string responseContent = await response.Content.ReadAsStringAsync();
-            
+
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
@@ -256,7 +256,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             // Act
             HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
             string actual = await response.Content.ReadAsStringAsync();
-            
+
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.Equal(expected, actual);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceOwnerAPI/AppsInstanceDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceOwnerAPI/AppsInstanceDelegationControllerTest.cs
@@ -152,7 +152,7 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         Paginated<AppsInstanceRevokeResponseDto> actual = JsonSerializer.Deserialize<Paginated<AppsInstanceRevokeResponseDto>>(await response.Content.ReadAsStringAsync(), options);
-        AssertionUtil.AssertPagination(expected, actual, AssertionUtil.AssertAppsInstanceRevokeResponseDto);        
+        AssertionUtil.AssertPagination(expected, actual, AssertionUtil.AssertAppsInstanceRevokeResponseDto);
     }
 
     [Theory]
@@ -181,7 +181,7 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         HttpResponseMessage response = await client.DeleteAsync($"accessmanagement/api/v1/app/delegationrevoke/resource/{resourceId}/instance/{instanceId}");
 
         // Assert
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);                
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Data/AuthorizedParties/TestDataAppsInstanceDelegation.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Data/AuthorizedParties/TestDataAppsInstanceDelegation.cs
@@ -147,7 +147,7 @@ public static class TestDataAppsInstanceDelegation
             AppId,
             RevokeAllInstance
         }
-    }; 
+    };
 
     public static TheoryData<string, AppsInstanceDelegationRequestDto, string, string, AppsInstanceRevokeResponseDto> RevokeReadForAppNoExistingPolicyRevokeLast() => new()
     {
@@ -159,7 +159,7 @@ public static class TestDataAppsInstanceDelegation
             GetExpectedResponse<AppsInstanceRevokeResponseDto>("Revoke", AppId, InstanceIdNewPolicyNoResponceOnWrite)
         }
     };
-    
+
     /// <summary>
     /// Test case:  POST v1/apps/instancedelegation/{resourceId}/{instanceId}
     ///             with: 
@@ -279,7 +279,7 @@ public static class TestDataAppsInstanceDelegation
         Assert.Equal(expected.Type, actual.Type);
         Assert.Equal(expected.Title, actual.Title);
         Assert.Equal(expected.ErrorCode, actual.ErrorCode);
-        AssertionUtil.AssertCollections(expected.Extensions.ToDictionary(), actual.Extensions.ToDictionary(), AssertProblemDetailsExtensionEqual);        
+        AssertionUtil.AssertCollections(expected.Extensions.ToDictionary(), actual.Extensions.ToDictionary(), AssertProblemDetailsExtensionEqual);
     }
 
     public static void AssertProblemDetailsExtensionEqual(KeyValuePair<string, object> expected, KeyValuePair<string, object> actual)
@@ -287,7 +287,7 @@ public static class TestDataAppsInstanceDelegation
         Assert.Equal(expected.Key, actual.Key);
         JsonElement? actualJson = actual.Value as JsonElement?;
         JsonElement? expectedJson = expected.Value as JsonElement?;
-        
+
         if (actualJson == null)
         {
             Assert.Null(expectedJson);
@@ -296,18 +296,18 @@ public static class TestDataAppsInstanceDelegation
 
         Assert.NotNull(actualJson);
         Assert.NotNull(expectedJson);
-        
+
         var actualExtensionList = actualJson.Value.EnumerateArray().ToList();
         var expectedExtensionList = expectedJson.Value.EnumerateArray().ToList();
         Assert.Equal(expectedExtensionList.Count, actualExtensionList.Count);
-        
+
         for (int i = 0; i < actualExtensionList.Count; i++)
         {
             ErrorDetails expectedDetail = JsonSerializer.Deserialize<ErrorDetails>(expectedExtensionList[i].GetRawText(), JsonOptions);
             ErrorDetails actualDetail = JsonSerializer.Deserialize<ErrorDetails>(actualExtensionList[i].GetRawText(), JsonOptions);
             Assert.Equal(expectedDetail.Code, actualDetail.Code);
             Assert.Equal(expectedDetail.Detail, actualDetail.Detail);
-            
+
             if (expectedDetail.Paths == null)
             {
                 Assert.Null(expectedDetail.Paths);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs
@@ -118,7 +118,7 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         var serviceTask = service.StartAsync(testCts.Token);
 
         await Task.Delay(10);
-        
+
         // Advance by EmptyFeedDelayMs + max jitter (2000ms)
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.EmptyFeedDelayMs + 2000));
         await Task.Delay(10);
@@ -312,7 +312,7 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
         await Task.Delay(10);
-        
+
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000));
 
@@ -586,7 +586,7 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         var serviceTask = service.StartAsync(testCts.Token);
 
         await Task.Delay(10);
-        
+
         // The jitter adds 1000-2000ms to the EmptyFeedDelayMs
         // So we need to advance by at least EmptyFeedDelayMs + 1000ms to guarantee triggering
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.EmptyFeedDelayMs + 1000));

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/MessageHandlerMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/MessageHandlerMock.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 
 namespace Altinn.AccessManagement.Tests.Mocks;
 
-    /// <summary>
-    /// Class for mocking http responses when testing
-    /// </summary>
+/// <summary>
+/// Class for mocking http responses when testing
+/// </summary>
 public class MessageHandlerMock : DelegatingHandler
 {
     private readonly HttpStatusCode _expectedResponseStatus;
@@ -28,6 +28,6 @@ public class MessageHandlerMock : DelegatingHandler
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         return Task.FromResult<HttpResponseMessage>(new HttpResponseMessage()
-            { StatusCode = _expectedResponseStatus, Content = _httpContent });
+        { StatusCode = _expectedResponseStatus, Content = _httpContent });
     }
 }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/PepWithPDPAuthorizationMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/PepWithPDPAuthorizationMock.cs
@@ -39,7 +39,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
         public async Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             return await Authorize(xacmlJsonRequest.Request, cancellationToken);
         }
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ResourceMetadataRepositoryMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ResourceMetadataRepositoryMock.cs
@@ -32,7 +32,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
             {
                 PropertyNameCaseInsensitive = true
             };
-            
+
             result = JsonSerializer.Deserialize<AccessManagementResource>(dataStream, options);
             return Task.FromResult(result);
         }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/XacmlResourceAttributes.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/XacmlResourceAttributes.cs
@@ -34,7 +34,7 @@ public class XacmlResourceAttributes
     /// Gets or sets the value for app resource. 
     /// </summary>
     public string AppResourceValue { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the resource registry Id
     /// </summary>

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/PolicyAdministrationPointTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/PolicyAdministrationPointTest.cs
@@ -45,7 +45,7 @@ namespace Altinn.AccessManagement.Tests
             ServiceProvider serviceProvider = services.BuildServiceProvider();
 
             IMemoryCache memoryCache = serviceProvider.GetService<IMemoryCache>();
-            
+
             _logger = new Mock<ILogger<IPolicyAdministrationPoint>>();
             _delegationMetadataRepositoryMock = new DelegationMetadataRepositoryMock();
             _prp = new PolicyFactoryMock(new Mock<ILogger<PolicyRepositoryMock>>().Object);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentMigrationServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentMigrationServiceTests.cs
@@ -128,12 +128,12 @@ public class ConsentMigrationServiceTests
         var consentId = Guid.NewGuid();
         using CancellationTokenSource cts = new CancellationTokenSource();
         _consentServiceMock.Setup(x => x.GetAndStoreAltinn2Consent(consentId, It.IsAny<CancellationToken>()))
-            .Callback(() => 
-            { 
+            .Callback(() =>
+            {
                 cts.Cancel();
                 cts.Token.ThrowIfCancellationRequested();
             });
-        
+
         var service = CreateService();
 
         // Act & Assert

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentMigrationSyncServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentMigrationSyncServiceTests.cs
@@ -49,7 +49,7 @@ public class ConsentMigrationSyncServiceTests
             MaxDegreeOfParallelism = 10
         };
 
-        _settingsMonitorMock = new Mock<IOptionsMonitor<ConsentMigrationSettings>>();        
+        _settingsMonitorMock = new Mock<IOptionsMonitor<ConsentMigrationSettings>>();
         _settingsMonitorMock.Setup(x => x.CurrentValue).Returns(_settings);
 
         // Setup meter factory

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/RequestServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/RequestServiceTests.cs
@@ -166,7 +166,7 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
 
     [Fact]
     public async Task GetRequest_WithPackageRequestId_ReturnsRequestDto()
-    {        
+    {
         var created = (await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft)).Value;
 
         var result = await _requestService.GetRequest(created.Id);
@@ -213,7 +213,7 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     #endregion
 
     #region CreateRequestAssignmentPackage
-    
+
     [Fact]
     public async Task CreateRequestAssignmentPackage_WithValidInput_CreatesDraftRequest()
     {
@@ -296,7 +296,7 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
         Assert.Equal(created.Id, fetched.Value.Id);
 
         // 5. Enduser accepts
-        var accepted = (await _requestService.UpdateRequest(OrgFrom.Id,created.Id, RequestStatus.Approved)).Value;
+        var accepted = (await _requestService.UpdateRequest(OrgFrom.Id, created.Id, RequestStatus.Approved)).Value;
         Assert.Equal(RequestStatus.Approved, accepted.Status);
     }
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/TranslationServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/TranslationServiceTests.cs
@@ -44,7 +44,7 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             .Options;
 
         _db = new AppDbContext(options);
-        
+
         // Set up audit accessor with test values
         _db.AuditAccessor = new AuditAccessor
         {
@@ -53,7 +53,7 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
                 changedBySystem: AuditDefaults.StaticDataIngest
             )
         };
-        
+
         _cache = new MemoryCache(new MemoryCacheOptions());
         _translationService = new TranslationService(_db, _cache, NullLogger<TranslationService>.Instance);
     }
@@ -528,10 +528,10 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
 
         // Act - First call (should query database) - Using normalized language code
         var result1 = await _translationService.TranslateAsync(role, "eng");
-        
+
         // Reset the object
         role.Name = "Original";
-        
+
         // Second call (should use cache)
         var result2 = await _translationService.TranslateAsync(role, "eng");
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Translation/DeepTranslationExtensionsTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Translation/DeepTranslationExtensionsTests.cs
@@ -69,7 +69,7 @@ public class DeepTranslationExtensionsTests : IClassFixture<PostgresFixture>
         Assert.Equal("Property registration", translated.Name);
         Assert.NotNull(translated.Area);
         Assert.Equal("Construction, Infrastructure and Real Estate", translated.Area.Name);
-        Assert.Equal("This authorization area includes access packages related to construction, infrastructure and real estate.", 
+        Assert.Equal("This authorization area includes access packages related to construction, infrastructure and real estate.",
             translated.Area.Description);
     }
 
@@ -183,11 +183,11 @@ public class DeepTranslationExtensionsTests : IClassFixture<PostgresFixture>
 
         // Assert
         Assert.Equal(2, translated.Count);
-        
+
         // First package
         Assert.Equal("Property registration", translated[0].Name);
         Assert.Equal("Construction, Infrastructure and Real Estate", translated[0].Area.Name);
-        
+
         // Second package
         Assert.Equal("Agriculture", translated[1].Name);
         Assert.Equal("Agriculture, Forestry, Hunting, Fishing and Aquaculture", translated[1].Area.Name);
@@ -369,10 +369,10 @@ public class DeepTranslationExtensionsTests : IClassFixture<PostgresFixture>
                 Id = ProviderConstants.Altinn3.Id,
                 Name = "Resource 1",
                 Description = "Test resource 1",
-                Provider = new ProviderDto 
-                { 
-                    Id = ProviderConstants.Altinn3.Id, 
-                    Name = "Altinn 3" 
+                Provider = new ProviderDto
+                {
+                    Id = ProviderConstants.Altinn3.Id,
+                    Name = "Altinn 3"
                 }
             },
             new ResourceDto
@@ -380,10 +380,10 @@ public class DeepTranslationExtensionsTests : IClassFixture<PostgresFixture>
                 Id = ProviderConstants.Altinn2.Id,
                 Name = "Resource 2",
                 Description = "Test resource 2",
-                Provider = new ProviderDto 
-                { 
-                    Id = ProviderConstants.Altinn2.Id, 
-                    Name = "Altinn 2" 
+                Provider = new ProviderDto
+                {
+                    Id = ProviderConstants.Altinn2.Id,
+                    Name = "Altinn 2"
                 }
             }
         };
@@ -445,10 +445,10 @@ public class DeepTranslationExtensionsTests : IClassFixture<PostgresFixture>
                 Id = RoleConstants.MainAdministrator.Id,
                 Name = "Hovedadministrator",
                 Description = "Intern rolle beskrivelse",
-                Provider = new ProviderDto 
-                { 
-                    Id = ProviderConstants.Altinn3.Id, 
-                    Name = "Altinn 3" 
+                Provider = new ProviderDto
+                {
+                    Id = ProviderConstants.Altinn3.Id,
+                    Name = "Altinn 3"
                 }
             },
             new RoleDto
@@ -456,10 +456,10 @@ public class DeepTranslationExtensionsTests : IClassFixture<PostgresFixture>
                 Id = RoleConstants.DeputyLeader.Id,
                 Name = "Nestleder",
                 Description = "Nestleder beskrivelse",
-                Provider = new ProviderDto 
-                { 
-                    Id = ProviderConstants.CentralCoordinatingRegister.Id, 
-                    Name = "Enhetsregisteret" 
+                Provider = new ProviderDto
+                {
+                    Id = ProviderConstants.CentralCoordinatingRegister.Id,
+                    Name = "Enhetsregisteret"
                 }
             }
         };
@@ -540,7 +540,7 @@ public class DeepTranslationExtensionsTests : IClassFixture<PostgresFixture>
         // Assert - Should complete within reasonable time (parallel processing should help)
         Assert.Equal(50, translated.Count());
         Assert.True(duration.TotalSeconds < 10, $"Translation took {duration.TotalSeconds} seconds, expected < 10 seconds");
-        
+
         // Verify translations actually happened
         var firstPackage = translated.First();
         Assert.Equal("Property registration", firstPackage.Name);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utils/AssertionUtil.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utils/AssertionUtil.cs
@@ -85,7 +85,7 @@ namespace Altinn.AccessManagement.Tests.Utils
                 AssertEqual(expected.Results.First(), actual.Results.First());
             }
         }
-        
+
         /// <summary>
         /// Assert that two <see cref="XacmlJsonResponse"/> have the same property values.
         /// </summary>
@@ -127,7 +127,7 @@ namespace Altinn.AccessManagement.Tests.Utils
                 AssertEqual(expectedEntry.Value, actualValue);
             }
         }
-        
+
         /// <summary>
         /// Assert that two lists of <see cref="DelegationChange"/> have the same property values.
         /// </summary>
@@ -145,17 +145,17 @@ namespace Altinn.AccessManagement.Tests.Utils
             foreach (DelegationChange expectedEntity in expected)
             {
                 DelegationChange actualentity =
-                    actual.FirstOrDefault(a => a.ResourceId == expectedEntity.ResourceId && 
-                                               a.ResourceType == expectedEntity.ResourceType && 
-                                               a.BlobStoragePolicyPath == expectedEntity.BlobStoragePolicyPath && 
-                                               a.CoveredByPartyId == expectedEntity.CoveredByPartyId && 
+                    actual.FirstOrDefault(a => a.ResourceId == expectedEntity.ResourceId &&
+                                               a.ResourceType == expectedEntity.ResourceType &&
+                                               a.BlobStoragePolicyPath == expectedEntity.BlobStoragePolicyPath &&
+                                               a.CoveredByPartyId == expectedEntity.CoveredByPartyId &&
                                                a.CoveredByUserId == expectedEntity.CoveredByUserId &&
                                                a.OfferedByPartyId == expectedEntity.OfferedByPartyId &&
                                                a.DelegationChangeType == expectedEntity.DelegationChangeType);
                 Assert.NotNull(actualentity);
             }
         }
-        
+
         /// <summary>
         /// Assert that two lists of <see cref="DelegationChange"/> have the same property values.
         /// </summary>
@@ -983,7 +983,7 @@ namespace Altinn.AccessManagement.Tests.Utils
             Assert.Equal(expected.Value, actual.Value);
         }
 
-        private static void AssertEqual(Delegation expected, Delegation actual) 
+        private static void AssertEqual(Delegation expected, Delegation actual)
         {
             Assert.Equal(expected.CoveredByPartyId, actual.CoveredByPartyId);
             Assert.Equal(expected.PerformedByUserId, actual.PerformedByUserId);
@@ -997,7 +997,7 @@ namespace Altinn.AccessManagement.Tests.Utils
             Assert.Equal(expected.Identifier, actual.Identifier);
             Assert.Equal(expected.Title, actual.Title);
         }
-        
+
         private static void AssertEqual(DelegationChangeExternal expected, DelegationChangeExternal actual)
         {
             Assert.Equal(expected.DelegationChangeId, actual.DelegationChangeId);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utils/PrincipalUtil.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utils/PrincipalUtil.cs
@@ -99,7 +99,7 @@ namespace Altinn.AccessManagement.Tests.Util
         /// <param name="supplier">The supplier</param>
         /// <param name="consumerPrefix">If maskinporten token sets the scope prefixes the organization owns or authorized for</param>
         /// <returns>Claims principal</returns>
-        public static ClaimsPrincipal GetClaimsPrincipal(string org, string orgNumber, string scope = null, string supplier = null,  string[] consumerPrefix = null, bool includeAltinnClaims = true)
+        public static ClaimsPrincipal GetClaimsPrincipal(string org, string orgNumber, string scope = null, string supplier = null, string[] consumerPrefix = null, bool includeAltinnClaims = true)
         {
             string issuer = "https://platform.altinn.cloud/authentication/api/v1/openid/";
 
@@ -128,7 +128,7 @@ namespace Altinn.AccessManagement.Tests.Util
             }
 
             claims.Add(new Claim("consumer", GetOrgNoObject(orgNumber)));
-            
+
             if (includeAltinnClaims)
             {
                 claims.Add(new Claim(AltinnCoreClaimTypes.OrgNumber, orgNumber.ToString(), ClaimValueTypes.Integer32, issuer));

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ClientDelegationControllerTest.cs
@@ -840,7 +840,7 @@ public class ClientDelegationControllerTest
 
                 db.DelegationPackages.Add(delegationPackageFromNordisToPaula);
                 db.DelegationPackages.Add(delegationPackageFromNordisToOrjan);
-      
+
                 db.SaveChanges();
             });
         }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.AddResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.AddResourceRights.cs
@@ -168,7 +168,7 @@ public partial class ConnectionsControllerTest
 
                 foreach (XacmlMatch match in subjectMatches)
                 {
-                   Assert.Equal(TestData.MilleHundefrisor.Entity.PartyId.ToString(),match.AttributeValue.Value);
+                    Assert.Equal(TestData.MilleHundefrisor.Entity.PartyId.ToString(), match.AttributeValue.Value);
                 }
             }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetConnections.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetConnections.cs
@@ -102,7 +102,7 @@ public partial class ConnectionsControllerTest
             client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
             return client;
         }
-        
+
         /// <summary>
         /// Verdiq queries connections where it is the receiver (to=Verdiq) using from-others read scope.
         /// Expects OK.

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/RightsInternalDelegateAndRevokeInstanceDelegation.RevokeInstance.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/RightsInternalDelegateAndRevokeInstanceDelegation.RevokeInstance.cs
@@ -82,7 +82,7 @@ public class RightsInternalDelegateAndRevokeInstanceDelegation : IClassFixture<A
         var toUuid = TestData.BenSolo.Id;
         var performedBy = TestData.HanSolo.Id;
         var resourceId = TestData.TestdirektoratetCorrespondenceService.RefId;
-            
+
         // First, create a delegation to revoke
         var delegationRequest = new InstanceDelegationRequest
         {
@@ -102,7 +102,7 @@ public class RightsInternalDelegateAndRevokeInstanceDelegation : IClassFixture<A
             MediaTypeNames.Application.Json);
 
         var client = CreateClient();
-            
+
         // Create the delegation first
         var delegationResponse = await client.PostAsync(RouteDelegation, delegationContent);
         Assert.Equal(HttpStatusCode.Created, delegationResponse.StatusCode);
@@ -113,7 +113,7 @@ public class RightsInternalDelegateAndRevokeInstanceDelegation : IClassFixture<A
                 a =>
                     a.FromId == fromUuid &&
                     a.ToId == toUuid &&
-                    a.RoleId == RoleConstants.Rightholder, 
+                    a.RoleId == RoleConstants.Rightholder,
                 cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(existingAssignment);
 
@@ -156,7 +156,7 @@ public class RightsInternalDelegateAndRevokeInstanceDelegation : IClassFixture<A
                     a.ToId == toUuid &&
                     a.RoleId == RoleConstants.Rightholder,
                 cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Null(revokedAssignment);            
+        Assert.Null(revokedAssignment);
     }
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Controllers/ServiceOwnerConnectionsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Controllers/ServiceOwnerConnectionsControllerTest.cs
@@ -201,7 +201,7 @@ public class ServiceOwnerConnectionsControllerTest
 
             // Assert - The current implementation only handles person identifiers, so organization identifiers should return BadRequest
             var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-            
+
             // Update this assertion once organization support is added
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Data/TestData.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Data/TestData.cs
@@ -1209,7 +1209,7 @@ public static class TestData
     private static readonly Guid AssignJosephinePriv = Guid.Parse("0196a0b1-0001-7001-8001-000000000042");
     private static readonly Guid AssignMilenaPriv = Guid.Parse("0196a0b1-0001-7001-8001-000000000043");
     private static readonly Guid AssignJinxArcanePriv = Guid.Parse("0196a0b1-0001-7001-8001-000000000044");
-    private static readonly Guid AssignAlexTheArtistPriv = Guid.Parse("0196a0b1-0001-7001-8001-000000000045");    
+    private static readonly Guid AssignAlexTheArtistPriv = Guid.Parse("0196a0b1-0001-7001-8001-000000000045");
     private static readonly Guid AssignHanSoloPriv = Guid.Parse("019dba34-78cc-7b38-b91b-393fc2488c4a");
     private static readonly Guid AssignBenSoloPriv = Guid.Parse("019dba34-a7ce-7ec3-9cc7-beb6e3c7dbce");
     private static readonly Guid AssignLeiaOrganaPriv = Guid.Parse("019dba34-bcf3-7285-8ad8-7709b37cd47a");

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Mocks/ResourceRegistryClientMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Mocks/ResourceRegistryClientMock.cs
@@ -115,7 +115,7 @@ namespace Altinn.AccessManagement.TestUtils.Mocks
         private static string GetResourcePath(string resourceRegistryId)
         {
             string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(ResourceRegistryClientMock).Assembly.Location).LocalPath);
-            return Path.Combine(unitTestFolder, "..", "..", "..","..", "AccessMgmt.Tests", "Data", "ResourceRegistryResources", $"{resourceRegistryId}", "resource.json");
+            return Path.Combine(unitTestFolder, "..", "..", "..", "..", "AccessMgmt.Tests", "Data", "ResourceRegistryResources", $"{resourceRegistryId}", "resource.json");
         }
 
         private static string GetDataPathForResources()
@@ -136,7 +136,7 @@ namespace Altinn.AccessManagement.TestUtils.Mocks
         #region Code from resource registry to support mocking of rights decomposition in access management tests
         public static List<Models.ResourceRegistry.Right> DecomposePolicy(XacmlPolicy policy, string resourceId, bool includeServiceOwnerRights, bool includeAppRights)
         {
-            Dictionary<string, Models.ResourceRegistry.Right> rights = new Dictionary<string, Models.ResourceRegistry.Right >();
+            Dictionary<string, Models.ResourceRegistry.Right> rights = new Dictionary<string, Models.ResourceRegistry.Right>();
 
             foreach (XacmlRule rule in policy.Rules)
             {
@@ -285,7 +285,7 @@ namespace Altinn.AccessManagement.TestUtils.Mocks
                 {
                     result.Add(urn);
                 }
-            } 
+            }
 
             return result;
         }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/DelegationCheckHelperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/DelegationCheckHelperTest.cs
@@ -92,7 +92,7 @@ public class DelegationCheckHelperTest
             anyOfs.Add(new XacmlAnyOf([new XacmlAllOf([MakeXacmlMatch(
                 XacmlConstants.MatchAttributeCategory.Subject,
                 subject.Value.attrId,
-                subject.Value.value)])]));  
+                subject.Value.value)])]));
         }
 
         if (resources != null)
@@ -342,7 +342,7 @@ public class DelegationCheckHelperTest
             "urn:oasis:names:tc:xacml:1.0:action:action-id", "write");
 
         var resourceAllOf = new XacmlAllOf([orgMatch, appMatch]);
-        var actionAllOf   = new XacmlAllOf([actionMatch]);
+        var actionAllOf = new XacmlAllOf([actionMatch]);
         var rule = new XacmlRule("r", XacmlEffectType.Permit)
         {
             Target = new XacmlTarget(

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/Mappers/DtoMapperConnectionQueryTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/Mappers/DtoMapperConnectionQueryTest.cs
@@ -17,37 +17,37 @@ public class DtoMapperConnectionQueryTest
 {
     // ── known EntityTypeConstants / EntityVariantConstants ids ────────────────
     private static readonly Guid OrganizationTypeId = new("8c216e2f-afdd-4234-9ba2-691c727bb33d");
-    private static readonly Guid UtbgVariantId      = new("99a54a28-52d3-4608-9298-94081bb3f3d2");
+    private static readonly Guid UtbgVariantId = new("99a54a28-52d3-4608-9298-94081bb3f3d2");
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
     private static Entity MakeEntity(string name = "Corp") => new()
     {
-        Id        = Guid.NewGuid(),
-        TypeId    = OrganizationTypeId,
+        Id = Guid.NewGuid(),
+        TypeId = OrganizationTypeId,
         VariantId = UtbgVariantId,
-        Name      = name,
+        Name = name,
     };
 
     private static Role MakeRole(string code = "dagl") => new()
     {
-        Id         = Guid.NewGuid(),
-        Code       = code,
-        Urn        = $"altinn:role:{code}",
-        LegacyUrn  = $"urn:altinn:role:{code}",
+        Id = Guid.NewGuid(),
+        Code = code,
+        Urn = $"altinn:role:{code}",
+        LegacyUrn = $"urn:altinn:role:{code}",
     };
 
     private static ConnectionQueryPackage MakeQueryPackage(string urn = "altinn:pkg:test") => new()
     {
-        Id     = Guid.NewGuid(),
-        Urn    = urn,
+        Id = Guid.NewGuid(),
+        Urn = urn,
         AreaId = Guid.NewGuid(),
     };
 
     private static ConnectionQueryResource MakeQueryResource(string name = "Res") => new()
     {
-        Id    = Guid.NewGuid(),
-        Name  = name,
+        Id = Guid.NewGuid(),
+        Name = name,
         RefId = "ref-1",
     };
 
@@ -61,15 +61,15 @@ public class DtoMapperConnectionQueryTest
         List<ConnectionQueryResource>? resources = null) =>
         new()
         {
-            FromId   = from.Id,
-            ToId     = to.Id,
-            RoleId   = role.Id,
-            ViaId    = viaId,
-            Reason   = reason,
-            From     = from,
-            To       = to,
-            Role     = role,
-            Packages = packages  ?? [],
+            FromId = from.Id,
+            ToId = to.Id,
+            RoleId = role.Id,
+            ViaId = viaId,
+            Reason = reason,
+            From = from,
+            To = to,
+            Role = role,
+            Packages = packages ?? [],
             Resources = resources ?? [],
         };
 
@@ -81,18 +81,18 @@ public class DtoMapperConnectionQueryTest
         string reason = "Direct",
         Entity? via = null,
         Package? package = null) => new()
-    {
-        FromId    = from.Id,
-        ToId      = to.Id,
-        RoleId    = role.Id,
-        ViaId     = via?.Id,
-        Reason    = reason,
-        From      = from,
-        To        = to,
-        Role      = role,
-        Via       = via,
-        Package   = package,
-    };
+        {
+            FromId = from.Id,
+            ToId = to.Id,
+            RoleId = role.Id,
+            ViaId = via?.Id,
+            Reason = reason,
+            From = from,
+            To = to,
+            Role = role,
+            Via = via,
+            Package = package,
+        };
 
     // ══════════════════════════════════════════════════════════════════════════
     // ConvertToOthers
@@ -108,9 +108,9 @@ public class DtoMapperConnectionQueryTest
     public void ConvertToOthers_SingleAssignmentRecord_ReturnsMappedConnectionDto()
     {
         var from = MakeEntity("From");
-        var to   = MakeEntity("To");
+        var to = MakeEntity("To");
         var role = MakeRole();
-        var rec  = MakeRecord(from, to, role, ConnectionReason.Assignment);
+        var rec = MakeRecord(from, to, role, ConnectionReason.Assignment);
 
         var result = DtoMapper.ConvertToOthers([rec]);
 
@@ -123,9 +123,9 @@ public class DtoMapperConnectionQueryTest
     public void ConvertToOthers_KeyRoleReason_ExcludedWhenGetSingleFalse()
     {
         var from = MakeEntity();
-        var to   = MakeEntity();
+        var to = MakeEntity();
         var role = MakeRole();
-        var rec  = MakeRecord(from, to, role, ConnectionReason.KeyRole);
+        var rec = MakeRecord(from, to, role, ConnectionReason.KeyRole);
 
         DtoMapper.ConvertToOthers([rec], getSingle: false).Should().BeEmpty();
     }
@@ -134,9 +134,9 @@ public class DtoMapperConnectionQueryTest
     public void ConvertToOthers_KeyRoleReason_IncludedWhenGetSingleTrue()
     {
         var from = MakeEntity();
-        var to   = MakeEntity();
+        var to = MakeEntity();
         var role = MakeRole();
-        var rec  = MakeRecord(from, to, role, ConnectionReason.KeyRole);
+        var rec = MakeRecord(from, to, role, ConnectionReason.KeyRole);
 
         var result = DtoMapper.ConvertToOthers([rec], getSingle: true);
 
@@ -148,9 +148,9 @@ public class DtoMapperConnectionQueryTest
     public void ConvertToOthers_DelegationReason_ExcludedWhenGetSingleFalse()
     {
         var from = MakeEntity();
-        var to   = MakeEntity();
+        var to = MakeEntity();
         var role = MakeRole();
-        var rec  = MakeRecord(from, to, role, ConnectionReason.Delegation);
+        var rec = MakeRecord(from, to, role, ConnectionReason.Delegation);
 
         DtoMapper.ConvertToOthers([rec], getSingle: false).Should().BeEmpty();
     }
@@ -159,7 +159,7 @@ public class DtoMapperConnectionQueryTest
     public void ConvertToOthers_MultipleRecordsSameToId_DeduplicatesRoles()
     {
         var from = MakeEntity();
-        var to   = MakeEntity();
+        var to = MakeEntity();
         var role = MakeRole("dagl");
         var rec1 = MakeRecord(from, to, role);
         var rec2 = MakeRecord(from, to, role);
@@ -173,12 +173,12 @@ public class DtoMapperConnectionQueryTest
     [Fact]
     public void ConvertToOthers_WithViaId_BuildsSubConnections()
     {
-        var from   = MakeEntity("From");
-        var to     = MakeEntity("To");
-        var sub    = MakeEntity("Sub");
-        var role   = MakeRole();
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
+        var sub = MakeEntity("Sub");
+        var role = MakeRole();
         var direct = MakeRecord(from, to, role, ConnectionReason.Assignment);
-        var via    = MakeRecord(from, sub, role, ConnectionReason.KeyRole, viaId: to.Id);
+        var via = MakeRecord(from, sub, role, ConnectionReason.KeyRole, viaId: to.Id);
 
         var result = DtoMapper.ConvertToOthers([direct, via]);
 
@@ -190,10 +190,10 @@ public class DtoMapperConnectionQueryTest
     public void ConvertToOthers_PackagesOnRecord_MappedToDto()
     {
         var from = MakeEntity();
-        var to   = MakeEntity();
+        var to = MakeEntity();
         var role = MakeRole();
-        var pkg  = MakeQueryPackage("altinn:pkg:test");
-        var rec  = MakeRecord(from, to, role, packages: [pkg]);
+        var pkg = MakeQueryPackage("altinn:pkg:test");
+        var rec = MakeRecord(from, to, role, packages: [pkg]);
 
         var result = DtoMapper.ConvertToOthers([rec]);
 
@@ -215,9 +215,9 @@ public class DtoMapperConnectionQueryTest
     public void ConvertFromOthers_SingleRecord_ReturnsMappedConnectionDtoFromFrom()
     {
         var from = MakeEntity("From");
-        var to   = MakeEntity("To");
+        var to = MakeEntity("To");
         var role = MakeRole();
-        var rec  = MakeRecord(from, to, role, ConnectionReason.Assignment);
+        var rec = MakeRecord(from, to, role, ConnectionReason.Assignment);
 
         var result = DtoMapper.ConvertFromOthers([rec]);
 
@@ -230,9 +230,9 @@ public class DtoMapperConnectionQueryTest
     public void ConvertFromOthers_HierarchyReason_ExcludedWhenGetSingleFalse()
     {
         var from = MakeEntity();
-        var to   = MakeEntity();
+        var to = MakeEntity();
         var role = MakeRole();
-        var rec  = MakeRecord(from, to, role, ConnectionReason.Hierarchy);
+        var rec = MakeRecord(from, to, role, ConnectionReason.Hierarchy);
 
         DtoMapper.ConvertFromOthers([rec], getSingle: false).Should().BeEmpty();
     }
@@ -241,9 +241,9 @@ public class DtoMapperConnectionQueryTest
     public void ConvertFromOthers_HierarchyReason_IncludedWhenGetSingleTrue()
     {
         var from = MakeEntity();
-        var to   = MakeEntity();
+        var to = MakeEntity();
         var role = MakeRole();
-        var rec  = MakeRecord(from, to, role, ConnectionReason.Hierarchy);
+        var rec = MakeRecord(from, to, role, ConnectionReason.Hierarchy);
 
         var result = DtoMapper.ConvertFromOthers([rec], getSingle: true);
 
@@ -255,8 +255,8 @@ public class DtoMapperConnectionQueryTest
     public void ConvertFromOthers_MultipleRecordsSameFromId_DeduplicatesRoles()
     {
         var from = MakeEntity("Shared From");
-        var to1  = MakeEntity("To1");
-        var to2  = MakeEntity("To2");
+        var to1 = MakeEntity("To1");
+        var to2 = MakeEntity("To2");
         var role = MakeRole("dagl");
         var rec1 = MakeRecord(from, to1, role);
         var rec2 = MakeRecord(from, to2, role);
@@ -287,13 +287,13 @@ public class DtoMapperConnectionQueryTest
     [Fact]
     public void ConvertSubConnectionsToOthers_GroupsByToId_MapsRolesAndPackages()
     {
-        var from  = MakeEntity("From");
-        var to    = MakeEntity("To");
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
         var role1 = MakeRole("dagl");
         var role2 = MakeRole("regn");
-        var pkg   = MakeQueryPackage();
-        var rec1  = MakeRecord(from, to, role1, packages: [pkg]);
-        var rec2  = MakeRecord(from, to, role2);
+        var pkg = MakeQueryPackage();
+        var rec1 = MakeRecord(from, to, role1, packages: [pkg]);
+        var rec2 = MakeRecord(from, to, role2);
 
         var result = DtoMapper.ConvertSubConnectionsToOthers([rec1, rec2]);
 
@@ -316,13 +316,13 @@ public class DtoMapperConnectionQueryTest
     [Fact]
     public void ConvertSubConnectionsFromOthers_GroupsByFromId_MapsRolesAndResources()
     {
-        var from  = MakeEntity("From");
-        var to    = MakeEntity("To");
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
         var role1 = MakeRole("dagl");
         var role2 = MakeRole("regn");
-        var res   = MakeQueryResource("MyRes");
-        var rec1  = MakeRecord(from, to, role1, resources: [res]);
-        var rec2  = MakeRecord(from, to, role2);
+        var res = MakeQueryResource("MyRes");
+        var rec1 = MakeRecord(from, to, role1, resources: [res]);
+        var rec2 = MakeRecord(from, to, role2);
 
         var result = DtoMapper.ConvertSubConnectionsFromOthers([rec1, rec2]);
 
@@ -340,10 +340,10 @@ public class DtoMapperConnectionQueryTest
     public void ConvertPackages_SinglePackage_ReturnsSinglePackagePermissionDtoWithPermission()
     {
         var from = MakeEntity();
-        var to   = MakeEntity();
+        var to = MakeEntity();
         var role = MakeRole();
-        var pkg  = MakeQueryPackage("altinn:pkg:invoicing");
-        var rec  = MakeRecord(from, to, role, packages: [pkg]);
+        var pkg = MakeQueryPackage("altinn:pkg:invoicing");
+        var rec = MakeRecord(from, to, role, packages: [pkg]);
 
         var result = DtoMapper.ConvertPackages([rec]);
 
@@ -356,10 +356,10 @@ public class DtoMapperConnectionQueryTest
     public void ConvertPackages_SamePackageTwoRecords_DeduplicatesPackageCreatesMultiplePermissions()
     {
         var from = MakeEntity();
-        var to1  = MakeEntity("To1");
-        var to2  = MakeEntity("To2");
+        var to1 = MakeEntity("To1");
+        var to2 = MakeEntity("To2");
         var role = MakeRole();
-        var pkg  = MakeQueryPackage();
+        var pkg = MakeQueryPackage();
         var rec1 = MakeRecord(from, to1, role, packages: [pkg]);
         var rec2 = MakeRecord(from, to2, role, packages: [pkg]);
 
@@ -377,10 +377,10 @@ public class DtoMapperConnectionQueryTest
     public void ConvertResources_FromExtendedRecord_SingleResource_MapsWithPermission()
     {
         var from = MakeEntity();
-        var to   = MakeEntity();
+        var to = MakeEntity();
         var role = MakeRole();
-        var res  = MakeQueryResource("Invoice Resource");
-        var rec  = MakeRecord(from, to, role, resources: [res]);
+        var res = MakeQueryResource("Invoice Resource");
+        var rec = MakeRecord(from, to, role, resources: [res]);
 
         var result = DtoMapper.ConvertResources([rec]);
 
@@ -397,10 +397,10 @@ public class DtoMapperConnectionQueryTest
     public void ConvertToAgentDto_SingleAgent_MapsPartyRolesAndPackages()
     {
         var from = MakeEntity("Client");
-        var to   = MakeEntity("Agent");
+        var to = MakeEntity("Agent");
         var role = MakeRole("dagl");
-        var pkg  = MakeQueryPackage("altinn:pkg:accounting");
-        var rec  = MakeRecord(from, to, role, packages: [pkg]);
+        var pkg = MakeQueryPackage("altinn:pkg:accounting");
+        var rec = MakeRecord(from, to, role, packages: [pkg]);
 
         var result = DtoMapper.ConvertToAgentDto([rec]);
 
@@ -413,12 +413,12 @@ public class DtoMapperConnectionQueryTest
     [Fact]
     public void ConvertToAgentDto_TwoAgents_ReturnsTwoDtos()
     {
-        var from  = MakeEntity("Client");
-        var to1   = MakeEntity("Agent1");
-        var to2   = MakeEntity("Agent2");
-        var role  = MakeRole();
-        var rec1  = MakeRecord(from, to1, role);
-        var rec2  = MakeRecord(from, to2, role);
+        var from = MakeEntity("Client");
+        var to1 = MakeEntity("Agent1");
+        var to2 = MakeEntity("Agent2");
+        var role = MakeRole();
+        var rec1 = MakeRecord(from, to1, role);
+        var rec2 = MakeRecord(from, to2, role);
 
         var result = DtoMapper.ConvertToAgentDto([rec1, rec2]);
 
@@ -462,11 +462,11 @@ public class DtoMapperConnectionQueryTest
     [Fact]
     public void ExtractRelationDtoToOthers_OnlyDirectConnectionsReturned()
     {
-        var mapper    = new DtoMapper();
-        var from      = MakeEntity("From");
-        var to        = MakeEntity("To");
-        var role      = MakeRole();
-        var direct    = MakeConnection(from, to, role, "Direct");
+        var mapper = new DtoMapper();
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
+        var role = MakeRole();
+        var direct = MakeConnection(from, to, role, "Direct");
         var nonDirect = MakeConnection(from, to, role, "Delegated");
 
         var result = mapper.ExtractRelationDtoToOthers([direct, nonDirect]).ToList();
@@ -478,12 +478,12 @@ public class DtoMapperConnectionQueryTest
     [Fact]
     public void ExtractRelationDtoToOthers_IncludeSubConnections_PopulatesConnections()
     {
-        var mapper  = new DtoMapper();
-        var from    = MakeEntity("From");
-        var to      = MakeEntity("To");
-        var sub     = MakeEntity("Sub");
-        var role    = MakeRole();
-        var direct  = MakeConnection(from, to, role, "Direct");
+        var mapper = new DtoMapper();
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
+        var sub = MakeEntity("Sub");
+        var role = MakeRole();
+        var direct = MakeConnection(from, to, role, "Direct");
         var subConn = MakeConnection(from, sub, role, "Delegated", via: to);
 
         var result = mapper.ExtractRelationDtoToOthers([direct, subConn], includeSubConnections: true).ToList();
@@ -496,12 +496,12 @@ public class DtoMapperConnectionQueryTest
     public void ExtractRelationDtoFromOthers_AllConnectionsGroupedByFromId()
     {
         var mapper = new DtoMapper();
-        var from   = MakeEntity("SharedFrom");
-        var to1    = MakeEntity("To1");
-        var to2    = MakeEntity("To2");
-        var role   = MakeRole();
-        var conn1  = MakeConnection(from, to1, role);
-        var conn2  = MakeConnection(from, to2, role);
+        var from = MakeEntity("SharedFrom");
+        var to1 = MakeEntity("To1");
+        var to2 = MakeEntity("To2");
+        var role = MakeRole();
+        var conn1 = MakeConnection(from, to1, role);
+        var conn2 = MakeConnection(from, to2, role);
 
         var result = mapper.ExtractRelationDtoFromOthers([conn1, conn2]).ToList();
 
@@ -512,11 +512,11 @@ public class DtoMapperConnectionQueryTest
     [Fact]
     public void ExtractSubRelationDtoToOthers_FiltersByViaPartyAndNonDirect()
     {
-        var mapper  = new DtoMapper();
-        var from    = MakeEntity("From");
-        var to      = MakeEntity("To");
-        var via     = MakeEntity("Via");
-        var role    = MakeRole();
+        var mapper = new DtoMapper();
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
+        var via = MakeEntity("Via");
+        var role = MakeRole();
         var subConn = MakeConnection(from, to, role, "Delegated", via: via);
 
         var result = mapper.ExtractSubRelationDtoToOthers([subConn], via.Id).ToList();
@@ -529,10 +529,10 @@ public class DtoMapperConnectionQueryTest
     public void ExtractSubRelationDtoToOthers_DirectConnectionsExcluded()
     {
         var mapper = new DtoMapper();
-        var from   = MakeEntity();
-        var to     = MakeEntity();
-        var via    = MakeEntity();
-        var role   = MakeRole();
+        var from = MakeEntity();
+        var to = MakeEntity();
+        var via = MakeEntity();
+        var role = MakeRole();
         var direct = MakeConnection(from, to, role, "Direct", via: via);
 
         var result = mapper.ExtractSubRelationDtoToOthers([direct], via.Id).ToList();
@@ -543,11 +543,11 @@ public class DtoMapperConnectionQueryTest
     [Fact]
     public void ExtractSubRelationDtoFromOthers_FiltersByViaPartyAndNonDirect()
     {
-        var mapper  = new DtoMapper();
-        var from    = MakeEntity("From");
-        var to      = MakeEntity("To");
-        var via     = MakeEntity("Via");
-        var role    = MakeRole();
+        var mapper = new DtoMapper();
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
+        var via = MakeEntity("Via");
+        var role = MakeRole();
         var subConn = MakeConnection(from, to, role, "Delegated", via: via);
 
         var result = mapper.ExtractSubRelationDtoFromOthers([subConn], via.Id).ToList();
@@ -560,11 +560,11 @@ public class DtoMapperConnectionQueryTest
     public void ExtractRelationPackageDtoToOthers_DirectConnectionsWithPackagesMapped()
     {
         var mapper = new DtoMapper();
-        var from   = MakeEntity("From");
-        var to     = MakeEntity("To");
-        var role   = MakeRole();
-        var pkg    = new Package { Id = Guid.NewGuid(), Urn = "altinn:pkg:test", Name = "Test" };
-        var conn   = MakeConnection(from, to, role, "Direct", package: pkg);
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
+        var role = MakeRole();
+        var pkg = new Package { Id = Guid.NewGuid(), Urn = "altinn:pkg:test", Name = "Test" };
+        var conn = MakeConnection(from, to, role, "Direct", package: pkg);
 
         var result = mapper.ExtractRelationPackageDtoToOthers([conn]).ToList();
 
@@ -577,11 +577,11 @@ public class DtoMapperConnectionQueryTest
     public void ExtractRelationPackageDtoFromOthers_AllConnectionsGroupedByFromIdWithPackages()
     {
         var mapper = new DtoMapper();
-        var from   = MakeEntity("From");
-        var to     = MakeEntity("To");
-        var role   = MakeRole();
-        var pkg    = new Package { Id = Guid.NewGuid(), Urn = "altinn:pkg:from-pkg", Name = "From Pkg" };
-        var conn   = MakeConnection(from, to, role, package: pkg);
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
+        var role = MakeRole();
+        var pkg = new Package { Id = Guid.NewGuid(), Urn = "altinn:pkg:from-pkg", Name = "From Pkg" };
+        var conn = MakeConnection(from, to, role, package: pkg);
 
         var result = mapper.ExtractRelationPackageDtoFromOthers([conn]).ToList();
 
@@ -593,12 +593,12 @@ public class DtoMapperConnectionQueryTest
     [Fact]
     public void ExtractSubRelationPackageDtoToOthers_FiltersByViaWithPackages()
     {
-        var mapper  = new DtoMapper();
-        var from    = MakeEntity("From");
-        var to      = MakeEntity("To");
-        var via     = MakeEntity("Via");
-        var role    = MakeRole();
-        var pkg     = new Package { Id = Guid.NewGuid(), Urn = "altinn:pkg:sub", Name = "Sub Pkg" };
+        var mapper = new DtoMapper();
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
+        var via = MakeEntity("Via");
+        var role = MakeRole();
+        var pkg = new Package { Id = Guid.NewGuid(), Urn = "altinn:pkg:sub", Name = "Sub Pkg" };
         var subConn = MakeConnection(from, to, role, "Delegated", via: via, package: pkg);
 
         var result = mapper.ExtractSubRelationPackageDtoToOthers([subConn], via.Id).ToList();
@@ -611,12 +611,12 @@ public class DtoMapperConnectionQueryTest
     [Fact]
     public void ExtractSubRelationPackageDtoFromOthers_FiltersByViaWithPackages()
     {
-        var mapper  = new DtoMapper();
-        var from    = MakeEntity("From");
-        var to      = MakeEntity("To");
-        var via     = MakeEntity("Via");
-        var role    = MakeRole();
-        var pkg     = new Package { Id = Guid.NewGuid(), Urn = "altinn:pkg:subfrom", Name = "Sub From Pkg" };
+        var mapper = new DtoMapper();
+        var from = MakeEntity("From");
+        var to = MakeEntity("To");
+        var via = MakeEntity("Via");
+        var role = MakeRole();
+        var pkg = new Package { Id = Guid.NewGuid(), Urn = "altinn:pkg:subfrom", Name = "Sub From Pkg" };
         var subConn = MakeConnection(from, to, role, "Delegated", via: via, package: pkg);
 
         var result = mapper.ExtractSubRelationPackageDtoFromOthers([subConn], via.Id).ToList();

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Clients/PartyClient.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Clients/PartyClient.cs
@@ -10,7 +10,7 @@ namespace Altinn.Platform.Authorization.Clients
     /// Client configuration for actor api
     /// </summary>
     public class PartyClient
-    {        
+    {
         /// <summary>
         /// Gets an instance of httpclient from httpclientfactory
         /// </summary>

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Clients/ProfileClient.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Clients/ProfileClient.cs
@@ -10,7 +10,7 @@ namespace Altinn.Platform.Authorization.Clients
     /// Client configuration for profile api
     /// </summary>
     public class ProfileClient
-    {        
+    {
         /// <summary>
         /// Gets an instance of httpclient from httpclientfactory
         /// </summary>

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Clients/ResourceRegistryClient.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Clients/ResourceRegistryClient.cs
@@ -10,7 +10,7 @@ namespace Altinn.Platform.Authorization.Clients
     /// Client configuration for resource registry
     /// </summary>
     public class ResourceRegistryClient
-    {        
+    {
         /// <summary>
         /// Gets an instance of httpclient from httpclientfactory
         /// </summary>

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Clients/SBLClient.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Clients/SBLClient.cs
@@ -10,7 +10,7 @@ namespace Altinn.Platform.Authorization.Clients
     /// Client configuration for actor api
     /// </summary>
     public class SBLClient
-    {        
+    {
         /// <summary>
         /// Gets an instance of httpclient from httpclientfactory
         /// </summary>

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Configuration/GeneralSettings.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Configuration/GeneralSettings.cs
@@ -49,8 +49,8 @@ namespace Altinn.Platform.Authorization.Configuration
         /// <summary>
         /// Gets or sets the cache timeout
         /// </summary>
-        public int PolicyCacheTimeout { get; set;  }
-        
+        public int PolicyCacheTimeout { get; set; }
+
         /// <summary>
         /// Name of the cookie for runtime
         /// </summary>

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
@@ -366,7 +366,7 @@ namespace Altinn.Platform.Authorization.Controllers
             decisionRequest = await this._contextHandler.Enrich(decisionRequest, isExernalRequest, _appInstanceInfo);
 
             XacmlPolicy policy = await _prp.GetPolicyAsync(decisionRequest);
-            
+
             if (policy == null)
             {
                 throw new ArgumentException("Policy not found for resource");

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/PolicyController.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/PolicyController.cs
@@ -136,7 +136,7 @@ namespace Altinn.Platform.Authorization.Controllers
         /// <returns>A list resourcePolicyResponses</returns>
         [AllowAnonymous]
         [HttpPost("/authorization/api/v1/policies/GetPolicies")]
-        public async Task<ActionResult> GetResourcePolicies([FromBody]List<List<AttributeMatch>> appIdList, [FromQuery] string language)
+        public async Task<ActionResult> GetResourcePolicies([FromBody] List<List<AttributeMatch>> appIdList, [FromQuery] string language)
         {
             List<ResourcePolicyResponse> resourcePolicyResponses = new List<ResourcePolicyResponse>();
             foreach (var attributeMatches in appIdList)

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Extensions/ClaimsPrincipalExtensions.cs
@@ -2,7 +2,7 @@ using System.Security.Claims;
 using AltinnCore.Authentication.Constants;
 
 namespace Altinn.Platform.Authenticaiton.Extensions
-{ 
+{
     /// <summary>
     /// Helper methods to extend ClaimsPrincipal. 
     /// </summary>

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Helpers/Extensions/StringExtensions.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Helpers/Extensions/StringExtensions.cs
@@ -31,7 +31,7 @@ namespace Altinn.Platform.Authorization.Helpers.Extensions
             if (throwExceptionOnInvalidCharacters)
             {
                 if (illegalFileNameCharacters.Any(ic => input.Any(i => ic == i)))
-                {                    
+                {
                     throw new ArgumentOutOfRangeException(nameof(input));
                 }
 

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Helpers/PolicyHelper.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Helpers/PolicyHelper.cs
@@ -325,7 +325,7 @@ namespace Altinn.Platform.Authorization.Helpers
         public static XacmlRule BuildDelegationRule(string org, string app, int offeredByPartyId, int? coveredByPartyId, int? coveredByUserId, Rule rule)
         {
             rule.RuleId = Guid.NewGuid().ToString();
-            
+
             string coveredBy = coveredByPartyId.HasValue ? coveredByPartyId.Value.ToString() : coveredByUserId.Value.ToString();
             XacmlRule delegationRule = new XacmlRule(rule.RuleId, XacmlEffectType.Permit)
             {
@@ -514,7 +514,7 @@ namespace Altinn.Platform.Authorization.Helpers
                     if (action != null)
                     {
                         return new AttributeMatch { Id = action.AttributeDesignator.AttributeId.OriginalString, Value = action.AttributeValue.Value };
-                    }                    
+                    }
                 }
             }
 
@@ -530,7 +530,7 @@ namespace Altinn.Platform.Authorization.Helpers
                 {
                     foreach (XacmlMatch xacmlMatch in allOf.Matches.Where(m => m.AttributeDesignator.Category.Equals(XacmlConstants.MatchAttributeCategory.Resource)))
                     {
-                        result.Add(new AttributeMatch { Id = xacmlMatch.AttributeDesignator.AttributeId.OriginalString, Value = xacmlMatch.AttributeValue.Value });                        
+                        result.Add(new AttributeMatch { Id = xacmlMatch.AttributeDesignator.AttributeId.OriginalString, Value = xacmlMatch.AttributeValue.Value });
                     }
                 }
             }

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Modelbindig/XacmlRequestApiModelBinderProvider.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Modelbindig/XacmlRequestApiModelBinderProvider.cs
@@ -24,7 +24,7 @@ namespace Altinn.Platform.Authorization.ModelBinding
 
             if (modelType.Equals(typeof(XacmlRequestApiModel)))
             {
-               return new XacmlRequestApiModelBinder();
+                return new XacmlRequestApiModelBinder();
             }
 
             return null;

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/External/XacmlJsonResultExternal.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/External/XacmlJsonResultExternal.cs
@@ -16,7 +16,7 @@ namespace Altinn.Platform.Authorization.Models.External
         /// <summary>
         /// Gets or sets the status.
         /// </summary>
-        public XacmlJsonStatusExternal Status { get; set;  }
+        public XacmlJsonStatusExternal Status { get; set; }
 
         /// <summary>
         /// Gets or sets any obligations of the result.
@@ -31,7 +31,7 @@ namespace Altinn.Platform.Authorization.Models.External
         /// <summary>
         /// Gets or sets category.
         /// </summary>
-        public List<XacmlJsonCategoryExternal> Category { get; set;  }
+        public List<XacmlJsonCategoryExternal> Category { get; set; }
 
         /// <summary>
         /// Gets or sets policy Identifyer list related to the result.

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/RequestToDelete.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/RequestToDelete.cs
@@ -39,7 +39,7 @@ namespace Altinn.Platform.Authorization.Models
 
             if (this.DeletedByUserId == 0)
             {
-                validationResult.Add(new ValidationResult("Not all RequestToDelete has a value for the user performing the delete"));                
+                validationResult.Add(new ValidationResult("Not all RequestToDelete has a value for the user performing the delete"));
             }
 
             return validationResult;

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/ResourceRegistry/AccessListInfoDTO.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/ResourceRegistry/AccessListInfoDTO.cs
@@ -12,7 +12,7 @@ namespace Altinn.ResourceRegistry.Models;
 /// <param name="Name">The access list name</param>
 /// <param name="Description">The access list description</param>
 public record AccessListInfoDto(
-    AccessListUrn Urn, 
+    AccessListUrn Urn,
     string Identifier,
     string Name,
     string Description

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/ResourceRegistry/Keyword.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/ResourceRegistry/Keyword.cs
@@ -8,7 +8,7 @@ public class Keyword
     /// <summary>
     /// The key word
     /// </summary>
-    public string Word { get; set; } 
+    public string Word { get; set; }
 
     /// <summary>
     /// Language of the key word

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/ResourceRegistry/ReferenceSource.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/ResourceRegistry/ReferenceSource.cs
@@ -7,7 +7,7 @@ namespace Altinn.Authorization.Models.ResourceRegistry;
 /// </summary>
 public enum ReferenceSource
 {
-    [EnumMember(Value = "Default")]    
+    [EnumMember(Value = "Default")]
     Default = 0,
 
     [EnumMember(Value = "Altinn1")]

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/ResourceRegistry/ReferenceType.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/ResourceRegistry/ReferenceType.cs
@@ -12,13 +12,13 @@ public enum ReferenceType
 
     [EnumMember(Value = "Uri")]
     Uri = 1,
-    
+
     [EnumMember(Value = "DelegationSchemeId")]
     DelegationSchemeId = 2,
 
     [EnumMember(Value = "MaskinportenScope")]
     MaskinportenScope = 3,
-    
+
     [EnumMember(Value = "ServiceCode")]
     ServiceCode = 4,
 

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/ResourceRegistry/ServiceResource.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/ResourceRegistry/ServiceResource.cs
@@ -36,12 +36,12 @@ public class ServiceResource
     /// <summary>
     /// Description explaining the rights a recipient will receive if given access to the resource
     /// </summary>
-    public Dictionary<string, string>? RightDescription { get; set;  }
+    public Dictionary<string, string>? RightDescription { get; set; }
 
     /// <summary>
     /// The homepage
     /// </summary>
-    public string? Homepage { get; set; }    
+    public string? Homepage { get; set; }
 
     /// <summary>
     /// The status
@@ -52,7 +52,7 @@ public class ServiceResource
     /// spatial coverage
     /// This property represents that area(s) a Public Service is likely to be available only within, typically the area(s) covered by a particular public authority.
     /// </summary>
-    public List<string>? Spatial { get; set;  }
+    public List<string>? Spatial { get; set; }
 
     /// <summary>
     /// List of possible contact points
@@ -63,7 +63,7 @@ public class ServiceResource
     /// <summary>
     /// Linkes to the outcome of a public service
     /// </summary>
-    public List<string>? Produces { get; set;  }
+    public List<string>? Produces { get; set; }
 
     /// <summary>
     /// IsPartOf
@@ -78,17 +78,17 @@ public class ServiceResource
     /// <summary>
     /// ResourceReference
     /// </summary>
-    public List<ResourceReference>? ResourceReferences { get; set;  }
+    public List<ResourceReference>? ResourceReferences { get; set; }
 
     /// <summary>
     /// Is this resource possible to delegate to others or not
     /// </summary>
     public bool Delegable { get; set; } = true;
-    
+
     /// <summary>
     /// The visibility of the resource
     /// </summary>
-    public bool Visible { get; set; } = true; 
+    public bool Visible { get; set; } = true;
 
     /// <summary>
     /// HasCompetentAuthority

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
@@ -230,7 +230,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             if (resourceAttributes.ResourceInstanceValue != null && resourceAttributes.AppInstanceIdValue != null)
             {
                 // Missing resource registry instanceId attribute, add both old and new attribute for backward compatibility.
-                requestResourceAttributes.Attributes.Add(GetStringAttribute(XacmlRequestAttribute.ResourceRegistryInstanceAttribute, resourceAttributes.AppInstanceIdValue));           
+                requestResourceAttributes.Attributes.Add(GetStringAttribute(XacmlRequestAttribute.ResourceRegistryInstanceAttribute, resourceAttributes.AppInstanceIdValue));
                 requestResourceAttributes.Attributes.Add(GetStringAttribute(XacmlRequestAttribute.ResourceRegistryInstanceAttribute, resourceAttributes.ResourceInstanceValue));
             }
 
@@ -750,7 +750,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         protected XacmlAttribute GetPartyTypeAttribute(PartyType partyType)
         {
             XacmlAttribute attribute = new XacmlAttribute(new Uri(XacmlRequestAttribute.PartyTypeAttribute), false);
-           
+
             if (partyType == PartyType.Organisation)
             {
                 attribute.AttributeValues.Add(new XacmlAttributeValue(new Uri(XacmlConstants.DataTypes.XMLString), XacmlRequestAttribute.PartyTypeOrganizationValue));

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/RegisterService.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/RegisterService.cs
@@ -141,7 +141,7 @@ namespace Altinn.Platform.Authorization.Services
             {
                 return parties;
             }
-            
+
             string endpointUrl = $"parties/partylist?fetchSubUnits={includeSubunits}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _generalSettings.RuntimeCookieName);
             string accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "authorization");

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AccessListAuthorizationControllerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AccessListAuthorizationControllerTest.cs
@@ -57,7 +57,7 @@ public class AccessListAuthorizationControllerTest : IClassFixture<Authorization
 
     private static HttpRequestMessage GetPostRequestMessage(string testCase, string platformAccessToken = null)
     {
-        string requestPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(AccessListAuthorizationControllerTest).Assembly.Location).LocalPath),  "Data", "Json", "AccessListAuthorization");
+        string requestPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(AccessListAuthorizationControllerTest).Assembly.Location).LocalPath), "Data", "Json", "AccessListAuthorization");
         string requestText = File.ReadAllText(Path.Combine(requestPath, testCase + "_Request.json"));
 
         HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, "authorization/api/v1/accesslist/accessmanagement/authorization")

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AltinnApps_DecisionTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AltinnApps_DecisionTests.cs
@@ -96,7 +96,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             eventQueue.Setup(q => q.EnqueueAuthorizationEvent(It.IsAny<AuthorizationEvent>(), It.IsAny<CancellationToken>()));
             AuthorizationEvent expectedAuthorizationEvent = TestSetupUtil.GetAuthorizationEvent(testCase);
 
-            HttpClient client = GetTestClient(eventQueue.Object, featureManageMock.Object, timeProviderMock.Object);            
+            HttpClient client = GetTestClient(eventQueue.Object, featureManageMock.Object, timeProviderMock.Object);
             HttpRequestMessage httpRequestMessage = TestSetupUtil.CreateJsonProfileXacmlRequest(testCase);
             XacmlJsonResponse expected = TestSetupUtil.ReadExpectedJsonProfileResponse(testCase);
 
@@ -278,7 +278,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
         [Fact]
         public async Task PDP_Decision_AltinnApps0028()
         {
-            string testCase = "AltinnApps0028"; 
+            string testCase = "AltinnApps0028";
 
             Mock<IFeatureManager> featureManageMock = new Mock<IFeatureManager>();
             featureManageMock.Setup(m => m.IsEnabledAsync("DecisionRequestLogRequestOnError", It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
@@ -598,10 +598,10 @@ namespace Altinn.Platform.Authorization.IntegrationTests
         }
 
         private void SetupFeatureMock(bool featureFlag)
-        {            
+        {
             featureManageMock
                 .Setup(m => m.IsEnabledAsync("AuditLog"))
-                .Returns(Task.FromResult(featureFlag));            
+                .Returns(Task.FromResult(featureFlag));
         }
 
         private void SetupDateTimeMock()

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Data/TestDataHelper.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Data/TestDataHelper.cs
@@ -59,7 +59,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Data
                     OfferedByPartyId = offeredByPartyId,
                     Resource = new List<AttributeMatch> { new AttributeMatch { Id = AltinnXacmlConstants.MatchAttributeIdentifiers.OrgAttribute, Value = org }, new AttributeMatch { Id = AltinnXacmlConstants.MatchAttributeIdentifiers.AppAttribute, Value = app } }
                 },
-                
+
                 RuleIds = ruleIds
             };
 

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventsQueueClientTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventsQueueClientTests.cs
@@ -157,9 +157,9 @@ namespace Altinn.Authorization.Tests
             using var ms = new MemoryStream(sentData, 2, sentData.Length - 2);
             using var brotli = new BrotliStream(ms, CompressionMode.Decompress);
             var decompressed = JsonSerializer.Deserialize<AuthorizationEvent>(brotli, JsonSerializerOptions.Web);
-           
+
             Assert.Equal(evt.Operation, decompressed.Operation);
-            
+
             // Ensure the original JSON is preserved (fallback was NOT triggered)
             Assert.True(JsonElement.DeepEquals(evt.ContextRequestJson, decompressed.ContextRequestJson));
         }
@@ -169,7 +169,7 @@ namespace Altinn.Authorization.Tests
             var buffer = data.ToArray();
             Base64.DecodeFromUtf8InPlace(buffer, out var written);
             Base64.DecodeFromUtf8InPlace(buffer.AsSpan(0, written), out var finalWritten);
-            
+
             return buffer.AsMemory(0, finalWritten).ToArray();
         }
     }

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/MockServices/ContextHandlerMock.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/MockServices/ContextHandlerMock.cs
@@ -79,7 +79,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             string appresourceAttributeValue = string.Empty;
 
             XacmlContextAttributes resourceContextAttributes = request.GetResourceAttributes();
-      
+
             foreach (XacmlAttribute attribute in resourceContextAttributes.Attributes)
             {
                 if (attribute.AttributeId.OriginalString.Equals(_orgAttributeId))
@@ -191,7 +191,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
 
             if (subjectUserId == 0)
             {
-                return; 
+                return;
             }
 
             List<Role> roleList = await _rolesWrapper.GetDecisionPointRolesForUser(subjectUserId, resourcePartyId) ?? new List<Role>();
@@ -248,7 +248,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
 
         private string GetTestId(HttpContext context)
         {
-           return context.Request.Headers["testcase"];
+            return context.Request.Headers["testcase"];
         }
 
         private string GetAltinnAppsPath()

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/MockServices/DelegationMetadataRepositoryMock.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/MockServices/DelegationMetadataRepositoryMock.cs
@@ -48,7 +48,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
                 BlobStorageVersionId = delegationChange.BlobStorageVersionId,
                 Created = DateTime.Now
             };
-    
+
             current.Add(currentDelegationChange);
 
             if (string.IsNullOrEmpty(delegationChange.AltinnAppId) || delegationChange.AltinnAppId == "error/postgrewritechangefail")

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/MockServices/PolicyRetrievalPointMock.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/MockServices/PolicyRetrievalPointMock.cs
@@ -17,7 +17,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
 
         private readonly IHttpContextAccessor _httpContextAccessor;
 
-        private readonly ILogger<PolicyRetrievalPointMock> _logger;   
+        private readonly ILogger<PolicyRetrievalPointMock> _logger;
 
         private readonly string _orgAttributeId = "urn:altinn:org";
 
@@ -182,7 +182,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
                 XmlDocument policyDocument = new XmlDocument();
 
                 policyDocument.Load(Path.Combine(policyPath, policyDocumentTitle));
-                
+
                 using (XmlReader reader = XmlReader.Create(new StringReader(policyDocument.OuterXml)))
                 {
                     policy = XacmlParser.ParseXacmlPolicy(reader);

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/MockServices/ResourceRegistryMock.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/MockServices/ResourceRegistryMock.cs
@@ -123,7 +123,7 @@ public class ResourceRegistryMock : IResourceRegistry
         string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(AltinnApps_DecisionTests).Assembly.Location).LocalPath);
         return Path.Combine(unitTestFolder, "..", "..", "..", "Data", "Xacml", "3.0", "ResourceRegistry", resourceId);
     }
-    
+
     public static XacmlPolicy ParsePolicy(string policyDocumentTitle, string policyPath)
     {
         XmlDocument policyDocument = new XmlDocument();

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/MockServices/RolesMock.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/MockServices/RolesMock.cs
@@ -19,7 +19,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             if (File.Exists(rolesPath))
             {
                 string content = File.ReadAllText(rolesPath);
-                roles = (List<Role>)JsonSerializer.Deserialize(content, typeof(List<Role>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });               
+                roles = (List<Role>)JsonSerializer.Deserialize(content, typeof(List<Role>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
             }
 
             return Task.FromResult(roles);

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PartiesControllerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PartiesControllerTest.cs
@@ -165,5 +165,5 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
-            }
-        }
+    }
+}

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyAdministrationPointTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyAdministrationPointTest.cs
@@ -133,7 +133,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             {
                 TestDataHelper.GetRequestToDeleteModel(performedByUserId, offeredByPartyId, "org1", "app3", new List<string> { "0d0c8570-64fb-49f9-9f7d-45c057fddf94", "6f11dd0b-5e5d-4bd1-85f0-9796300dfded" }, coveredByUserId: coveredBy),
                 TestDataHelper.GetRequestToDeleteModel(performedByUserId, offeredByPartyId, "org2", "app3", new List<string> { "244278c1-7c6b-4f6b-b6e9-2bd41f84812f" }, coveredByUserId: coveredBy),
-                TestDataHelper.GetRequestToDeleteModel(performedByUserId, offeredByPartyId, "org1", "app4", new List<string> { "adfa64fa-5859-46e5-8d0d-62762082f3b9" }, coveredByUserId: coveredBy)                
+                TestDataHelper.GetRequestToDeleteModel(performedByUserId, offeredByPartyId, "org1", "app4", new List<string> { "adfa64fa-5859-46e5-8d0d-62762082f3b9" }, coveredByUserId: coveredBy)
             };
 
             List<Rule> expected = new List<Rule>
@@ -516,7 +516,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
                 TestDataHelper.GetRequestToDeleteModel(performedByUserId, offeredByPartyId, "org2", "app3", new List<string> { "244278c1-7c6b-4f6b-b6e9-2bd41f84812f" }, coveredByUserId: coveredBy),
                 TestDataHelper.GetRequestToDeleteModel(performedByUserId, offeredByPartyId, "org1", "app4", new List<string> { "ade3b138-7fa4-4c83-9306-8ec4a72c2daa" }, coveredByUserId: 0)
             };
-            
+
             List<Rule> expected = new List<Rule>
             {
                 TestDataHelper.GetRuleModel(performedByUserId, offeredByPartyId, coveredBy.ToString(), coveredByType, "read", "org1", "app3", createdSuccessfully: true),
@@ -1236,7 +1236,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
 
             List<Rule> unsortedRules = new List<Rule>
             {
-                TestDataHelper.GetRuleModel(delegatedByUserId, offeredByPartyId, coveredBy, coveredByType, "read", "org1", "app1"), 
+                TestDataHelper.GetRuleModel(delegatedByUserId, offeredByPartyId, coveredBy, coveredByType, "read", "org1", "app1"),
                 TestDataHelper.GetRuleModel(delegatedByUserId, offeredByPartyId, coveredBy, coveredByType, "read", "org2", "app1"),
                 TestDataHelper.GetRuleModel(delegatedByUserId, offeredByPartyId, coveredBy, coveredByType, "sign", "org1", "app1", "task1"),
                 TestDataHelper.GetRuleModel(delegatedByUserId, offeredByPartyId, coveredBy, coveredByType, "read", "org1", "app1", task: null, "event1") // This should fail all rules for org1, app1 as there is no event1 resource in the App Policy for this app

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyControllerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyControllerTest.cs
@@ -474,5 +474,5 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             return policies;
         }
 
-            }
-        }
+    }
+}

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyRetrievalPointTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyRetrievalPointTest.cs
@@ -35,7 +35,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             ServiceCollection services = new ServiceCollection();
             services.AddMemoryCache();
             ServiceProvider serviceProvider = services.BuildServiceProvider();
-            
+
             IMemoryCache memoryCache = serviceProvider.GetService<IMemoryCache>();
 
             _prp = new PolicyRetrievalPoint(
@@ -203,7 +203,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             xacmlContext.Attributes.Add(xacmlAttributeOrg);
 
             xacmlContexts.Add(xacmlContext);
-            
+
             return xacmlContexts;
         }
     }

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Util/AssertionUtil.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Util/AssertionUtil.cs
@@ -80,7 +80,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Util
                 AssertEqual(expected.Results.First(), actual.Results.First());
             }
         }
-        
+
         /// <summary>
         /// Assert that two <see cref="XacmlJsonResponse"/> have the same property values.
         /// </summary>
@@ -253,7 +253,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Util
             {
                 AssertCollections(expected.ResourcePolicies, actual.ResourcePolicies, AssertResourcePolicyEqual);
             }
-            
+
             AssertCollections(expected.AppId, actual.AppId, AssertAttributeMatchEqual);
             Assert.Equal(expected.MinimumAuthenticationLevel, actual.MinimumAuthenticationLevel);
 
@@ -308,7 +308,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Util
                                                     q.SubjectOrgCode == expectedAuthorizationEvent.SubjectOrgCode &&
                                                     q.SubjectOrgNumber == expectedAuthorizationEvent.SubjectOrgNumber &&
                                                     q.SubjectUserId == expectedAuthorizationEvent.SubjectUserId),
-                    It.IsAny<CancellationToken>()), 
+                    It.IsAny<CancellationToken>()),
                 numberOfTimes);
         }
 

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Xacml30ConformanceTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Xacml30ConformanceTests.cs
@@ -569,16 +569,16 @@ namespace Altinn.Platform.Authorization.IntegrationTests
         {
             HttpClient client = _factory.WithWebHostBuilder(builder =>
             {
-               builder.ConfigureTestServices(services =>
-                {
-                    services.AddScoped<IContextHandler, ContextHandlerMock>();
-                    services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
-                    services.AddSingleton<IDelegationMetadataRepository, DelegationMetadataRepositoryMock>();
-                    services.AddSingleton<IRoles, RolesMock>();
-                    services.AddSingleton<IPolicyRepository, PolicyRepositoryMock>();
-                    services.AddSingleton<IDelegationChangeEventQueue, DelegationChangeEventQueueMock>();
-                    services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
-                });
+                builder.ConfigureTestServices(services =>
+                 {
+                     services.AddScoped<IContextHandler, ContextHandlerMock>();
+                     services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
+                     services.AddSingleton<IDelegationMetadataRepository, DelegationMetadataRepositoryMock>();
+                     services.AddSingleton<IRoles, RolesMock>();
+                     services.AddSingleton<IPolicyRepository, PolicyRepositoryMock>();
+                     services.AddSingleton<IDelegationChangeEventQueue, DelegationChangeEventQueueMock>();
+                     services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
+                 });
             }).CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
 
             return client;

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/AccessPackageIdentifier.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/AccessPackageIdentifier.cs
@@ -10,7 +10,7 @@ namespace Altinn.Authorization.Api.Contracts.AccessManagement
     public sealed record AccessPackageIdentifier(string Value)
 : IFormattable
 , IParsable<AccessPackageIdentifier>
-        ,ISpanParsable<AccessPackageIdentifier>
+        , ISpanParsable<AccessPackageIdentifier>
     {
         public static AccessPackageIdentifier Parse(string s, IFormatProvider? provider)
             => new(s);

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/AccessReason.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/AccessReason.cs
@@ -23,10 +23,10 @@ public sealed class AccessReason
 
     public AccessReasonFlag ToEnum() => flag;
 
-    public AccessReason Add(AccessReasonFlag additional) => 
+    public AccessReason Add(AccessReasonFlag additional) =>
         new(flag | additional);
 
-    public AccessReason Remove(AccessReasonFlag remove) => 
+    public AccessReason Remove(AccessReasonFlag remove) =>
         new(flag & ~remove);
 
     public bool Contains(AccessReasonFlag f) =>

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/AttributeDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/AttributeDto.cs
@@ -41,7 +41,7 @@ namespace Altinn.Authorization.Api.Contracts.AccessManagement
         /// </summary>
         public string Urn()
         {
-            return $"{Type}:{Value}";            
+            return $"{Type}:{Value}";
         }
     }
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/ImportClientDelegationRequestDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/ImportClientDelegationRequestDto.cs
@@ -49,6 +49,6 @@
         /// This field uses the urn notation, such as:
         /// urn:altinn:accesspackage:ansvarlig-revisor
         /// </summary>
-        public required string PackageUrn { get; set; }        
+        public required string PackageUrn { get; set; }
     }
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/InstancePermissionDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/InstancePermissionDto.cs
@@ -18,5 +18,5 @@ public class InstancePermissionDto
     /// <summary>
     /// Parties with permissions
     /// </summary>
-    public IEnumerable<PermissionDto> Permissions { get; set; } 
+    public IEnumerable<PermissionDto> Permissions { get; set; }
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/ResourcePermissionDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/ResourcePermissionDto.cs
@@ -13,5 +13,5 @@ public class ResourcePermissionDto
     /// <summary>
     /// Parties with permissions
     /// </summary>
-    public IEnumerable<PermissionDto> Permissions { get; set; } 
+    public IEnumerable<PermissionDto> Permissions { get; set; }
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/Problems.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/Problems.cs
@@ -157,7 +157,7 @@ public static class Problems
     /// <summary>Gets a <see cref="ProblemDescriptor"/>.</summary>
     public static ProblemDescriptor InvalidRightKey { get; }
     = _factory.Create(36, HttpStatusCode.BadRequest, "Policy does not contain all rightkeys in delegation request");
-        
+
     /// <summary>Gets a <see cref="ProblemDescriptor"/>.</summary>
     public static ProblemDescriptor PackageNotAvailableForEntity { get; }
     = _factory.Create(37, HttpStatusCode.BadRequest, "The from entity does not match the package entity requirement");

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/ValidationErrors.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/ValidationErrors.cs
@@ -229,7 +229,7 @@ public static class ValidationErrors
     /// </summary>
     public static ValidationErrorDescriptor RequestFromSelfNotAllowed { get; }
         = _factory.Create(45, $"Self-targeted requests are not allowed.");
-    
+
     /// <summary>
     /// Either Resource or Package must be included in the request, but not both.
     /// </summary>

--- a/src/libs/Altinn.Authorization.Host/src/Altinn.Authorization.Host.Lease/StorageAccount/StorageAccountLeaseService.cs
+++ b/src/libs/Altinn.Authorization.Host/src/Altinn.Authorization.Host.Lease/StorageAccount/StorageAccountLeaseService.cs
@@ -31,7 +31,7 @@ public partial class StorageAccountLeaseService(ILogger<StorageAccountLeaseServi
 
         try
         {
-            var lease = await LeaseTelemetry.RecordLeaseAcquire(Logger,leaseName,async () => await leaseClient.AcquireAsync(MaxLeaseTime, default, cancellationToken));
+            var lease = await LeaseTelemetry.RecordLeaseAcquire(Logger, leaseName, async () => await leaseClient.AcquireAsync(MaxLeaseTime, default, cancellationToken));
             return new StorageAccountLease(Logger, client, leaseClient, lease);
         }
         catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.LeaseAlreadyPresent)

--- a/src/libs/Altinn.Authorization.Host/src/Altinn.Authorization.Host.Pipeline/Builders/PipelineSegmentBuilder.cs
+++ b/src/libs/Altinn.Authorization.Host/src/Altinn.Authorization.Host.Pipeline/Builders/PipelineSegmentBuilder.cs
@@ -7,11 +7,11 @@ internal class PipelineSegmentBuilder<TIn>(
     ) : ISegmentBuilder<TIn>
 {
     internal string Name { get; private set; }
-    
+
     internal object Func { get; private set; }
-    
+
     internal object? Segment { get; private set; }
-    
+
     internal object? Sink { get; private set; }
 
     /// <inheritdoc/>

--- a/src/libs/Altinn.Authorization.Host/src/Altinn.Authorization.Host.Pipeline/PipelineArgs.cs
+++ b/src/libs/Altinn.Authorization.Host/src/Altinn.Authorization.Host.Pipeline/PipelineArgs.cs
@@ -16,7 +16,7 @@ public class PipelineArgs
     /// Descriptor
     /// </summary>
     public IPipelineDescriptor Descriptor { get; internal set; }
-    
+
     /// <summary>
     /// The distributed lease associated with this pipeline, if configured.
     /// </summary>

--- a/src/libs/Altinn.Authorization.Host/src/Altinn.Authorization.Host.Pipeline/PipelineDescriptor.cs
+++ b/src/libs/Altinn.Authorization.Host/src/Altinn.Authorization.Host.Pipeline/PipelineDescriptor.cs
@@ -9,11 +9,11 @@ namespace Altinn.Authorization.Host.Pipeline;
 internal class PipelineDescriptor(PipelineGroup descriptor) : IPipelineDescriptor
 {
     /// <inheritdoc/>
-    public string? Name { get; private set; } 
+    public string? Name { get; private set; }
 
     /// <inheritdoc/>
     public Func<IServiceProvider, IServiceScope>? ServiceScope { get; set; }
-    
+
     internal PipelineSourceBuilder? Source { get; private set; }
 
     internal string? LeaseName { get; private set; }

--- a/src/libs/Altinn.Authorization.Host/src/Altinn.Authorization.Host.Pipeline/Telemetry/PipelineTelemetry.cs
+++ b/src/libs/Altinn.Authorization.Host/src/Altinn.Authorization.Host.Pipeline/Telemetry/PipelineTelemetry.cs
@@ -49,7 +49,7 @@ internal static partial class PipelineTelemetry
     internal static void RecordSinkFailure(PipelineArgs args)
     {
         var tags = BuildTags(args, "sink");
-        PipelineFailures.Add(1, [.. tags]); 
+        PipelineFailures.Add(1, [.. tags]);
         PipelinesRunSuccessfully.Record(0, [.. tags]);
     }
 

--- a/src/libs/Altinn.Authorization.Integration/src/Altinn.Authorization.Integration.Platform/AccessManagement/AltinnAccessManagementClient.cs
+++ b/src/libs/Altinn.Authorization.Integration/src/Altinn.Authorization.Integration.Platform/AccessManagement/AltinnAccessManagementClient.cs
@@ -62,7 +62,7 @@ public partial class AltinnAccessManagementClient(
         ];
 
         var response = await HttpClient.SendAsync(RequestComposer.New([.. request]), cancellationToken);
-        
+
         return new PaginatorStream<DelegationChange>(HttpClient, response, request);
     }
 }

--- a/src/libs/Altinn.Authorization.Integration/src/Altinn.Authorization.Integration.Platform/Notification/Models/NotificationStatusExt.cs
+++ b/src/libs/Altinn.Authorization.Integration/src/Altinn.Authorization.Integration.Platform/Notification/Models/NotificationStatusExt.cs
@@ -16,7 +16,7 @@ public abstract class NotificationStatusExt
     /// <summary>
     /// Gets or sets the number of generated notifications
     /// </summary>    
-    [JsonPropertyName("generated")] 
+    [JsonPropertyName("generated")]
     public int Generated { get; set; }
 
     /// <summary>

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Constants/XacmlConstants.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Constants/XacmlConstants.cs
@@ -807,9 +807,9 @@ namespace Altinn.Authorization.ABAC.Constants
             public const string DateTimeBagSize = "urn:oasis:names:tc:xacml:1.0:function:dateTime-bag-size";
         }
 
-            /// <summary>
-            /// Prefixed used in namespaces when writing to XML.
-            /// </summary>
+        /// <summary>
+        /// Prefixed used in namespaces when writing to XML.
+        /// </summary>
         public sealed class Prefixes
         {
             /// <summary>

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/PolicyDecisionPoint.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/PolicyDecisionPoint.cs
@@ -38,12 +38,12 @@ namespace Altinn.Authorization.ABAC
 
             if (matchingRules == null || matchingRules.Count == 0)
             {
-               contextResult = new XacmlContextResult(XacmlContextDecision.NotApplicable)
-               {
-                   Status = new XacmlContextStatus(XacmlContextStatusCode.Success),
-               };
+                contextResult = new XacmlContextResult(XacmlContextDecision.NotApplicable)
+                {
+                    Status = new XacmlContextStatus(XacmlContextStatusCode.Success),
+                };
 
-               return new XacmlContextResponse(contextResult);
+                return new XacmlContextResponse(contextResult);
             }
 
             XacmlContextDecision overallDecision = XacmlContextDecision.NotApplicable;

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Utils/XacmlParser.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Utils/XacmlParser.cs
@@ -874,7 +874,7 @@ namespace Altinn.Authorization.ABAC.Utils
             {
                 if (!ReadChoiceElement(reader, readerActions, isRequired))
                 {
-                   break;
+                    break;
                 }
             }
         }
@@ -1190,7 +1190,7 @@ namespace Altinn.Authorization.ABAC.Utils
                     attribute.Attributes.Add(new System.Xml.Linq.XAttribute(item.Key, item.Value));
                 }
                 catch
-                {                    
+                {
                 }
             }
 
@@ -1318,7 +1318,7 @@ namespace Altinn.Authorization.ABAC.Utils
             return new XmlException(message, null, info != null ? info.LineNumber : 0, info != null ? info.LinePosition : 0);
         }
 
-           /// <summary>
+        /// <summary>
         /// Validates if the next element Xacml XLM is of a given type.
         /// Throws exception if not.
         /// </summary>

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Xacml/JsonProfile/XacmlJsonResult.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Xacml/JsonProfile/XacmlJsonResult.cs
@@ -15,7 +15,7 @@ namespace Altinn.Authorization.ABAC.Xacml.JsonProfile
         /// <summary>
         /// Gets or sets the status.
         /// </summary>
-        public XacmlJsonStatus Status { get; set;  }
+        public XacmlJsonStatus Status { get; set; }
 
         /// <summary>
         /// Gets or sets any obligations of the result.
@@ -30,7 +30,7 @@ namespace Altinn.Authorization.ABAC.Xacml.JsonProfile
         /// <summary>
         /// Gets or sets category.
         /// </summary>
-        public List<XacmlJsonCategory> Category { get; set;  }
+        public List<XacmlJsonCategory> Category { get; set; }
 
         /// <summary>
         /// Gets or sets policy Identifyer list related to the result.

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Xacml/XacmlApply.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Xacml/XacmlApply.cs
@@ -43,9 +43,9 @@ namespace Altinn.Authorization.ABAC.Xacml
             this.functionId = functionId;
         }
 
-       /// <summary>
-       /// Gets the collection of parameters for the Apply object.
-       /// </summary>
+        /// <summary>
+        /// Gets the collection of parameters for the Apply object.
+        /// </summary>
         public ICollection<IXacmlExpression> Parameters
         {
             get
@@ -83,7 +83,7 @@ namespace Altinn.Authorization.ABAC.Xacml
             XacmlApply xacmlApply = null;
 
             foreach (IXacmlExpression xacmlExpression in this.Parameters)
-           {
+            {
                 if (xacmlExpression.GetType() == typeof(XacmlAttributeValue))
                 {
                     policyConditionAttributeValue = xacmlExpression as XacmlAttributeValue;
@@ -117,12 +117,12 @@ namespace Altinn.Authorization.ABAC.Xacml
             ICollection<XacmlContextAttributes> xacmlContextAttributes = new Collection<XacmlContextAttributes>();
 
             foreach (XacmlContextAttributes attributes in contextRequest.Attributes)
-           {
-               if (attributes.Category.Equals(attributeDesignator.Category))
+            {
+                if (attributes.Category.Equals(attributeDesignator.Category))
                 {
                     xacmlContextAttributes.Add(attributes);
                 }
-           }
+            }
 
             if (xacmlContextAttributes.Count == 0)
             {

--- a/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Authorization/ScopeAccessHandler.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Authorization/ScopeAccessHandler.cs
@@ -20,7 +20,7 @@ namespace Altinn.Common.PEP.Authorization
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, IScopeAccessRequirement requirement)
         {
             // get scope parameter from  user claims
-            string contextScope = context.User?.Identities 
+            string contextScope = context.User?.Identities
                 ?.FirstOrDefault(i => i.AuthenticationType != null && i.AuthenticationType.Equals("AuthenticationTypes.Federation"))?.Claims
                 .Where(c => c.Type.Equals("urn:altinn:scope"))?
                 .Select(c => c.Value).FirstOrDefault();

--- a/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/Database/DbHelper.cs
+++ b/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/Database/DbHelper.cs
@@ -104,7 +104,7 @@ internal sealed class DbHelper
     }
 
     async ValueTask IAsyncDisposable.DisposeAsync()
-    { 
+    {
         if (_transaction is { } t)
         {
             await t.DisposeAsync();

--- a/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/Database/ExportDatabaseCommand.cs
+++ b/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/Database/ExportDatabaseCommand.cs
@@ -45,7 +45,7 @@ public sealed class ExportDatabaseCommand(CancellationToken cancellationToken)
 
                 List<ExportTask> tasks = new(selected.Tables.Length);
                 await source.BeginTransaction(cancellationToken);
-                
+
                 if (!settings.NoClear)
                 {
                     clearTask = ctx.AddTask("clear output directory", autoStart: false, maxValue: 1);
@@ -75,7 +75,7 @@ public sealed class ExportDatabaseCommand(CancellationToken cancellationToken)
                 if (clearTask is not null)
                 {
                     clearTask.StartTask();
-                    
+
                     foreach (var subdir in settings.OutputDirectory.EnumerateDirectories())
                     {
                         subdir.Delete(recursive: true);

--- a/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/Program.cs
+++ b/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/Program.cs
@@ -5,7 +5,7 @@ using Spectre.Console.Cli;
 
 using Database = Altinn.Authorization.Cli.Database;
 using Register = Altinn.Authorization.Cli.Register;
-using ServiceBus=Altinn.Authorization.Cli.ServiceBus;
+using ServiceBus = Altinn.Authorization.Cli.ServiceBus;
 
 using var cancellationTokenSource = new CancellationTokenSource();
 using var sigInt = PosixSignalRegistration.Create(PosixSignal.SIGINT, OnSignal);
@@ -20,7 +20,7 @@ app.Configure(config =>
 {
     config.PropagateExceptions();
     config.Settings.Registrar.RegisterInstance(cancellationTokenSource.Token);
-    
+
     config.AddBranch("db", db =>
     {
         db.SetDescription("Commands for working with databases.");
@@ -29,7 +29,7 @@ app.Configure(config =>
         db.AddCommand<Database.CredentialsCommand>("cred");
         db.AddCommand<Database.BootstapCommand>("bootstrap");
     });
-    
+
     config.AddBranch("sb", sb =>
     {
         sb.SetDescription("Commands for working with service bus.");

--- a/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/Register/ExternalRolesCommand.cs
+++ b/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/Register/ExternalRolesCommand.cs
@@ -32,7 +32,8 @@ public class ExternalRolesCommand(CancellationToken ct)
                 register.external_role_definition erd
             """);
 
-        IOutputBuilder builder = settings.Format switch {
+        IOutputBuilder builder = settings.Format switch
+        {
             OutputFormat.TABLE => new TableOutputBuilder(),
             OutputFormat.SQL => new SqlBuilder(),
             OutputFormat.HTML => new HtmlBuilder(),
@@ -106,7 +107,7 @@ public class ExternalRolesCommand(CancellationToken ct)
 
         public void Render()
         {
-            foreach (var (source, table) in _tables) 
+            foreach (var (source, table) in _tables)
             {
                 var panel = new Panel(table).Header(new PanelHeader(source, Justify.Center)).NoBorder().Expand();
                 AnsiConsole.Write(panel);

--- a/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/Register/RetryA2ImportsCommand.cs
+++ b/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/Register/RetryA2ImportsCommand.cs
@@ -107,7 +107,7 @@ public sealed class RetryA2ImportsCommand(CancellationToken ct)
         QueueRuntimeProperties props)
     {
         var errorCount = props.DeadLetterMessageCount;
-        
+
         if (props.Name.EndsWith("_error", StringComparison.Ordinal))
         {
             errorCount += props.ActiveMessageCount;

--- a/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/ServiceBus/ExportErrorsCommand.cs
+++ b/src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli/ServiceBus/ExportErrorsCommand.cs
@@ -247,8 +247,8 @@ public sealed class ExportErrorsCommand(CancellationToken cancellationToken)
         task.StartTask();
 
         await using var receiver = sb.Client.CreateReceiver(
-            queue, 
-            new ServiceBusReceiverOptions 
+            queue,
+            new ServiceBusReceiverOptions
             {
                 ReceiveMode = ServiceBusReceiveMode.PeekLock,
                 PrefetchCount = Math.Clamp((int)stats.ActiveMessageCount, 100, 10_000),
@@ -352,7 +352,7 @@ public sealed class ExportErrorsCommand(CancellationToken cancellationToken)
     {
         var tasks = after.Where(t => t is not null).Select(t => t!.WaitAsync(cancellationToken));
         await Task.WhenAll(tasks);
-        
+
         if (disposable is IAsyncDisposable asyncDisposable)
         {
             await asyncDisposable.DisposeAsync();


### PR DESCRIPTION
## Result

Trailing-whitespace cleanup across 261 files via `dotnet format whitespace Altinn.Authorization.sln`. Build is green (0 errors). Warning count is unchanged vs main since this pass only touches whitespace.

## What changed

- Trailing whitespace removed from line ends.
- Line-internal runs of spaces collapsed where editorconfig requires it.
- No analyzer codefixes were run, so nothing was renamed, no disabled tests got re-enabled, and no source-file encoding was flipped.
- BOM additions that the format pass made on previously-BOM-less files were stripped before commit, so the diff shows only real whitespace edits (no invisible line-1 noops).

## Why this scope

First in a planned series of small, focused warning-cleanup PRs. Splitting per change type (whitespace → StyleCop analyzers → manual fixes → obsolete API migrations) keeps each diff reviewable on its own.

## Follow-ups

- Next pass: StyleCop analyzer codefixes (`dotnet format analyzers --severity warn`).
- Then: manual fixes for CS0108 (`new` keyword on hidden EF audit properties) and the small SA codes that don't have Fix-All providers.
- Then: obsolete-API migrations already filed as separate Tasks — [#3026](https://github.com/Altinn/altinn-authorization-tmp/issues/3026) DocumentDB.Core, [#3027](https://github.com/Altinn/altinn-authorization-tmp/issues/3027) GlobalTypeMapper, [#3028](https://github.com/Altinn/altinn-authorization-tmp/issues/3028) INpgsqlSingletonOptions.
- Cross-cutting: [#3032](https://github.com/Altinn/altinn-authorization-tmp/issues/3032) BOM convention normalization.

Refs #3022

## Test plan

- [ ] CI green