### PR TITLE
fix: replace obsolete X509Certificate2 ctors (warnings cleanup, part 4)

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Services/PlatformAuthorizationTokenProvider.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Services/PlatformAuthorizationTokenProvider.cs
@@ -55,7 +55,7 @@ public class PlatformAuthorizationTokenProvider : IPlatformAuthorizationTokenPro
                 _accessToken = _accessTokenGenerator.GenerateAccessToken(
                     _oidcProviderSettings["altinn"].Issuer,
                     "platform.authorization",
-                    new X509Certificate2(Convert.FromBase64String(certBase64), (string)null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable));
+                    X509CertificateLoader.LoadPkcs12(Convert.FromBase64String(certBase64), (string)null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable));
 
                 _cacheTokenUntil = DateTime.UtcNow.AddSeconds(_accessTokenSettings.TokenLifetimeInSeconds - 2); // Add some slack to avoid tokens expiring in transit
             }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Extensions/PersistenceDependencyInjectionExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Extensions/PersistenceDependencyInjectionExtensions.cs
@@ -168,7 +168,7 @@ public static class PersistenceDependencyInjectionExtensions
                 ConsentPortalViewMode.Show => "show",
                 _ => null,
             }))
-            .AddYuniqlMigrations(typeof(Marker), cfg =>
+            .AddYuniqlMigrations(cfg =>
             {
                 cfg.Workspace = "/";
                 cfg.WorkspaceFileProvider = fs;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Extensions/PersistenceDependencyInjectionExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Extensions/PersistenceDependencyInjectionExtensions.cs
@@ -168,7 +168,7 @@ public static class PersistenceDependencyInjectionExtensions
                 ConsentPortalViewMode.Show => "show",
                 _ => null,
             }))
-            .AddYuniqlMigrations(cfg =>
+            .AddYuniqlMigrations(typeof(Marker), cfg =>
             {
                 cfg.Workspace = "/";
                 cfg.WorkspaceFileProvider = fs;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConfigurationManagerStub.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConfigurationManagerStub.cs
@@ -38,7 +38,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
         {
             List<SecurityKey> signingKeys = [];
 
-            X509Certificate2 cert = new X509Certificate2("selfSignedTestCertificatePublic.cer");
+            X509Certificate2 cert = X509CertificateLoader.LoadCertificateFromFile("selfSignedTestCertificatePublic.cer");
             SecurityKey key = new X509SecurityKey(cert);
 
             signingKeys.Add(key);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/SigningKeyResolverMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/SigningKeyResolverMock.cs
@@ -26,7 +26,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
         public Task<IEnumerable<SecurityKey>> GetSigningKeys(string issuer)
         {
             List<SecurityKey> signingKeys = [];
-            X509Certificate2 cert = new X509Certificate2($"{issuer}-org.pem");
+            X509Certificate2 cert = X509CertificateLoader.LoadCertificateFromFile($"{issuer}-org.pem");
             SecurityKey key = new X509SecurityKey(cert);
 
             signingKeys.Add(key);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utils/JwtTokenMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utils/JwtTokenMock.cs
@@ -42,11 +42,11 @@ namespace Altinn.AccessManagement.Tests.Utils
             {
                 certPath = $"{issuer}-org.pfx";
 
-                X509Certificate2 certIssuer = new X509Certificate2(certPath);
+                X509Certificate2 certIssuer = X509CertificateLoader.LoadPkcs12FromFile(certPath, password: null);
                 return new X509SigningCredentials(certIssuer, SecurityAlgorithms.RsaSha256);
             }
 
-            X509Certificate2 cert = new X509Certificate2(certPath, "qwer1234");
+            X509Certificate2 cert = X509CertificateLoader.LoadPkcs12FromFile(certPath, "qwer1234");
             return new X509SigningCredentials(cert, SecurityAlgorithms.RsaSha256);
         }
     }


### PR DESCRIPTION
## Result

4 files, +5/-5. Build is green (0 errors). Clears 10 SYSLIB0057 warnings — `X509Certificate2` byte/file constructors are obsolete in .NET 9.

## What changed

Replaced obsolete constructors with `X509CertificateLoader`:
- `LoadPkcs12(byte[], password, flags)` for the base64-decoded PFX in `PlatformAuthorizationTokenProvider`.
- `LoadCertificateFromFile(path)` for `.cer` / `.pem` test cert paths in the test mocks.
- `LoadPkcs12FromFile(path, password)` for `.pfx` test cert paths in `JwtTokenMock`.

## Yuniql migration removed from this PR

The original version also switched `AddYuniqlMigrations(configure)` to the keyed overload `AddYuniqlMigrations(typeof(Marker), configure)`. Reverted after review feedback: the keyed overload expects a matching keyed `NpgsqlDataSource`, but `AddAltinnPostgresDataSource()` from the upstream package only registers an unkeyed one. Switching would have silently broken accessmanagement.* / consent.* / delegation.* migrations at startup.

The CS0618 `AddYuniqlMigrations` warning therefore stays for now; tracked as #3053.

Closes #3048
Refs #3022

## Test plan

- [ ] CI green
- [ ] JWT signing in tests still works after `X509CertificateLoader.LoadPkcs12FromFile` swap