### PR TITLE
fix(persistence-ef): remove redundant audit/policy property redeclarations (warnings cleanup, part 3)

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/AssignmentResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/AssignmentResource.cs
@@ -17,15 +17,5 @@ public class AssignmentResource : BaseAssignmentResource
     /// </summary>
     public Resource Resource { get; set; }
 
-    /// <summary>
-    /// Policy path refers to where the corresponding policy is stored
-    /// </summary>
-    public string PolicyPath { get; set; }
-
-    /// <summary>
-    /// The version of the policy referred to by this change.
-    /// </summary>
-    public string PolicyVersion { get; set; }
-
     public Entity? ChangedBy { get; set; }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAreaGroup.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAreaGroup.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditAreaGroup : BaseAreaGroup, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignment.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignment.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditAssignment : BaseAssignment, IAudit
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentInstance.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentInstance.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditAssignmentInstance : BaseAssignmentInstance, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentPackage.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentPackage.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditAssignmentPackage : BaseAssignmentPackage, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditAssignmentResource.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditAssignmentResource : BaseAssignmentResource, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegation.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditDelegation : BaseDelegation, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegationPackage.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegationPackage.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditDelegationPackage : BaseDelegationPackage, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegationResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditDelegationResource.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditDelegationResource : BaseDelegationResource, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntity.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntity.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditEntity : BaseEntity, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityLookup.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityLookup.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditEntityLookup : BaseEntityLookup, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityType.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityType.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditEntityType : BaseEntityType, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityVariant.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityVariant.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditEntityVariant : BaseEntityVariant, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityVariantRole.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditEntityVariantRole.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditEntityVariantRole : BaseEntityVariantRole, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditInstanceSourceType.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditInstanceSourceType.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditInstanceSourceType : BaseInstanceSourceType, IAudit
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditPackage.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditPackage.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditPackage : BasePackage, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditPackageResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditPackageResource.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditPackageResource : BasePackageResource, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditProvider.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditProvider.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditProvider : BaseProvider, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditProviderType.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditProviderType.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditProviderType : BaseProviderType, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditResource.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditResource : BaseResource, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditResourceType.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditResourceType.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditResourceType : BaseResourceType, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRole.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRole.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditRole : BaseRole, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRoleMap.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRoleMap.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditRoleMap : BaseRoleMap, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRolePackage.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRolePackage.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditRolePackage : BaseRolePackage, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRoleResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Audit/AuditRoleResource.cs
@@ -7,19 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Models.Audit;
 public class AuditRoleResource : BaseRoleResource, IAudit 
 {
     /// <inheritdoc />
-    public DateTimeOffset Audit_ValidFrom { get; set; }
-
-    /// <inheritdoc />
     public DateTimeOffset? Audit_ValidTo { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBy { get; set; }
-
-    /// <inheritdoc />
-    public Guid? Audit_ChangedBySystem { get; set; }
-
-    /// <inheritdoc />
-    public string Audit_ChangeOperation { get; set; }
 
     /// <inheritdoc />
     public Guid? Audit_DeletedBy { get; set; }


### PR DESCRIPTION
## Result

25 files, -298 lines (no insertions). Build is green (0 errors). Clears all 98 CS0108 warnings.

## What changed

Each `Audit*` model was redeclaring four properties already declared on `BaseAudit`. The redeclarations were dead duplicates that tripped CS0108 and contributed nothing at runtime. Removed them so the derived classes inherit those four properties from the base instead:

- 24 `Audit*.cs` files in `Altinn.AccessMgmt.PersistenceEF.Models.Audit`: dropped `Audit_ValidFrom`, `Audit_ChangedBy`, `Audit_ChangedBySystem`, `Audit_ChangeOperation` from the derived class.
- The four `IAudit` members that aren't on `BaseAudit` (`Audit_ValidTo`, `Audit_DeletedBy`, `Audit_DeletedBySystem`, `Audit_DeleteOperation`) remain on the derived class — they only make sense for the audit-history snapshot and have no equivalent on the live model.
- `AssignmentResource.cs`: dropped `PolicyPath` and `PolicyVersion` redeclarations — they were already plain auto-properties on `BaseAssignmentResource` with no semantic difference.

## Why this is safe

- Every `Audit*` class is registered as `DbSet<T>` in `AppDbContext`, and there are no direct `new AuditX(...)` constructions or reflection-based instantiations anywhere in the codebase. EF is the only path that materializes these entities.
- EF reads/writes audit columns via the `IAudit` interface configuration ([AuditConfiguration.cs](src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/Base/AuditConfiguration.cs)) — the column-to-property bindings are unchanged.
- `AssignmentResource` is constructed directly via object-initializer syntax (`new AssignmentResource() { PolicyPath = ..., PolicyVersion = ... }`) in several callsites; those continue to compile and behave identically against the inherited base properties.

Closes #3046
Refs #3022

## Test plan

- [ ] CI green
- [ ] No EF migration delta against current schema (audit columns are still mapped through `IAudit`)