### PR TITLE
bug/accmgmt-metadata-blanksearch

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -97,6 +97,11 @@ public class PackageService : IPackageService
         cancellationToken: cancellationToken
         );
 
+        if (string.IsNullOrEmpty(term))
+        {
+            return data.Select(t => new SearchObject<PackageDto>() { Object = t, Score = 0, Fields = [] });
+        }
+
         return data
             .Select(p => ScorePackage(p, term, searchInResources))
             .Where(s => s.Score > 0)


### PR DESCRIPTION
## Description
Frontend uses emptystring search to get all packages. Added same logic in new search.

## Issues
- #2904

