### PR TITLE
fix(tests): pass TestContext.Current.CancellationToken across test suite

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Altinn2RightsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Altinn2RightsControllerTest.cs
@@ -65,7 +65,7 @@ public class Altinn2RightsControllerTest : IClassFixture<ApiFixture>
     {
         var client = NewDefaultClient(WithHeader(header, value));
 
-        var response = await client.GetAsync($"internal/{GetUrlParameter(header, value)}/rights/delegation/offered");
+        var response = await client.GetAsync($"internal/{GetUrlParameter(header, value)}/rights/delegation/offered", TestContext.Current.CancellationToken);
 
         assert(response);
     }
@@ -102,7 +102,7 @@ public class Altinn2RightsControllerTest : IClassFixture<ApiFixture>
     {
         var client = NewDefaultClient(WithHeader(header, value));
 
-        var response = await client.GetAsync($"internal/{GetUrlParameter(header, value)}/rights/delegation/received");
+        var response = await client.GetAsync($"internal/{GetUrlParameter(header, value)}/rights/delegation/received", TestContext.Current.CancellationToken);
 
         assert(response);
     }
@@ -134,7 +134,7 @@ public class Altinn2RightsControllerTest : IClassFixture<ApiFixture>
         var client = NewClient(WithClientRoute("accessmanagement/api/v1/"));
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authnUserToken);
 
-        HttpResponseMessage response = await client.PutAsync($"internal/{party}/accesscache/clear", new StringContent(JsonSerializer.Serialize(toAttribute), Encoding.UTF8, MediaTypeNames.Application.Json));
+        HttpResponseMessage response = await client.PutAsync($"internal/{party}/accesscache/clear", new StringContent(JsonSerializer.Serialize(toAttribute), Encoding.UTF8, MediaTypeNames.Application.Json), TestContext.Current.CancellationToken);
 
         assert(response);
     }
@@ -177,7 +177,7 @@ public class Altinn2RightsControllerTest : IClassFixture<ApiFixture>
         var client = NewClient(WithClientRoute("accessmanagement/api/v1/"));
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authnUserToken);
 
-        HttpResponseMessage response = await client.PutAsync($"internal/{party}/accesscache/clear", new StringContent(JsonSerializer.Serialize(toAttribute), Encoding.UTF8, MediaTypeNames.Application.Json));
+        HttpResponseMessage response = await client.PutAsync($"internal/{party}/accesscache/clear", new StringContent(JsonSerializer.Serialize(toAttribute), Encoding.UTF8, MediaTypeNames.Application.Json), TestContext.Current.CancellationToken);
 
         assert(response);
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
@@ -281,13 +281,13 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
 
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}");
-            string responseText = await response.Content.ReadAsStringAsync();
-            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(requestId, consentRequest.Id);
             Assert.True(consentRequest.ConsentRights.Count > 0);
@@ -309,13 +309,13 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid requestId = Guid.Parse("2fe8bd3e-d482-4170-8c09-f44cf31797ce");
 
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}");
-            string responseText = await response.Content.ReadAsStringAsync();
-            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(requestId, consentRequest.Id);
             Assert.True(consentRequest.ConsentRights.Count > 0);
@@ -332,13 +332,13 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed46");
 
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}");
-            string responseText = await response.Content.ReadAsStringAsync();
-            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(requestId, consentRequest.Id);
             Assert.True(consentRequest.ConsentRights.Count > 0);
@@ -360,12 +360,12 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
 
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(-1)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(-1)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}");
-            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}", TestContext.Current.CancellationToken);
+            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestEventType.Created, consentRequest.ConsentRequestEvents[0].EventType);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestEventType.Expired, consentRequest.ConsentRequestEvents[1].EventType);
@@ -377,13 +377,13 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid requestId = Guid.Parse("e579b7a2-7994-4636-9aca-59e114915b70");
 
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}");
-            string responseText = await response.Content.ReadAsStringAsync();
-            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            ConsentRequestDetailsBffDto consentRequest = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(requestId, consentRequest.Id);
             Assert.True(consentRequest.ConsentRights.Count > 0);
@@ -402,7 +402,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
         {
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
 
@@ -418,10 +418,10 @@ namespace AccessMgmt.Tests.Controllers.Bff
             HttpContent httpContent = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/accept/", httpContent);
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/accept/", httpContent, TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            ConsentRequestDetailsBffDto consentInfo = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>();
+            ConsentRequestDetailsBffDto consentInfo = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.Equal(2, consentInfo.ConsentRequestEvents.Count);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestEventType.Created, consentInfo.ConsentRequestEvents[0].EventType);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), consentInfo.ConsentRequestEvents[0].PerformedBy);
@@ -433,7 +433,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
         {
             Guid requestId = Guid.Parse("2fe8bd3e-d482-4170-8c09-f44cf31797ce");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
 
@@ -449,10 +449,10 @@ namespace AccessMgmt.Tests.Controllers.Bff
             HttpContent httpContent = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/accept/", httpContent);
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/accept/", httpContent, TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            ConsentRequestDetailsBffDto consentInfo = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>();
+            ConsentRequestDetailsBffDto consentInfo = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.Equal(2, consentInfo.ConsentRequestEvents.Count);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestEventType.Created, consentInfo.ConsentRequestEvents[0].EventType);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), consentInfo.ConsentRequestEvents[0].PerformedBy);
@@ -464,7 +464,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
         {
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(-10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(-10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
 
@@ -480,8 +480,8 @@ namespace AccessMgmt.Tests.Controllers.Bff
             HttpContent httpContent = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/accept/", httpContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/accept/", httpContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(responseContent, _jsonOptions);
@@ -495,7 +495,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
         {
             Guid requestId = Guid.Parse("a4253d59-b40f-409a-a3f7-c6395f065192");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
 
@@ -511,8 +511,8 @@ namespace AccessMgmt.Tests.Controllers.Bff
             HttpContent httpContent = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/accept/", httpContent);
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/accept/", httpContent, TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             if (!response.IsSuccessStatusCode)
             {
                 _output.WriteLine($"❌ Request failed with status code: {response.StatusCode}");
@@ -521,7 +521,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
             }
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            ConsentRequestDetailsBffDto consentInfo = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>();
+            ConsentRequestDetailsBffDto consentInfo = await response.Content.ReadFromJsonAsync<ConsentRequestDetailsBffDto>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.Equal(2, consentInfo.ConsentRequestEvents.Count);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestEventType.Created, consentInfo.ConsentRequestEvents[0].EventType);
             Assert.Equal(Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), consentInfo.ConsentRequestEvents[0].PerformedBy);
@@ -534,8 +534,8 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid performedBy = Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5");
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
-            await repositgo.RejectConsentRequest(requestId, performedBy, default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
+            await repositgo.RejectConsentRequest(requestId, performedBy, TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, performedBy, AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
@@ -550,8 +550,8 @@ namespace AccessMgmt.Tests.Controllers.Bff
 
             // Create HttpContent from the JSON string
             HttpContent httpContent = new StringContent(jsonContent, Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/accept/", httpContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/accept/", httpContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(responseContent, _jsonOptions);
@@ -563,12 +563,12 @@ namespace AccessMgmt.Tests.Controllers.Bff
         {
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/reject/", null);
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/reject/", null, TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
@@ -577,12 +577,12 @@ namespace AccessMgmt.Tests.Controllers.Bff
         {
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5");
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             List<ConsentRequestDetailsBffDto> consentRequestList = JsonSerializer.Deserialize<List<ConsentRequestDetailsBffDto>>(responseText, _jsonOptions);
             Assert.Single(consentRequestList);
@@ -594,13 +594,13 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             Guid requestIdShow = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed46");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
-            await repositgo.CreateRequest(await GetRequest(requestIdShow, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
+            await repositgo.CreateRequest(await GetRequest(requestIdShow, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5");
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             List<ConsentRequestDetailsBffDto> consentRequestList = JsonSerializer.Deserialize<List<ConsentRequestDetailsBffDto>>(responseText, _jsonOptions);
             Assert.True(consentRequestList.Count == 2);
@@ -616,17 +616,17 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid performedBy = Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5");
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(-10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(-10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             ConsentContextDto consentContextExternal = new ConsentContextDto
             {
                 Language = "nb",
             };
-            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext());
+            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext(), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5");
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             List<ConsentRequestDetailsBffDto> consentRequestList = JsonSerializer.Deserialize<List<ConsentRequestDetailsBffDto>>(responseText, _jsonOptions);
             Assert.Single(consentRequestList);
@@ -640,16 +640,16 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid performedBy = Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5");
             Guid requestId2 = Guid.Parse("e579b7a2-7994-4636-9aca-59e114915b70");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId2, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
-            await repositgo.RejectConsentRequest(requestId2, performedBy, default);
+            await repositgo.CreateRequest(await GetRequest(requestId2, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
+            await repositgo.RejectConsentRequest(requestId2, performedBy, TestContext.Current.CancellationToken);
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
-            await repositgo.RejectConsentRequest(requestId, performedBy, default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
+            await repositgo.RejectConsentRequest(requestId, performedBy, TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5");
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             List<ConsentRequestDetailsBffDto> consentRequestList = JsonSerializer.Deserialize<List<ConsentRequestDetailsBffDto>>(responseText, _jsonOptions);
             Assert.Equal(2, consentRequestList.Count);
@@ -666,17 +666,17 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid performedBy = Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5");
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             ConsentContextDto consentContextExternal = new ConsentContextDto
             {
                 Language = "nb",
             };
-            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext());
+            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext(), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/reject/", null);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{requestId.ToString()}/reject/", null, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnMultipleProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnMultipleProblemDetails>(responseContent, _jsonOptions);
@@ -696,17 +696,17 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid performedBy = Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5");
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             ConsentContextDto consentContextExternal = new ConsentContextDto
             {
                 Language = "nb",
             };
-            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext());
+            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext(), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consents/{requestId.ToString()}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consents/{requestId.ToString()}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -716,7 +716,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
             }
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Consent consent = await response.Content.ReadFromJsonAsync<Consent>();
+            Consent consent = await response.Content.ReadFromJsonAsync<Consent>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.Equal(requestId, consent.Id);
             Assert.True(consent.ConsentRights.Count > 0);
             Assert.Equal("d5b861c8-8e3b-44cd-9952-5315e5990cf5", consent.From.ValueSpan);
@@ -742,18 +742,18 @@ namespace AccessMgmt.Tests.Controllers.Bff
 
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             ConsentContextDto consentContextExternal = new ConsentContextDto
             {
                 Language = "nb",
             };
-            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext());
+            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext(), TestContext.Current.CancellationToken);
 
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, performedBy, AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consents/{requestId.ToString()}/revoke/", null);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consents/{requestId.ToString()}/revoke/", null, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             ConsentRequestDetailsBffDto consentInfo = JsonSerializer.Deserialize<ConsentRequestDetailsBffDto>(responseContent, _jsonOptions);
             Assert.Equal(3, consentInfo.ConsentRequestEvents.Count);
@@ -770,13 +770,13 @@ namespace AccessMgmt.Tests.Controllers.Bff
 
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
 
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, performedBy, AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consents/{requestId.ToString()}/revoke/", null);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/bff/consents/{requestId.ToString()}/revoke/", null, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnMultipleProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnMultipleProblemDetails>(responseContent, _jsonOptions);
@@ -789,12 +789,12 @@ namespace AccessMgmt.Tests.Controllers.Bff
         {
             Guid requestId = Guid.Parse("019d7114-413f-7dbd-af65-72caa1c18d04");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/count/d5b861c8-8e3b-44cd-9952-5315e5990cf5?status=Created");
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/count/d5b861c8-8e3b-44cd-9952-5315e5990cf5?status=Created", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             int count = JsonSerializer.Deserialize<int>(responseText);
             Assert.True(count >= 1);
@@ -805,12 +805,12 @@ namespace AccessMgmt.Tests.Controllers.Bff
         {
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/count/d5b861c8-8e3b-44cd-9952-5315e5990cf5?status=Created");
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/count/d5b861c8-8e3b-44cd-9952-5315e5990cf5?status=Created", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             int count = JsonSerializer.Deserialize<int>(responseText);
             Assert.Equal(0, count);
@@ -821,12 +821,12 @@ namespace AccessMgmt.Tests.Controllers.Bff
         {
             Guid requestId = Guid.Parse("019d7110-437e-7560-b91a-5494525b4c66");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/count/d5b861c8-8e3b-44cd-9952-5315e5990cf5?status=Accepted");
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/count/d5b861c8-8e3b-44cd-9952-5315e5990cf5?status=Accepted", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             int count = JsonSerializer.Deserialize<int>(responseText);
             Assert.Equal(0, count);
@@ -838,19 +838,19 @@ namespace AccessMgmt.Tests.Controllers.Bff
             Guid performedBy = Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5");
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed46");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
 
             ConsentContextDto consentContextExternal = new ConsentContextDto
             {
                 Language = "nb",
             };
-            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext());
+            await repositgo.AcceptConsentRequest(requestId, performedBy, consentContextExternal.ToConsentContext(), TestContext.Current.CancellationToken);
 
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, performedBy, AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/count/d5b861c8-8e3b-44cd-9952-5315e5990cf5?status=Accepted");
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/count/d5b861c8-8e3b-44cd-9952-5315e5990cf5?status=Accepted", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             int count = JsonSerializer.Deserialize<int>(responseText);
             Assert.True(count >= 1);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/DelegationsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/DelegationsControllerTest.cs
@@ -105,9 +105,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -146,9 +146,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             string expectedRuleId = "99e5cced-3bcb-42b6-9089-63c834f89e77";
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -186,9 +186,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -221,7 +221,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -256,9 +256,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -290,9 +290,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -331,9 +331,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -365,9 +365,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -399,9 +399,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -440,9 +440,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeleteRules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -482,9 +482,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -524,9 +524,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -560,9 +560,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             string expectedErrorMessage = "\"Unable to complete deletion\"";
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -592,7 +592,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -628,9 +628,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -662,9 +662,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -693,9 +693,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -727,9 +727,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/DeletePolicy", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -757,7 +757,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -780,7 +780,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -803,7 +803,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -834,9 +834,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -874,9 +874,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -915,9 +915,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -959,9 +959,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             List<Rule> expected = new List<Rule> { rule1, rule2 };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -999,9 +999,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             List<Rule> expected = new List<Rule> { rule1, rule2 };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1038,9 +1038,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1078,9 +1078,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1122,9 +1122,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1160,8 +1160,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync("accessmanagement/api/v1/delegations/addrules", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actual = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1189,8 +1189,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             List<Rule> expectedRules = GetExpectedRulesForUser();
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actualRules = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1213,8 +1213,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             expectedRules.Add(TestDataUtil.GetRuleModel(20001337, 50001337, "50001338", AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, "sign", "skd", "taxreport", ruleType: RuleType.InheritedViaKeyRole));
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actualRules = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1238,8 +1238,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             expectedRules.Add(TestDataUtil.GetRuleModel(20001339, 50001335, "50001337", AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, "read", "skd", "taxreport", ruleType: RuleType.InheritedAsSubunitViaKeyrole));
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actualRules = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1262,8 +1262,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             expectedRules.Add(TestDataUtil.GetRuleModel(20001339, 50001338, "50001336", AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, "sign", "skd", "taxreport", ruleType: RuleType.InheritedAsSubunit));
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actualRules = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1284,8 +1284,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -1304,8 +1304,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -1325,8 +1325,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             List<Rule> expectedRules = new List<Rule>();
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actualRules = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1349,8 +1349,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             expectedRules.AddRange(GetExpectedRulesForParty());
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/delegations/getrules", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<Rule> actualRules = JsonSerializer.Deserialize<List<Rule>>(responseContent, options);
 
             // Assert
@@ -1381,8 +1381,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418672;
             int consumerOrg = 810418192;
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<MPDelegationExternal> actualDelegations = JsonSerializer.Deserialize<List<MPDelegationExternal>>(responseContent);
 
             // Assert
@@ -1413,8 +1413,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418672;
             int consumerOrg = 810418192;
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<MPDelegationExternal> actualDelegations = JsonSerializer.Deserialize<List<MPDelegationExternal>>(responseContent);
 
             // Assert
@@ -1439,8 +1439,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418362;
             int consumerOrg = 810418532;
             string scope = "altinn:instances.read";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ProblemDetails errorResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
 
             // Assert
@@ -1465,8 +1465,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418362;
             int consumerOrg = 810418532;
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1495,8 +1495,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418672;
             int consumerOrg = 810418192;
 
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope=");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope=", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<MPDelegationExternal> actualDelegations = JsonSerializer.Deserialize<List<MPDelegationExternal>>(responseContent);
 
             // Assert
@@ -1521,8 +1521,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             string supplierOrg = "12345";
             string consumerOrg = "810418532";
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails errorResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
 
             // Assert
@@ -1547,8 +1547,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             string supplierOrg = "810418362";
             string consumerOrg = "12345";
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails errorResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
 
             // Assert
@@ -1573,8 +1573,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418672;
             int consumerOrg = 810418192;
             string scope = "altinn:test/test";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1596,8 +1596,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418672;
             int consumerOrg = 810418192;
             string scope = "altinn:maskinporten:urn:scope:test";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/admin/delegations/maskinportenschema/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterprise.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterprise.cs
@@ -128,8 +128,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             StringContent stringContent = new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await client.PostAsync(url, stringContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, stringContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.NotNull(responseContent);
             ConsentRequestDetailsDto consentInfo = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(responseContent, _jsonOptions);
@@ -196,8 +196,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             StringContent stringContent = new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await client.PostAsync(url, stringContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, stringContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.NotNull(responseContent);
             ConsentRequestDetailsDto consentInfo = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(responseContent, _jsonOptions);
@@ -264,8 +264,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetOrgToken(null, "991825827", "altinn:consentrequests.org");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             StringContent stringContent = new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await client.PostAsync(url, stringContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, stringContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.NotNull(responseContent);
             ConsentRequestDetailsDto consentInfo = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(responseContent, _jsonOptions);
@@ -333,8 +333,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetOrgToken(null, "991825827", "altinn:consentrequests.org");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             StringContent stringContent = new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await client.PostAsync(url, stringContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, stringContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(responseContent, _jsonOptions);
@@ -392,7 +392,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetOrgToken(null, "991825827", "altinn:consentrequests.org");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             StringContent stringContent = new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await client.PostAsync(url, stringContent);
+            HttpResponseMessage response = await client.PostAsync(url, stringContent, TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         }
 
@@ -444,8 +444,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.NotNull(responseContent);
             ConsentRequestDetailsDto consentInfo = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(responseContent, _jsonOptions);
@@ -461,8 +461,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             Assert.Equal(ConsentPartyUrn.OrganizationId.Create(OrganizationNumber.Parse("810419512")), consentInfo.ConsentRequestEvents[0].PerformedBy);
 
             // Post again. Expects 200 ok since everyhing is the same
-            HttpResponseMessage response2 = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent2 = await response2.Content.ReadAsStringAsync();
+            HttpResponseMessage response2 = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent2 = await response2.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
             Assert.NotNull(responseContent2);
             ConsentRequestDetailsDto consentInfo2 = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(responseContent, _jsonOptions);
@@ -523,8 +523,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.NotNull(responseContent);
             ConsentRequestDetailsDto consentInfo = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(responseContent, _jsonOptions);
@@ -541,8 +541,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
 
             // Post again but changes from. Should cause problem
             consentRequest.From = ConsentPartyUrn.PersonId.Create(PersonIdentifier.Parse("01025181049"));
-            HttpResponseMessage response2 = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent2 = await response2.Content.ReadAsStringAsync();
+            HttpResponseMessage response2 = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent2 = await response2.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // TODO This need to ve created
             Assert.Equal(HttpStatusCode.BadRequest, response2.StatusCode);
@@ -596,8 +596,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             string location = response.Headers.Location.ToString();
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.NotNull(responseContent);
@@ -615,8 +615,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             Assert.Equal(ConsentRequestStatusType.Created, consentInfo.Status);
 
             string getUrl = $"/accessmanagement/api/v1/enterprise/consentrequests/{consentInfo.Id}";
-            HttpResponseMessage getResponse = await client.GetAsync(location);
-            string getResponseConsent = await getResponse.Content.ReadAsStringAsync();
+            HttpResponseMessage getResponse = await client.GetAsync(location, TestContext.Current.CancellationToken);
+            string getResponseConsent = await getResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             Assert.NotNull(getResponseConsent);
             ConsentRequestDetailsDto consentInfoFromGet = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(getResponseConsent, _jsonOptions);
@@ -678,8 +678,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             string location = response.Headers.Location.ToString();
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.NotNull(responseContent);
@@ -696,8 +696,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             Assert.Equal(ConsentPartyUrn.OrganizationId.Create(OrganizationNumber.Parse("810419512")), consentInfo.ConsentRequestEvents[0].PerformedBy);
 
             string getUrl = $"/accessmanagement/api/v1/enterprise/consentrequests/{consentInfo.Id}";
-            HttpResponseMessage getResponse = await client.GetAsync(location);
-            string getResponseConsent = await getResponse.Content.ReadAsStringAsync();
+            HttpResponseMessage getResponse = await client.GetAsync(location, TestContext.Current.CancellationToken);
+            string getResponseConsent = await getResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             Assert.NotNull(getResponseConsent);
             ConsentRequestDetailsDto consentInfoFromGet = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(getResponseConsent, _jsonOptions);
@@ -759,8 +759,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write", "810418192");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             string location = response.Headers.Location.ToString();
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.NotNull(responseContent);
@@ -779,8 +779,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string getUrl = $"/accessmanagement/api/v1/enterprise/consentrequests/{consentInfo.Id}";
             token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.read", "810418192");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage getResponse = await client.GetAsync(location);
-            string getResponseConsent = await getResponse.Content.ReadAsStringAsync();
+            HttpResponseMessage getResponse = await client.GetAsync(location, TestContext.Current.CancellationToken);
+            string getResponseConsent = await getResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             Assert.NotNull(getResponseConsent);
             ConsentRequestDetailsDto consentInfoFromGet = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(getResponseConsent, _jsonOptions);
@@ -842,8 +842,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
             Assert.NotNull(responseContent);
             ConsentRequestDetailsDto consentInfo = JsonSerializer.Deserialize<ConsentRequestDetailsDto>(responseContent, _jsonOptions);
@@ -924,8 +924,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
 
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(responseContent, _jsonOptions);
@@ -978,8 +978,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(responseContent, _jsonOptions);
@@ -1052,8 +1052,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnMultipleProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnMultipleProblemDetails>(responseContent, _jsonOptions);
@@ -1112,8 +1112,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(responseContent, _jsonOptions);
@@ -1156,8 +1156,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(responseContent, _jsonOptions);
@@ -1211,8 +1211,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(responseContent, _jsonOptions);
@@ -1272,8 +1272,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetOrgToken(null, "810419512", "altinn:consentrequests.write");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"));
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsync(url, new StringContent(JsonSerializer.Serialize(consentRequest, _jsonOptions), Encoding.UTF8, "application/json"), TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(responseContent, _jsonOptions);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
@@ -231,7 +231,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             HttpClient client = GetTestClient();
 
             string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
-            HttpResponseMessage response = await client.GetAsync(url);
+            HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
@@ -249,7 +249,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
-            HttpResponseMessage response = await client.GetAsync(url);
+            HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
@@ -267,8 +267,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
-            HttpResponseMessage response = await client.GetAsync(url);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotNull(responseContent);
@@ -277,8 +277,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             if (result.Links.Next != null)
             {
                 // Fetch next page
-                var nextResponse = await client.GetAsync(result.Links.Next);
-                PaginatedResult<ConsentStatusChangeDto> nextResult = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(await nextResponse.Content.ReadAsStringAsync(), _jsonOptions);
+                var nextResponse = await client.GetAsync(result.Links.Next, TestContext.Current.CancellationToken);
+                PaginatedResult<ConsentStatusChangeDto> nextResult = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(await nextResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
                 AssertResponseForGetStatusChanges(nextResult);
             }
         }
@@ -299,8 +299,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string readToken = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", readToken);
             string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
-            HttpResponseMessage responsePage1 = await client.GetAsync(url);
-            string responseContent1 = await responsePage1.Content.ReadAsStringAsync();
+            HttpResponseMessage responsePage1 = await client.GetAsync(url, TestContext.Current.CancellationToken);
+            string responseContent1 = await responsePage1.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.OK, responsePage1.StatusCode);
             var resultPage1 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(responseContent1, _jsonOptions);
@@ -312,8 +312,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             // Fetch next page using continuation token
             if (resultPage1.Links.Next != null)
             {
-                HttpResponseMessage responsePage2 = await client.GetAsync(resultPage1.Links.Next);
-                string responseContent2 = await responsePage2.Content.ReadAsStringAsync();
+                HttpResponseMessage responsePage2 = await client.GetAsync(resultPage1.Links.Next, TestContext.Current.CancellationToken);
+                string responseContent2 = await responsePage2.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 Assert.Equal(HttpStatusCode.OK, responsePage2.StatusCode);
                 var resultPage2 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(responseContent2, _jsonOptions);
 
@@ -346,15 +346,15 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
 
             // Fetch first page
             string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
-            HttpResponseMessage responsePage1 = await client.GetAsync(url);
-            string responseContent1 = await responsePage1.Content.ReadAsStringAsync();
+            HttpResponseMessage responsePage1 = await client.GetAsync(url, TestContext.Current.CancellationToken);
+            string responseContent1 = await responsePage1.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, responsePage1.StatusCode);
             var resultPage1 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(responseContent1, _jsonOptions);
 
             // Fetch next page
             Assert.NotNull(resultPage1.Links.Next);
-            HttpResponseMessage responsePage2 = await client.GetAsync(resultPage1.Links.Next);
-            string responseContent2 = await responsePage2.Content.ReadAsStringAsync();
+            HttpResponseMessage responsePage2 = await client.GetAsync(resultPage1.Links.Next, TestContext.Current.CancellationToken);
+            string responseContent2 = await responsePage2.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, responsePage2.StatusCode);
             var resultPage2 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(responseContent2, _jsonOptions);
 
@@ -404,11 +404,11 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string urlWithParam = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?pageSize=100";
             string urlWithoutParam = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
 
-            var responseWith = await client.GetAsync(urlWithParam);
-            var responseWithout = await client.GetAsync(urlWithoutParam);
+            var responseWith = await client.GetAsync(urlWithParam, TestContext.Current.CancellationToken);
+            var responseWithout = await client.GetAsync(urlWithoutParam, TestContext.Current.CancellationToken);
 
-            var resultWith = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(await responseWith.Content.ReadAsStringAsync(), _jsonOptions);
-            var resultWithout = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(await responseWithout.Content.ReadAsStringAsync(), _jsonOptions);
+            var resultWith = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(await responseWith.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+            var resultWithout = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(await responseWithout.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
 
             // Both should return config-driven page size (5), not 100
             Assert.Equal(resultWithout.Items.Count(), resultWith.Items.Count());
@@ -424,11 +424,11 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
-            HttpResponseMessage response = await client.GetAsync(url);
+            HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
-                await response.Content.ReadAsStringAsync(), _jsonOptions);
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
 
             // LatestChangesPageSize is set to 5 in PostConfigure — assert exactly that
             Assert.Equal(5, result.Items.Count());
@@ -443,10 +443,10 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
-            HttpResponseMessage response = await client.GetAsync(url);
+            HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
             var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
-                await response.Content.ReadAsStringAsync(), _jsonOptions);
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
 
             Assert.NotNull(result.Links.Next);
 
@@ -464,23 +464,23 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Page 1
-            var response1 = await client.GetAsync("/accessmanagement/api/v1/enterprise/consentrequests/latestchanges");
+            var response1 = await client.GetAsync("/accessmanagement/api/v1/enterprise/consentrequests/latestchanges", TestContext.Current.CancellationToken);
             var page1 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
-                await response1.Content.ReadAsStringAsync(), _jsonOptions);
+                await response1.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
             Assert.Equal(5, page1.Items.Count());
             Assert.NotNull(page1.Links.Next);
 
             // Page 2
-            var response2 = await client.GetAsync(page1.Links.Next);
+            var response2 = await client.GetAsync(page1.Links.Next, TestContext.Current.CancellationToken);
             var page2 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
-                await response2.Content.ReadAsStringAsync(), _jsonOptions);
+                await response2.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
             Assert.Equal(5, page2.Items.Count());
             Assert.NotNull(page2.Links.Next); // Full page → link exists (accepted extra round-trip behavior)
 
             // Page 3 - empty, terminates pagination
-            var response3 = await client.GetAsync(page2.Links.Next);
+            var response3 = await client.GetAsync(page2.Links.Next, TestContext.Current.CancellationToken);
             var page3 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
-                await response3.Content.ReadAsStringAsync(), _jsonOptions);
+                await response3.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
             Assert.Empty(page3.Items);
             Assert.Null(page3.Links.Next); // No more data → terminates correctly
         }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinPorten/ConsentControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinPorten/ConsentControllerTest.cs
@@ -109,9 +109,9 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
                 To = Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.OrganizationId.Create(OrganizationNumber.Parse("810419512"))
             };
 
-            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup);
-            var task = await repositgo.GetRequest(requestId, default);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup, cancellationToken: TestContext.Current.CancellationToken);
+            var task = await repositgo.GetRequest(requestId, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ConsentInfoMaskinportenDto consentInfo = JsonSerializer.Deserialize<ConsentInfoMaskinportenDto>(responseContent, _jsonOptions);
             Assert.True(requestId == consentInfo.Id);
             Assert.Equal(2, consentInfo.ConsentRights.Count());
@@ -142,9 +142,9 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
                 To = Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.OrganizationId.Create(OrganizationNumber.Parse("810419512"))
             };
 
-            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup);
-            var task = await repositgo.GetRequest(requestId, default);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup, cancellationToken: TestContext.Current.CancellationToken);
+            var task = await repositgo.GetRequest(requestId, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ProblemDetails problemDetails = JsonSerializer.Deserialize<ProblemDetails>(responseContent, _jsonOptions);
             Assert.Equal("Consent is expired", problemDetails.Detail);
         }
@@ -174,9 +174,9 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
                 To = Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.OrganizationId.Create(OrganizationNumber.Parse("810419512"))
             };
 
-            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup);
-            var task = await repositgo.GetRequest(requestId, default);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup, cancellationToken: TestContext.Current.CancellationToken);
+            var task = await repositgo.GetRequest(requestId, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ConsentInfoMaskinportenDto consentInfo = JsonSerializer.Deserialize<ConsentInfoMaskinportenDto>(responseContent, _jsonOptions);
             Assert.True(requestId == consentInfo.Id);
             Assert.Equal(2, consentInfo.ConsentRights.Count());
@@ -189,7 +189,7 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
 
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
 
             HttpClient client = GetTestClient();
             string url = $"/accessmanagement/api/v1/maskinporten/consent/lookup/";
@@ -204,8 +204,8 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
                 To = Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.OrganizationId.Create(OrganizationNumber.Parse("810419512"))
             };
 
-            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup, cancellationToken: TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnMultipleProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnMultipleProblemDetails>(responseContent, _jsonOptions);
@@ -223,12 +223,12 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
             ConsentRequest request = await GetRequest(requestId);
             request.ValidTo = DateTime.UtcNow.AddDays(10);
-            await repositgo.CreateRequest(request, Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(request, Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             ConsentContextDto consentContextExternal = new ConsentContextDto
             {
                 Language = "nb",
             };
-            await repositgo.AcceptConsentRequest(requestId, Guid.NewGuid(), consentContextExternal.ToConsentContext());
+            await repositgo.AcceptConsentRequest(requestId, Guid.NewGuid(), consentContextExternal.ToConsentContext(), TestContext.Current.CancellationToken);
 
             HttpClient client = GetTestClient();
             string url = $"/accessmanagement/api/v1/maskinporten/consent/lookup/";
@@ -243,8 +243,8 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
                 To = Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.OrganizationId.Create(OrganizationNumber.Parse("810419512"))
             };
 
-            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup, cancellationToken: TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ConsentInfoMaskinportenDto consentInfo = JsonSerializer.Deserialize<ConsentInfoMaskinportenDto>(responseContent, _jsonOptions);
             Assert.True(DateTime.UtcNow.AddDays(-2) < consentInfo.Consented);
             Assert.Equal(2, consentInfo.ConsentRights.Count());
@@ -264,12 +264,12 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
             ConsentRequest request = await GetRequest(requestId);
             request.ValidTo = DateTime.UtcNow.AddDays(10);
-            await repositgo.CreateRequest(request, Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(request, Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             ConsentContextDto consentContextExternal = new ConsentContextDto
             {
                 Language = "nb",
             };
-            await repositgo.AcceptConsentRequest(requestId, Guid.NewGuid(), consentContextExternal.ToConsentContext());
+            await repositgo.AcceptConsentRequest(requestId, Guid.NewGuid(), consentContextExternal.ToConsentContext(), TestContext.Current.CancellationToken);
 
             HttpClient client = GetTestClient();
             string url = $"/accessmanagement/api/v1/maskinporten/consent/lookup/";
@@ -284,8 +284,8 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
                 To = Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.OrganizationId.Create(OrganizationNumber.Parse("810419512"))
             };
 
-            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup, cancellationToken: TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ConsentInfoMaskinportenDto consentInfo = JsonSerializer.Deserialize<ConsentInfoMaskinportenDto>(responseContent, _jsonOptions);
             Assert.True(DateTime.UtcNow.AddDays(-2) < consentInfo.Consented);
             Assert.Equal(2, consentInfo.ConsentRights.Count());
@@ -300,7 +300,7 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
             ConsentRequest request = await GetRequest(requestId);
             request.ValidTo = DateTime.UtcNow.AddDays(10);
-            await repositgo.CreateRequest(request, Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(request, Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
 
             HttpClient client = GetTestClient();
             string url = $"/accessmanagement/api/v1/maskinporten/consent/lookup/";
@@ -315,8 +315,8 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
                 To = Altinn.Authorization.Api.Contracts.Consent.ConsentPartyUrn.OrganizationId.Create(OrganizationNumber.Parse("810419512"))
             };
 
-            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.PostAsJsonAsync(url, consentLookup, cancellationToken: TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.NotNull(responseContent);
             AltinnMultipleProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnMultipleProblemDetails>(responseContent, _jsonOptions);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinportenSchemaControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinportenSchemaControllerTest.cs
@@ -184,8 +184,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004223/maskinportenschema/offered");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004223/maskinportenschema/offered", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -210,8 +210,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Add("Altinn-Party-OrganizationNumber", "810418982");
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/offered");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/offered", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -228,7 +228,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
         public async Task GetOfferedMaskinportenSchemaDelegations_Notfound_MissingOfferedBy()
         {
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1//maskinportenschema/offered");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1//maskinportenschema/offered", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -247,7 +247,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/123/maskinportenschema/offered");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/123/maskinportenschema/offered", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -266,8 +266,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             string expected = "[]";
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004225/maskinportenschema/offered");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004225/maskinportenschema/offered", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -287,8 +287,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004226/maskinportenschema/offered");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004226/maskinportenschema/offered", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -307,7 +307,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Remove("Authorization");
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004223/maskinportenschema/offered");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004223/maskinportenschema/offered", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -325,7 +325,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "This is an invalid token");
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004223/maskinportenschema/offered");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004223/maskinportenschema/offered", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -345,8 +345,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004219/maskinportenschema/received");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004219/maskinportenschema/received", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -372,8 +372,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Add("Altinn-Party-OrganizationNumber", "810418192");
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/received");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/received", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -390,7 +390,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
         public async Task GetReceivedMaskinportenSchemaDelegations_Missing_CoveredBy()
         {
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1//maskinportenschema/received");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1//maskinportenschema/received", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -409,7 +409,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/1234/maskinportenschema/received");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/1234/maskinportenschema/received", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -428,8 +428,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             string expected = "[]";
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004225/maskinportenschema/received");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004225/maskinportenschema/received", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -450,8 +450,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004216/maskinportenschema/received");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004216/maskinportenschema/received", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -470,7 +470,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Remove("Authorization");
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004223/maskinportenschema/received");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004223/maskinportenschema/received", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -487,7 +487,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "This is an invalid token");
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004223/maskinportenschema/received");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/50004223/maskinportenschema/received", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -516,8 +516,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418672;
             int consumerOrg = 810418192;
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<MPDelegationExternal> actualDelegations = JsonSerializer.Deserialize<List<MPDelegationExternal>>(responseContent);
 
             // Assert
@@ -548,8 +548,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418672;
             int consumerOrg = 810418192;
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<MPDelegationExternal> actualDelegations = JsonSerializer.Deserialize<List<MPDelegationExternal>>(responseContent);
 
             // Assert
@@ -578,8 +578,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
 
             // Act
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<MPDelegationExternal> actualDelegations = JsonSerializer.Deserialize<List<MPDelegationExternal>>(responseContent);
 
             // Assert
@@ -604,8 +604,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418362;
             int consumerOrg = 810418532;
             string scope = "altinn:instances.read";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ProblemDetails errorResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
 
             // Assert
@@ -630,8 +630,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418362;
             int consumerOrg = 810418532;
 
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope=");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope=", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ProblemDetails errorResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
 
             // Assert
@@ -659,8 +659,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418362;
             int consumerOrg = 810418532;
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -689,8 +689,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418672;
             int consumerOrg = 810418192;
 
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope=");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope=", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<MPDelegationExternal> actualDelegations = JsonSerializer.Deserialize<List<MPDelegationExternal>>(responseContent);
 
             // Assert
@@ -712,8 +712,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             string expected = "Query without parameter; scope, must provide at least one of; supplierOrg, consumerOrg";
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg=&consumerorg=&scope=");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg=&consumerorg=&scope=", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ProblemDetails errorResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
 
             // Assert
@@ -738,8 +738,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             string supplierOrg = "12345";
             string consumerOrg = "810418532";
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails errorResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
 
             // Assert
@@ -764,8 +764,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             string supplierOrg = "810418362";
             string consumerOrg = "12345";
             string scope = "altinn:test/theworld.write";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails errorResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
 
             // Assert
@@ -790,8 +790,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418672;
             int consumerOrg = 810418192;
             string scope = "altinn:test/test";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -813,8 +813,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             int supplierOrg = 810418672;
             int consumerOrg = 810418192;
             string scope = "altinn:maskinporten:urn:scope:test";
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/maskinporten/delegations/?supplierorg={supplierOrg}&consumerorg={consumerOrg}&scope={scope}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -837,7 +837,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Add("Altinn-Party-OrganizationNumber", "810418192");
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/offered");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/offered", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expectedStatusCode, response.StatusCode);
@@ -860,7 +860,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Add("Altinn-Party-OrganizationNumber", "810418192");
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/offered");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/offered", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expectedStatusCode, response.StatusCode);
@@ -882,7 +882,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Add("Altinn-Party-OrganizationNumber", "810418192");
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/received");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/received", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expectedStatusCode, response.StatusCode);
@@ -905,7 +905,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             _client.DefaultRequestHeaders.Add("Altinn-Party-OrganizationNumber", "810418192");
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/received");
+            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/organization/maskinportenschema/received", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expectedStatusCode, response.StatusCode);
@@ -928,12 +928,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "jks_audi_etron_gt", $"p{fromParty}", "p50004222");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             RightsDelegationResponseExternal actualResponse = JsonSerializer.Deserialize<RightsDelegationResponseExternal>(responseContent, options);
             AssertionUtil.AssertRightsDelegationResponseExternalEqual(expectedResponse, actualResponse);
         }
@@ -957,12 +957,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "jks_audi_etron_gt", $"p{fromParty}", "p50004222");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/organization/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/organization/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             RightsDelegationResponseExternal actualResponse = JsonSerializer.Deserialize<RightsDelegationResponseExternal>(responseContent, options);
             AssertionUtil.AssertRightsDelegationResponseExternalEqual(expectedResponse, actualResponse);
         }
@@ -985,12 +985,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "jks_audi_etron_gt", $"p{fromParty}", "810418672");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             RightsDelegationResponseExternal actualResponse = JsonSerializer.Deserialize<RightsDelegationResponseExternal>(responseContent, options);
             AssertionUtil.AssertRightsDelegationResponseExternalEqual(expectedResponse, actualResponse);
         }
@@ -1007,7 +1007,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "jks_audi_etron_gt", $"p{fromParty}", "p50004222");
 
             // Act
-            HttpResponseMessage response = await NewClient().PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await NewClient().PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -1032,12 +1032,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p{fromParty}", "p2", "ExpectedOutput_InvalidTo");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1061,12 +1061,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p{fromParty}", "u20001337", "ExpectedOutput_InvalidTo_UserId");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1090,12 +1090,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p{fromParty}", "u20001337", "ExpectedOutput_InvalidTo_Ssn");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1119,12 +1119,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("MaskinportenScopeDelegation", "non_delegable_maskinportenschema", $"p{fromParty}", "p50004222");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1148,12 +1148,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "digdirs_company_car", $"p{fromParty}", "p50004222");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1182,7 +1182,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("RevokeOfferedMaskinportenScopeDelegation", "jks_audi_etron_gt", $"p{fromParty}", "p50004221");
 
             // Act
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/revoke", requestContent);
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
@@ -1206,7 +1206,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("RevokeOfferedMaskinportenScopeDelegation", "jks_audi_etron_gt", $"p{fromParty}", "810418532");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/revoke", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
@@ -1231,7 +1231,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("RevokeOfferedMaskinportenScopeDelegation", "jks_audi_etron_gt", $"p{fromParty}", "810418532");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/revoke", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
@@ -1254,7 +1254,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("RevokeOfferedMaskinportenScopeDelegation", "jks_audi_etron_gt", $"p{fromParty}", "p50004221");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/revoke", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -1279,12 +1279,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("RevokeOfferedMaskinportenScopeDelegation", "mp_validation_problem_details", $"p{fromParty}", "p2", "ExpectedOutput_InvalidTo");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/revoke", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1313,7 +1313,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("RevokeReceivedMaskinportenScopeDelegation", "jks_audi_etron_gt", $"p50005545", $"p{toParty}");
 
             // Act
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/{toParty}/maskinportenschema/received/revoke", requestContent);
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/{toParty}/maskinportenschema/received/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
@@ -1339,7 +1339,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("RevokeReceivedMaskinportenScopeDelegation", "jks_undelegable", $"p50005545", $"p{toParty}");
 
             // Act
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/{toParty}/maskinportenschema/received/revoke", requestContent);
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/{toParty}/maskinportenschema/received/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
@@ -1364,7 +1364,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("RevokeReceivedMaskinportenScopeDelegation", "jks_audi_etron_gt", $"p50005545", $"p{toParty}");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/organization/maskinportenschema/received/revoke", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/organization/maskinportenschema/received/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
@@ -1389,7 +1389,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("RevokeReceivedMaskinportenScopeDelegation", "jks_audi_etron_gt", $"910459880", $"810418532");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/organization/maskinportenschema/received/revoke", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/organization/maskinportenschema/received/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
@@ -1412,7 +1412,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("RevokeReceivedMaskinportenScopeDelegation", "jks_audi_etron_gt", $"p50005545", $"p{toParty}");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{toParty}/maskinportenschema/received/revoke", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{toParty}/maskinportenschema/received/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -1437,12 +1437,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("RevokeReceivedMaskinportenScopeDelegation", "mp_validation_problem_details", $"p2", $"p{toParty}", "ExpectedOutput_InvalidFrom");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{toParty}/maskinportenschema/received/revoke", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{toParty}/maskinportenschema/received/revoke", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1464,12 +1464,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "jks_audi_etron_gt", $"p{fromParty}", "p50005545");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1493,12 +1493,12 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "jks_audi_etron_gt", $"p{fromParty}", toOrg);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered", requestContent);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{fromParty}/maskinportenschema/offered", requestContent, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1526,8 +1526,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1559,8 +1559,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1590,8 +1590,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -1618,8 +1618,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -1649,8 +1649,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -1680,8 +1680,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -1712,8 +1712,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/{reporteePartyId}/maskinportenschema/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1893,10 +1893,10 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p1", "p2", "Input_SingleRightOnly");
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p1", "p2", "ExpectedOutput_SingleRightOnly");
 
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/1/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/1/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1911,10 +1911,10 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p1", "p2", "Input_OrgAppResource");
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p1", "p2", "ExpectedOutput_OrgAppResource");
 
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/1/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/1/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1929,10 +1929,10 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p1", "p2", "Input_InvalidResourceRegistryId");
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p1", "p2", "ExpectedOutput_InvalidResourceRegistryId");
 
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/1/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/1/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1947,10 +1947,10 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p1", "p2", "Input_InvalidResourceType");
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p1", "p2", "ExpectedOutput_InvalidResourceType");
 
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/1/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/1/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }
@@ -1967,10 +1967,10 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRequestContent("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p{fromParty}", "p2", "Input_Default");
             ValidationProblemDetails expectedResponse = GetExpectedValidationProblemDetails("MaskinportenScopeDelegation", "mp_validation_problem_details", $"p{fromParty}", "p2", "ExpectedOutput_InvalidFrom_Ssn");
 
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/person/maskinportenschema/offered/", requestContent);
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/person/maskinportenschema/offered/", requestContent, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             ValidationProblemDetails actualResponse = JsonSerializer.Deserialize<ValidationProblemDetails>(responseContent, options);
             AssertionUtil.AssertValidationProblemDetailsEqual(expectedResponse, actualResponse);
         }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PartyControllerTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PartyControllerTests.cs
@@ -61,7 +61,7 @@ namespace Altinn.AccessManagement.Api.Internal.IntegrationTests.Controllers
                 }
             };
 
-            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage);
+            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
@@ -83,7 +83,7 @@ namespace Altinn.AccessManagement.Api.Internal.IntegrationTests.Controllers
                 }
             };
 
-            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage);
+            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
@@ -105,11 +105,11 @@ namespace Altinn.AccessManagement.Api.Internal.IntegrationTests.Controllers
                 }
             };
 
-            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage);
+            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
             AltinnProblemDetails actual = JsonSerializer.Deserialize<AltinnProblemDetails>(
-                await response.Content.ReadAsStringAsync(), _jsonOptions)!;
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions)!;
             Assert.Equal("The Entitytype is not supported", actual.Detail);
         }
 
@@ -131,11 +131,11 @@ namespace Altinn.AccessManagement.Api.Internal.IntegrationTests.Controllers
                 }
             };
 
-            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage);
+            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
             AltinnProblemDetails actual = JsonSerializer.Deserialize<AltinnProblemDetails>(
-                await response.Content.ReadAsStringAsync(), _jsonOptions)!;
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions)!;
             Assert.Equal("The EntityVariant is not found or not valid for the given EntityType", actual.Detail);
         }
 
@@ -157,10 +157,10 @@ namespace Altinn.AccessManagement.Api.Internal.IntegrationTests.Controllers
                 }
             };
 
-            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage);
+            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-            var result = await response.Content.ReadFromJsonAsync<AddPartyResultDto>();
+            var result = await response.Content.ReadFromJsonAsync<AddPartyResultDto>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.True(result!.PartyCreated);
         }
 
@@ -182,10 +182,10 @@ namespace Altinn.AccessManagement.Api.Internal.IntegrationTests.Controllers
                 }
             };
 
-            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage);
+            HttpResponseMessage response = await GetClient().SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-            var result = await response.Content.ReadFromJsonAsync<AddPartyResultDto>();
+            var result = await response.Content.ReadFromJsonAsync<AddPartyResultDto>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.True(result!.PartyCreated);
         }
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PolicyInformationPointControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PolicyInformationPointControllerTest.cs
@@ -81,12 +81,12 @@ public class PolicyInformationPointControllerTest : IClassFixture<ApiFixture>
     public async Task GetDelegationChanges_ValidResponse(string scenario)
     {
         // Act
-        HttpResponseMessage actualResponse = await _client.PostAsync($"accessmanagement/api/v1/policyinformation/getdelegationchanges", GetRequest(scenario));
+        HttpResponseMessage actualResponse = await _client.PostAsync($"accessmanagement/api/v1/policyinformation/getdelegationchanges", GetRequest(scenario), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, actualResponse.StatusCode);
 
-        List<DelegationChangeExternal> actualDelegationChanges = JsonSerializer.Deserialize<List<DelegationChangeExternal>>(await actualResponse.Content.ReadAsStringAsync(), options);
+        List<DelegationChangeExternal> actualDelegationChanges = JsonSerializer.Deserialize<List<DelegationChangeExternal>>(await actualResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), options);
         AssertionUtil.AssertEqual(GetExpected(scenario), actualDelegationChanges);
     }
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceControllerTest.cs
@@ -74,8 +74,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             Stream dataStream = File.OpenRead("Data/Json/InsertAccessManagementResource/input1.json");
             StreamContent content = new StreamContent(dataStream);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-            string dataElement1 = await File.OpenText("Data/Json/InsertAccessManagementResource/InsertData_string.json").ReadToEndAsync();
-            string dataElement2 = await File.OpenText("Data/Json/InsertAccessManagementResource/InsertData_string2.json").ReadToEndAsync();
+            string dataElement1 = await File.OpenText("Data/Json/InsertAccessManagementResource/InsertData_string.json").ReadToEndAsync(TestContext.Current.CancellationToken);
+            string dataElement2 = await File.OpenText("Data/Json/InsertAccessManagementResource/InsertData_string2.json").ReadToEndAsync(TestContext.Current.CancellationToken);
             string expectedText = $"[{dataElement1},{dataElement2}]";
             List<AccessManagementResource> expected = JsonSerializer.Deserialize<List<AccessManagementResource>>(expectedText, options);
 
@@ -87,8 +87,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("platform", "resourceregistry"));
 
             // Act
-            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<AccessManagementResource> actual = JsonSerializer.Deserialize<List<AccessManagementResource>>(responseContent, options);
 
             // Assert
@@ -110,7 +110,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent content = new StreamContent(dataStream);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/internal/resources", content);
+            HttpResponseMessage response = await _client.PostAsync($"accessmanagement/api/v1/internal/resources", content, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -134,7 +134,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("UnitTest", "resourceregistry"));
 
             // Act
-            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -161,8 +161,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("platform", "resourceregistry"));
 
             // Act
-            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-            string actual = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+            string actual = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -189,8 +189,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("platform", "resourceregistry"));
 
             // Act
-            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -211,8 +211,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             Stream dataStream = File.OpenRead("Data/Json/InsertAccessManagementResource/input4.json");
             StreamContent content = new StreamContent(dataStream);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-            string dataElement1 = await File.OpenText("Data/Json/InsertAccessManagementResource/InsertData_string.json").ReadToEndAsync();
-            string dataElement2 = await File.OpenText("Data/Json/InsertAccessManagementResource/InsertData_string2.json").ReadToEndAsync();
+            string dataElement1 = await File.OpenText("Data/Json/InsertAccessManagementResource/InsertData_string.json").ReadToEndAsync(TestContext.Current.CancellationToken);
+            string dataElement2 = await File.OpenText("Data/Json/InsertAccessManagementResource/InsertData_string2.json").ReadToEndAsync(TestContext.Current.CancellationToken);
             string expectedText = $"[{dataElement1},{dataElement2}]";
             List<AccessManagementResource> expected = JsonSerializer.Deserialize<List<AccessManagementResource>>(expectedText, options);
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, $"accessmanagement/api/v1/internal/resources")
@@ -223,8 +223,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("platform", "resourceregistry"));
 
             // Act
-            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<AccessManagementResource> actual = JsonSerializer.Deserialize<List<AccessManagementResource>>(responseContent, options);
 
             // Assert
@@ -253,8 +253,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("platform", "resourceregistry"));
 
             // Act
-            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-            string actual = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+            string actual = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceOwnerAPI/AppsInstanceDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceOwnerAPI/AppsInstanceDelegationControllerTest.cs
@@ -78,12 +78,12 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         var client = GetTestClient(platformToken);
 
         // Act
-        HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/app/delegationcheck/resource/{resourceId}/instance/{instanceId}");
+        HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/app/delegationcheck/resource/{resourceId}/instance/{instanceId}", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        Paginated<ResourceRightDelegationCheckResultDto> actual = JsonSerializer.Deserialize<Paginated<ResourceRightDelegationCheckResultDto>>(await response.Content.ReadAsStringAsync(), options);
+        Paginated<ResourceRightDelegationCheckResultDto> actual = JsonSerializer.Deserialize<Paginated<ResourceRightDelegationCheckResultDto>>(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), options);
 
         AssertionUtil.AssertPagination(expected, actual, AssertionUtil.AssertResourceRightDelegationCheckResultDto);
     }
@@ -105,12 +105,12 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         var client = GetTestClient(platformToken);
 
         // Act
-        HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/app/delegations/resource/{resourceId}/instance/{instanceId}", new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, MediaTypeNames.Application.Json));
+        HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/app/delegations/resource/{resourceId}/instance/{instanceId}", new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, MediaTypeNames.Application.Json), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        AppsInstanceDelegationResponseDto actual = JsonSerializer.Deserialize<AppsInstanceDelegationResponseDto>(await response.Content.ReadAsStringAsync(), options);
+        AppsInstanceDelegationResponseDto actual = JsonSerializer.Deserialize<AppsInstanceDelegationResponseDto>(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), options);
         AssertionUtil.AssertAppsInstanceDelegationResponseDto(expected, actual);
     }
 
@@ -129,12 +129,12 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         var client = GetTestClient(platformToken);
 
         // Act
-        HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/app/delegationrevoke/resource/{resourceId}/instance/{instanceId}", new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, MediaTypeNames.Application.Json));
+        HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/app/delegationrevoke/resource/{resourceId}/instance/{instanceId}", new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, MediaTypeNames.Application.Json), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        AppsInstanceRevokeResponseDto actual = JsonSerializer.Deserialize<AppsInstanceRevokeResponseDto>(await response.Content.ReadAsStringAsync(), options);
+        AppsInstanceRevokeResponseDto actual = JsonSerializer.Deserialize<AppsInstanceRevokeResponseDto>(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), options);
         AssertionUtil.AssertAppsInstanceRevokeResponseDto(expected, actual);
     }
 
@@ -145,12 +145,12 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         var client = GetTestClient(platformToken);
 
         // Act
-        HttpResponseMessage response = await client.DeleteAsync($"accessmanagement/api/v1/app/delegationrevoke/resource/{resourceId}/instance/{instanceId}");
+        HttpResponseMessage response = await client.DeleteAsync($"accessmanagement/api/v1/app/delegationrevoke/resource/{resourceId}/instance/{instanceId}", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        Paginated<AppsInstanceRevokeResponseDto> actual = JsonSerializer.Deserialize<Paginated<AppsInstanceRevokeResponseDto>>(await response.Content.ReadAsStringAsync(), options);
+        Paginated<AppsInstanceRevokeResponseDto> actual = JsonSerializer.Deserialize<Paginated<AppsInstanceRevokeResponseDto>>(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), options);
         AssertionUtil.AssertPagination(expected, actual, AssertionUtil.AssertAppsInstanceRevokeResponseDto);
     }
 
@@ -161,12 +161,12 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         var client = GetTestClient(platformToken);
 
         // Act
-        HttpResponseMessage response = await client.DeleteAsync($"accessmanagement/api/v1/app/delegationrevoke/resource/{resourceId}/instance/{instanceId}");
+        HttpResponseMessage response = await client.DeleteAsync($"accessmanagement/api/v1/app/delegationrevoke/resource/{resourceId}/instance/{instanceId}", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-        AltinnProblemDetails actual = JsonSerializer.Deserialize<AltinnProblemDetails>(await response.Content.ReadAsStringAsync(), options);
+        AltinnProblemDetails actual = JsonSerializer.Deserialize<AltinnProblemDetails>(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), options);
         TestDataAppsInstanceDelegation.AssertAltinnProblemDetailsEqual(expected, actual);
     }
 
@@ -177,7 +177,7 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         var client = GetTestClient(null);
 
         // Act
-        HttpResponseMessage response = await client.DeleteAsync($"accessmanagement/api/v1/app/delegationrevoke/resource/{resourceId}/instance/{instanceId}");
+        HttpResponseMessage response = await client.DeleteAsync($"accessmanagement/api/v1/app/delegationrevoke/resource/{resourceId}/instance/{instanceId}", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -196,12 +196,12 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         var client = GetTestClient(platformToken);
 
         // Act
-        HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/app/delegations/resource/{resourceId}/instance/{instanceId}", new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, MediaTypeNames.Application.Json));
+        HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/app/delegations/resource/{resourceId}/instance/{instanceId}", new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, MediaTypeNames.Application.Json), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.PartialContent, response.StatusCode);
 
-        AppsInstanceDelegationResponseDto actual = JsonSerializer.Deserialize<AppsInstanceDelegationResponseDto>(await response.Content.ReadAsStringAsync(), options);
+        AppsInstanceDelegationResponseDto actual = JsonSerializer.Deserialize<AppsInstanceDelegationResponseDto>(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), options);
         AssertionUtil.AssertAppsInstanceDelegationResponseDto(expected, actual);
     }
 
@@ -218,12 +218,12 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         var client = GetTestClient(platformToken);
 
         // Act
-        HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/app/delegations/resource/{resourceId}/instance/{instanceId}", new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, MediaTypeNames.Application.Json));
+        HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/app/delegations/resource/{resourceId}/instance/{instanceId}", new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, MediaTypeNames.Application.Json), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
-        AltinnProblemDetails actual = JsonSerializer.Deserialize<AltinnProblemDetails>(await response.Content.ReadAsStringAsync(), options);
+        AltinnProblemDetails actual = JsonSerializer.Deserialize<AltinnProblemDetails>(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), options);
         TestDataAppsInstanceDelegation.AssertAltinnProblemDetailsEqual(expected, actual);
     }
 
@@ -234,12 +234,12 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
         var client = GetTestClient(platformToken);
 
         // Act
-        HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/app/delegations/resource/{resourceId}/instance/{instanceId}");
+        HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/app/delegations/resource/{resourceId}/instance/{instanceId}", TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        Paginated<AppsInstanceDelegationResponseDto> actual = JsonSerializer.Deserialize<Paginated<AppsInstanceDelegationResponseDto>>(await response.Content.ReadAsStringAsync(), options);
+        Paginated<AppsInstanceDelegationResponseDto> actual = JsonSerializer.Deserialize<Paginated<AppsInstanceDelegationResponseDto>>(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), options);
         AssertionUtil.AssertPagination(expected, actual, AssertionUtil.AssertAppsInstanceDelegationResponseDto);
     }
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/RightsInternalControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/RightsInternalControllerTest.cs
@@ -92,8 +92,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("jks_audi_etron_gt", "p50005545", "u20000095");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -117,8 +117,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("jks_audi_etron_gt", "p50005545", "u20000095");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -142,9 +142,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             // Act
             var client = GetTestClient(sblInternalToken);
 
-            var response = await client.PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent);
+            var response = await client.PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -167,9 +167,9 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("jks_audi_etron_gt", "p50005545", "u20000490");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent);
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent, TestContext.Current.CancellationToken);
 
-            string responseContent = await response.Content.ReadAsStringAsync();
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -191,8 +191,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("digdirs_company_car", "p50005545", "u20001337");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -216,8 +216,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("digdirs_company_car", "p50005545", "u20001337");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -243,8 +243,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("jks_audi_etron_gt", "p50004221", "u20000490");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -270,8 +270,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("jks_audi_etron_gt", "p50004221", "u20000490");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -294,8 +294,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("org1_app1", "p50001337", "u20001337");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -319,8 +319,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("org1_app1", "p50001337", "u20001337");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -342,8 +342,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("ttd_rf-0002", "p50005545", "u20000490");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -366,8 +366,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("ttd_rf-0002", "p50005545", "u20000490");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/rights/?returnAllPolicyRights=true", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -389,8 +389,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("ttd_rf-0002", "p50005545", "u20000490");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -413,8 +413,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("ttd_rf-0002", "p50005545", "u20000490");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/?returnAllPolicyRights=true", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/?returnAllPolicyRights=true", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -439,8 +439,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("jks_audi_etron_gt", "p50004221", "u20000490");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -466,8 +466,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("jks_audi_etron_gt", "p50004221", "u20000490");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/?returnAllPolicyRights=true", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/?returnAllPolicyRights=true", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -489,8 +489,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("digdirs_company_car", "p50005545", "u20001337");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -514,8 +514,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("digdirs_company_car", "p50005545", "u20001337");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/?returnAllPolicyRights=true", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/?returnAllPolicyRights=true", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -539,8 +539,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("org1_app1", "p50001337", "u20001337");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -564,8 +564,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsQueryRequestContent("org1_app1", "p50001337", "u20001337");
 
             // Act
-            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/?returnAllPolicyRights=true", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(sblInternalToken).PostAsync($"accessmanagement/api/v1/internal/query/delegablerights/?returnAllPolicyRights=true", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<RightExternal> actualRights = JsonSerializer.Deserialize<List<RightExternal>>(responseContent, options);
 
             // Assert
@@ -600,8 +600,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -625,8 +625,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -650,8 +650,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -675,8 +675,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -721,8 +721,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -767,8 +767,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -803,8 +803,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -840,8 +840,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -875,8 +875,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -906,8 +906,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -937,8 +937,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -967,8 +967,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -997,8 +997,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetDelegationCheckContent(resourceId);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{reporteePartyId}/rights/delegation/delegationcheck", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -1034,8 +1034,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.Ssn, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1071,8 +1071,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.Uuid, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1108,8 +1108,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.Uuid, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -1142,8 +1142,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.Uuid, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1177,8 +1177,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.Uuid, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1207,8 +1207,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.Ssn, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -1242,8 +1242,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.Ssn, to.Ssn, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1278,8 +1278,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.Ssn, to.Uuid, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1317,8 +1317,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.Ssn, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1354,8 +1354,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.OrgNo, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1388,8 +1388,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.Username, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1423,8 +1423,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.Uuid, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1460,8 +1460,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.OrgNo, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1497,8 +1497,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.Ssn, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -1529,8 +1529,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.OrgNo, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -1561,8 +1561,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             StreamContent requestContent = GetRightsDelegationContent(resourceId, from.OrgNo, to.OrgNo, by.Ssn, scenario);
 
             // Act
-            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await GetTestClient(token).PostAsync($"accessmanagement/api/v1/internal/{from.PartyId}/rights/delegation/offered", requestContent, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -1706,7 +1706,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
                 client.DefaultRequestHeaders.Add(headerKey, headerValue);
             }
 
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/internal/{partyRouteValue}/rights/delegation/offered/revoke", new StringContent(JsonSerializer.Serialize(input), new MediaTypeHeaderValue(MediaTypeNames.Application.Json)));
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/internal/{partyRouteValue}/rights/delegation/offered/revoke", new StringContent(JsonSerializer.Serialize(input), new MediaTypeHeaderValue(MediaTypeNames.Application.Json)), TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
@@ -1728,7 +1728,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
                 client.DefaultRequestHeaders.Add(headerKey, headerValue);
             }
 
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/internal/{partyRouteValue}/rights/delegation/received/revoke", new StringContent(JsonSerializer.Serialize(input), new MediaTypeHeaderValue(MediaTypeNames.Application.Json)));
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/internal/{partyRouteValue}/rights/delegation/received/revoke", new StringContent(JsonSerializer.Serialize(input), new MediaTypeHeaderValue(MediaTypeNames.Application.Json)), TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HealthCheckTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HealthCheckTests.cs
@@ -32,8 +32,8 @@ namespace Altinn.AccessManagement.Tests.Health
         {
             var request = new HttpRequestMessage(HttpMethod.Get, "/health");
 
-            HttpResponseMessage response = await _client.SendAsync(request);
-            Assert.Equal("Healthy", await response.Content.ReadAsStringAsync());
+            HttpResponseMessage response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+            Assert.Equal("Healthy", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
@@ -46,8 +46,8 @@ namespace Altinn.AccessManagement.Tests.Health
         {
             var request = new HttpRequestMessage(HttpMethod.Get, "/alive");
 
-            HttpResponseMessage response = await _client.SendAsync(request);
-            await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.SendAsync(request, TestContext.Current.CancellationToken);
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/DelegationHelperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/DelegationHelperTest.cs
@@ -204,7 +204,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
         {
             // Arrange
             Rule rule = TestDataUtil.GetRuleModel(20001337, 50001337, "20001336", AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, "write", "org1", "app1");
-            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "app1");
+            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "app1", TestContext.Current.CancellationToken);
 
             // Act
             bool actual = DelegationHelper.PolicyContainsMatchingRule(policy, rule);
@@ -228,7 +228,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
         {
             // Arrange
             Rule rule = TestDataUtil.GetRuleModel(20001337, 50001337, "20001336", AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, "read", "org1", "unorderedresources");
-            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "unorderedresources");
+            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "unorderedresources", TestContext.Current.CancellationToken);
 
             // Act
             bool actual = DelegationHelper.PolicyContainsMatchingRule(policy, rule);
@@ -253,7 +253,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
         {
             // Arrange
             Rule rule = TestDataUtil.GetRuleModel(20001337, 50001337, "20001336", AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, "eat", "org1", "singlecomplexrule", appresource: "banana");
-            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "singlecomplexrule");
+            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "singlecomplexrule", TestContext.Current.CancellationToken);
 
             // Act
             bool actual = DelegationHelper.PolicyContainsMatchingRule(policy, rule);
@@ -277,7 +277,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
         {
             // Arrange
             Rule rule = TestDataUtil.GetRuleModel(20001337, 50001337, "20001336", AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, "sign", "org1", "app1", task: "task1");
-            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "app1");
+            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "app1", TestContext.Current.CancellationToken);
 
             // Act
             bool actual = DelegationHelper.PolicyContainsMatchingRule(policy, rule);
@@ -301,7 +301,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
         {
             // Arrange
             Rule rule = TestDataUtil.GetRuleModel(20001337, 50001337, "20001336", AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, "sign", "org1", "app1");
-            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "app1");
+            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "app1", TestContext.Current.CancellationToken);
 
             // Act
             bool actual = DelegationHelper.PolicyContainsMatchingRule(policy, rule);
@@ -325,7 +325,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
         {
             // Arrange
             Rule rule = TestDataUtil.GetRuleModel(20001337, 50001337, "20001336", AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, "read", "org2", "app1");
-            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "app1");
+            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "app1", TestContext.Current.CancellationToken);
 
             // Act
             bool actual = DelegationHelper.PolicyContainsMatchingRule(policy, rule);
@@ -349,7 +349,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
         {
             // Arrange
             Rule rule = TestDataUtil.GetRuleModel(20001337, 50001337, "20001336", AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, "read", "org2", "app1");
-            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "app1");
+            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "app1", TestContext.Current.CancellationToken);
 
             // Act
             bool actual = DelegationHelper.PolicyContainsMatchingRule(policy, rule);
@@ -374,7 +374,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
         {
             // Arrange
             Rule rule = TestDataUtil.GetRuleModel(20001337, 50001337, "20001336", AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, "eat", "org1", "singlecomplexrule");
-            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "singlecomplexrule");
+            XacmlPolicy policy = await _prpMock.GetPolicyAsync("org1", "singlecomplexrule", TestContext.Current.CancellationToken);
 
             // Act
             bool actual = DelegationHelper.PolicyContainsMatchingRule(policy, rule);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/PolicyHelperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/PolicyHelperTest.cs
@@ -63,7 +63,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
         public async Task GetRolesWithAccess()
         {
             // Arrange
-            XacmlPolicy policy = await _policyRetrievalPointMock.GetPolicyAsync("resource1");
+            XacmlPolicy policy = await _policyRetrievalPointMock.GetPolicyAsync("resource1", TestContext.Current.CancellationToken);
 
             List<string> expected = TestDataUtil.GetRolesWithAccess();
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs
@@ -83,12 +83,12 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.FeatureDisabledDelayMs * 2));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert
         _leaseServiceMock.Verify(
@@ -117,14 +117,14 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         // Advance by EmptyFeedDelayMs + max jitter (2000ms)
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.EmptyFeedDelayMs + 2000));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert
         _leaseServiceMock.Verify(
@@ -157,12 +157,12 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert
         _leaseServiceMock.Verify(
@@ -195,12 +195,12 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.EmptyFeedDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert
         _syncServiceMock.Verify(
@@ -230,12 +230,12 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert
         _syncServiceMock.Verify(
@@ -275,14 +275,14 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
         _timeProvider.Advance(TimeSpan.FromMinutes(1)); // Error delay
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert - Service continues after exception
         _syncServiceMock.Verify(
@@ -311,10 +311,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
 
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert - no exception thrown, service stops cleanly
         Assert.True(true);
@@ -342,12 +342,12 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert
         _leaseMock.Verify(x => x.DisposeAsync(), Times.AtLeastOnce);
@@ -375,18 +375,18 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         // Trigger first iteration
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         // Trigger second iteration
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert - Lease acquired multiple times (one per iteration)
         _leaseServiceMock.Verify(
@@ -425,7 +425,7 @@ public class ConsentMigrationHostedServiceTests : IDisposable
 
         // Wait for ProcessBatch to be called before asserting
         await processBatchCalled.Task;
-        await Task.Delay(50);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Assert - The service should throw OperationCanceledException when cancellation is requested
         await Assert.ThrowsAsync<OperationCanceledException>(async () => await serviceTask);
@@ -469,12 +469,12 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert
         _leaseServiceMock.Verify(
@@ -496,17 +496,17 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         // Advance by FeatureDisabledDelayMs multiple times
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.FeatureDisabledDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.FeatureDisabledDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert - Should not acquire lease when feature is disabled
         _leaseServiceMock.Verify(
@@ -541,22 +541,22 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         // First attempt - no lease (includes jitter up to 2000ms)
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.EmptyFeedDelayMs + 2000));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         // Second attempt - no lease (includes jitter up to 2000ms)
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.EmptyFeedDelayMs + 2000));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         // Third attempt - lease acquired
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert
         _leaseServiceMock.Verify(
@@ -585,15 +585,15 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         // The jitter adds 1000-2000ms to the EmptyFeedDelayMs
         // So we need to advance by at least EmptyFeedDelayMs + 1000ms to guarantee triggering
         _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.EmptyFeedDelayMs + 1000));
-        await Task.Delay(10);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000));
+        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert - Verify lease was attempted (jitter doesn't prevent retry)
         _leaseServiceMock.Verify(

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/PolicyAdministrationPointTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/PolicyAdministrationPointTest.cs
@@ -68,7 +68,7 @@ namespace Altinn.AccessManagement.Tests
             Stream dataStream = File.OpenRead("Data/Policies/policy.xml");
 
             // Act
-            bool successfullyStored = await _pap.WritePolicyAsync("org", "app", dataStream);
+            bool successfullyStored = await _pap.WritePolicyAsync("org", "app", dataStream, TestContext.Current.CancellationToken);
             SetupUtils.DeleteAppBlobData("org", "app");
 
             // Assert
@@ -83,7 +83,7 @@ namespace Altinn.AccessManagement.Tests
         public async Task WritePolicy_TC02()
         {
             // Act & Assert
-            await Assert.ThrowsAsync<ArgumentException>(() => _pap.WritePolicyAsync(string.Empty, "app", new MemoryStream()));
+            await Assert.ThrowsAsync<ArgumentException>(() => _pap.WritePolicyAsync(string.Empty, "app", new MemoryStream(), TestContext.Current.CancellationToken));
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Altinn.AccessManagement.Tests
         public async Task WritePolicy_TC03()
         {
             // Act & Assert
-            await Assert.ThrowsAsync<ArgumentException>(() => _pap.WritePolicyAsync("org", string.Empty, new MemoryStream()));
+            await Assert.ThrowsAsync<ArgumentException>(() => _pap.WritePolicyAsync("org", string.Empty, new MemoryStream(), TestContext.Current.CancellationToken));
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace Altinn.AccessManagement.Tests
         public async Task WritePolicy_TC04()
         {
             // Act & Assert
-            await Assert.ThrowsAsync<ArgumentException>(() => _pap.WritePolicyAsync("org", "app", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => _pap.WritePolicyAsync("org", "app", null, TestContext.Current.CancellationToken));
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Altinn.AccessManagement.Tests
         public async Task WritePolicy_TC05()
         {
             // Act & Assert
-            await Assert.ThrowsAsync<ArgumentException>(() => _pap.WritePolicyAsync("org", "app", null));
+            await Assert.ThrowsAsync<ArgumentException>(() => _pap.WritePolicyAsync("org", "app", null, TestContext.Current.CancellationToken));
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -209,7 +209,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -266,7 +266,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -321,7 +321,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -372,7 +372,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -423,7 +423,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -482,7 +482,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -541,7 +541,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -601,7 +601,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -659,7 +659,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicyRules(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -714,7 +714,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -762,7 +762,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -821,7 +821,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -881,7 +881,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -933,7 +933,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -986,7 +986,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1046,7 +1046,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1106,7 +1106,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess);
+            List<Rule> actual = await _pap.TryDeleteDelegationPolicies(inputRuleMatchess, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1159,7 +1159,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules, cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1206,7 +1206,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules, cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1261,7 +1261,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules, cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1314,7 +1314,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules, cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1367,7 +1367,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules, cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1414,7 +1414,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules, cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1461,7 +1461,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules, cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1508,7 +1508,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules, cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1555,7 +1555,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules, cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);
@@ -1602,7 +1602,7 @@ namespace Altinn.AccessManagement.Tests
             };
 
             // Act
-            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules);
+            List<Rule> actual = await _pap.TryWriteDelegationPolicyRules(unsortedRules, cancellationToken: TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(expected.Count, actual.Count);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Resolvers/Altinn/AltinnOrganizationResolverTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Resolvers/Altinn/AltinnOrganizationResolverTests.cs
@@ -28,7 +28,7 @@ public class AltinnOrganizationResolverTests
     {
         var resolver = ResolverServiceCollection.ConfigureServices(ResolverServiceCollection.DefaultServiceCollection);
 
-        var result = await resolver.Resolve(attributes, wants, default);
+        var result = await resolver.Resolve(attributes, wants, TestContext.Current.CancellationToken);
 
         assert(result);
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Resolvers/Altinn/AltinnPersonResolverTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Resolvers/Altinn/AltinnPersonResolverTests.cs
@@ -29,7 +29,7 @@ public class AltinnPersonResolverTests
     {
         var resolver = ResolverServiceCollection.ConfigureServices(ResolverServiceCollection.DefaultServiceCollection);
 
-        var result = await resolver.Resolve(attributes, wants, default);
+        var result = await resolver.Resolve(attributes, wants, TestContext.Current.CancellationToken);
 
         assert(result);
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/AMPartyServiceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/AMPartyServiceTest.cs
@@ -67,7 +67,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup());
 
-        var result = await svc.GetByOrgNo(OrganizationNumber.Parse("937884117"));
+        var result = await svc.GetByOrgNo(OrganizationNumber.Parse("937884117"), TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
     }
@@ -79,7 +79,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup(MakeLookup("OrganizationIdentifier", "937884117", entityId, "Test Org", OrgTypeId)));
 
-        var result = await svc.GetByOrgNo(OrganizationNumber.Parse("937884117"));
+        var result = await svc.GetByOrgNo(OrganizationNumber.Parse("937884117"), TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result!.PartyUuid.Should().Be(entityId);
@@ -95,7 +95,7 @@ public class AMPartyServiceTest
             MakeLookup("OrganizationIdentifier", "937884117", Guid.NewGuid(), "Org A", OrgTypeId),
             MakeLookup("OrganizationIdentifier", "937884117", Guid.NewGuid(), "Org B", OrgTypeId)));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetByOrgNo(OrganizationNumber.Parse("937884117")));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetByOrgNo(OrganizationNumber.Parse("937884117"), TestContext.Current.CancellationToken));
     }
 
     #endregion
@@ -108,7 +108,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup());
 
-        var result = await svc.GetByPartyId(12345);
+        var result = await svc.GetByPartyId(12345, TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
     }
@@ -121,7 +121,7 @@ public class AMPartyServiceTest
             MakeLookup("PartyId", "12345", Guid.NewGuid(), "A", OrgTypeId),
             MakeLookup("PartyId", "12345", Guid.NewGuid(), "B", OrgTypeId)));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetByPartyId(12345));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetByPartyId(12345, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -131,7 +131,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup(MakeLookup("PartyId", "99001", entityId, "Person Name", PersonTypeId, "12345678901")));
 
-        var result = await svc.GetByPartyId(99001);
+        var result = await svc.GetByPartyId(99001, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result!.PersonId.Should().Be("12345678901");
@@ -146,7 +146,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup(MakeLookup("PartyId", "99002", entityId, "Org Name", OrgTypeId, "919272567")));
 
-        var result = await svc.GetByPartyId(99002);
+        var result = await svc.GetByPartyId(99002, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result!.OrganizationId.Should().Be("919272567");
@@ -160,7 +160,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup(MakeLookup("PartyId", "99003", entityId, "Unknown", UnknownTypeId, "some-ref")));
 
-        var result = await svc.GetByPartyId(99003);
+        var result = await svc.GetByPartyId(99003, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result!.PersonId.Should().BeNull();
@@ -177,7 +177,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup());
 
-        var result = await svc.GetByPersonNo(PersonIdentifier.Parse("02013299997"));
+        var result = await svc.GetByPersonNo(PersonIdentifier.Parse("02013299997"), TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
     }
@@ -190,7 +190,7 @@ public class AMPartyServiceTest
             MakeLookup("PersonIdentifier", "02013299997", Guid.NewGuid(), "A", PersonTypeId),
             MakeLookup("PersonIdentifier", "02013299997", Guid.NewGuid(), "B", PersonTypeId)));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetByPersonNo(PersonIdentifier.Parse("02013299997")));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetByPersonNo(PersonIdentifier.Parse("02013299997"), TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup(MakeLookup("PersonIdentifier", "02013299997", entityId, "John Doe", PersonTypeId)));
 
-        var result = await svc.GetByPersonNo(PersonIdentifier.Parse("02013299997"));
+        var result = await svc.GetByPersonNo(PersonIdentifier.Parse("02013299997"), TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result!.PartyUuid.Should().Be(entityId);
@@ -218,7 +218,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupExpressionResult(repo, Lookup());
 
-        var result = await svc.GetByUuid(Guid.NewGuid());
+        var result = await svc.GetByUuid(Guid.NewGuid(), TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
     }
@@ -231,7 +231,7 @@ public class AMPartyServiceTest
         SetupExpressionResult(repo, Lookup(
             MakeLookup("OrganizationIdentifier", "919272567", partyUuid, "Org Name", OrgTypeId)));
 
-        var result = await svc.GetByUuid(partyUuid);
+        var result = await svc.GetByUuid(partyUuid, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result!.OrganizationId.Should().Be("919272567");
@@ -246,7 +246,7 @@ public class AMPartyServiceTest
         SetupExpressionResult(repo, Lookup(
             MakeLookup("PersonIdentifier", "02013299997", partyUuid, "John Doe", PersonTypeId)));
 
-        var result = await svc.GetByUuid(partyUuid);
+        var result = await svc.GetByUuid(partyUuid, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result!.PersonId.Should().Be("02013299997");
@@ -261,7 +261,7 @@ public class AMPartyServiceTest
         SetupExpressionResult(repo, Lookup(
             MakeLookup("Name", "Display Name Override", partyUuid, "Entity Name", UnknownTypeId)));
 
-        var result = await svc.GetByUuid(partyUuid);
+        var result = await svc.GetByUuid(partyUuid, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result!.Name.Should().Be("Display Name Override");
@@ -277,7 +277,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup());
 
-        var result = await svc.GetByUserId(42);
+        var result = await svc.GetByUserId(42, TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
     }
@@ -290,7 +290,7 @@ public class AMPartyServiceTest
             MakeLookup("UserId", "42", Guid.NewGuid(), "A", PersonTypeId),
             MakeLookup("UserId", "42", Guid.NewGuid(), "B", PersonTypeId)));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetByUserId(42));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.GetByUserId(42, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -300,7 +300,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup(MakeLookup("UserId", "42", entityId, "Person Name", PersonTypeId, "02013299997")));
 
-        var result = await svc.GetByUserId(42);
+        var result = await svc.GetByUserId(42, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result!.PersonId.Should().Be("02013299997");
@@ -313,7 +313,7 @@ public class AMPartyServiceTest
         var (svc, repo) = MakeSut();
         SetupFilterResult(repo, Lookup(MakeLookup("UserId", "42", entityId, "Unknown Name", UnknownTypeId, "some-ref")));
 
-        var result = await svc.GetByUserId(42);
+        var result = await svc.GetByUserId(42, TestContext.Current.CancellationToken);
 
         result.Should().NotBeNull();
         result!.PersonId.Should().BeNull();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConnectionQueryTests.cs
@@ -63,7 +63,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
             EnrichPackageResources = false
         };
 
-        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true);
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true, TestContext.Current.CancellationToken);
         var connections = DtoMapper.ConvertFromOthers(dbResult, false);
 
         Assert.Single<ConnectionDto>(connections, t => t.Party.Id == orgId);
@@ -95,7 +95,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
             EnrichPackageResources = false
         };
 
-        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true);
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true, TestContext.Current.CancellationToken);
         var connections = DtoMapper.ConvertFromOthers(dbResult, false);
 
         Assert.Single<ConnectionDto>(connections, t => t.Party.Id == orgId);
@@ -127,7 +127,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
             EnrichPackageResources = false
         };
 
-        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true);
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true, TestContext.Current.CancellationToken);
         var connections = DtoMapper.ConvertFromOthers(dbResult, false);
 
         Assert.Single<ConnectionDto>(connections, t => t.Party.Id == orgId);
@@ -152,7 +152,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
             EnrichPackageResources = false
         };
 
-        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true);
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true, TestContext.Current.CancellationToken);
         var connections = DtoMapper.ConvertFromOthers(dbResult, false);
 
         Assert.Single<ConnectionDto>(connections, t => t.Party.Id == orgId);
@@ -182,7 +182,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
             EnrichPackageResources = false
         };
 
-        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true);
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true, TestContext.Current.CancellationToken);
         var connections = DtoMapper.ConvertFromOthers(dbResult, false);
 
         Assert.Single<ConnectionDto>(connections, t => t.Party.Id == orgId);
@@ -203,7 +203,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
             IncludeKeyRole = true
         };
 
-        var result = await _query.GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers, true);
+        var result = await _query.GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers, true, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.True(result.Any(), "Expected a connections, but none were found.");
@@ -219,7 +219,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
             IncludeKeyRole = false
         };
 
-        var result = await _query.GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers);
+        var result = await _query.GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers, ct: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.False(result.Any(), "Expected no connections, but some were found.");
@@ -228,7 +228,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
     [Fact]
     public async Task Baker_ShouldExist()
     {
-        var petter = await _db.Entities.AsNoTracking().SingleAsync(t => t.RefId == "ORG-01");
+        var petter = await _db.Entities.AsNoTracking().SingleAsync(t => t.RefId == "ORG-01", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(petter);
         Assert.Equal("Baker Johnsen", petter.Name);
@@ -237,7 +237,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
     [Fact]
     public async Task Organization_ShouldExist()
     {
-        var orgType = await _db.EntityTypes.AsNoTracking().SingleAsync(t => t.Id == EntityTypeConstants.Organization);
+        var orgType = await _db.EntityTypes.AsNoTracking().SingleAsync(t => t.Id == EntityTypeConstants.Organization, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(orgType);
         Assert.Equal("Organisasjon", orgType.Name);
@@ -264,7 +264,7 @@ public class ConnectionQueryTests : IClassFixture<PostgresFixture>
             OnlyUniqueResults = flags[7]
         };
 
-        await _query.GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers);
+        await _query.GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers, ct: TestContext.Current.CancellationToken);
     }
 
     public static IEnumerable<object[]> GetFilterCombinations()

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
@@ -217,7 +217,7 @@ public class ConsentServiceTests
         var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
 
         // Allow listener to process
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.IsProblem);
@@ -261,7 +261,7 @@ public class ConsentServiceTests
 
         var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
 
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
 
         Assert.False(result.IsProblem);
         Assert.NotNull(result.Value);
@@ -297,7 +297,7 @@ public class ConsentServiceTests
 
         var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
 
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
 
         Assert.True(result.IsProblem || result.Value == null);
         Assert.True(collector.GetMeasurements("consent_migration_update_a2_duration_seconds").Any());
@@ -339,7 +339,7 @@ public class ConsentServiceTests
         var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
 
         // Allow listener to process
-        await Task.Delay(20);
+        await Task.Delay(20, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result.IsProblem);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/PartyServiceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/PartyServiceTest.cs
@@ -91,7 +91,7 @@ public class PartyServiceTest
         var (svc, mocks) = MakeSut();
         SetupEntityExists(mocks.EntityRepo, exists: true);
 
-        var result = await svc.AddParty(MakeParty(), options: null);
+        var result = await svc.AddParty(MakeParty(), options: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.IsProblem.Should().BeFalse();
         result.Value.PartyCreated.Should().BeFalse();
@@ -103,7 +103,7 @@ public class PartyServiceTest
         var (svc, mocks) = MakeSut();
         SetupEntityExists(mocks.EntityRepo, exists: false);
 
-        var result = await svc.AddParty(MakeParty(entityType: "Organisation"), options: null);
+        var result = await svc.AddParty(MakeParty(entityType: "Organisation"), options: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.IsProblem.Should().BeTrue();
     }
@@ -115,7 +115,7 @@ public class PartyServiceTest
         SetupEntityExists(mocks.EntityRepo, exists: false);
         SetupEntityType(mocks.TypeRepo, type: null);
 
-        var result = await svc.AddParty(MakeParty(), options: null);
+        var result = await svc.AddParty(MakeParty(), options: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.IsProblem.Should().BeTrue();
     }
@@ -128,7 +128,7 @@ public class PartyServiceTest
         SetupEntityType(mocks.TypeRepo, new EntityType { Id = EntityTypeId, Name = "Systembruker" });
         SetupEntityVariant(mocks.VariantRepo, variant: null);
 
-        var result = await svc.AddParty(MakeParty(), options: null);
+        var result = await svc.AddParty(MakeParty(), options: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.IsProblem.Should().BeTrue();
     }
@@ -150,7 +150,7 @@ public class PartyServiceTest
                 It.IsAny<string>()))
             .ReturnsAsync(1);
 
-        var result = await svc.AddParty(party, options: null);
+        var result = await svc.AddParty(party, options: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.IsProblem.Should().BeFalse();
         result.Value.PartyCreated.Should().BeTrue();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/RelationServiceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/RelationServiceTest.cs
@@ -65,7 +65,7 @@ public class RelationServiceTest
         var (svc, _, fullRepo) = MakeSut();
         SetupFullGetExtended(fullRepo, Resp<ExtRelation>());
 
-        var result = await svc.GetConnectionsToOthers(Guid.NewGuid(), packageId: null);
+        var result = await svc.GetConnectionsToOthers(Guid.NewGuid(), packageId: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEmpty();
     }
@@ -79,7 +79,7 @@ public class RelationServiceTest
         var relation = FullRelation(from, to, "Direct");
         SetupFullGetExtended(fullRepo, Resp(relation));
 
-        var result = await svc.GetConnectionsToOthers(from.Id, packageId: null);
+        var result = await svc.GetConnectionsToOthers(from.Id, packageId: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().ContainSingle(r => r.Party.Id == to.Id);
     }
@@ -93,7 +93,7 @@ public class RelationServiceTest
         var relation = FullRelation(from, to, "Delegated");
         SetupFullGetExtended(fullRepo, Resp(relation));
 
-        var result = await svc.GetConnectionsToOthers(from.Id, packageId: null);
+        var result = await svc.GetConnectionsToOthers(from.Id, packageId: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEmpty();
     }
@@ -109,7 +109,7 @@ public class RelationServiceTest
         var r2 = new ExtRelation { From = from, To = to, Role = new CompactRole { Id = roleId }, Reason = "Direct" };
         SetupFullGetExtended(fullRepo, Resp(r1, r2));
 
-        var result = await svc.GetConnectionsToOthers(from.Id, packageId: null);
+        var result = await svc.GetConnectionsToOthers(from.Id, packageId: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().ContainSingle().Which.Roles.Should().ContainSingle();
     }
@@ -124,7 +124,7 @@ public class RelationServiceTest
         var (svc, _, fullRepo) = MakeSut();
         SetupFullGetExtended(fullRepo, Resp<ExtRelation>());
 
-        var result = await svc.GetConnectionsFromOthers(Guid.NewGuid(), packageId: null);
+        var result = await svc.GetConnectionsFromOthers(Guid.NewGuid(), packageId: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEmpty();
     }
@@ -138,7 +138,7 @@ public class RelationServiceTest
         var relation = FullRelation(from, to, "Direct");
         SetupFullGetExtended(fullRepo, Resp(relation));
 
-        var result = await svc.GetConnectionsFromOthers(to.Id, packageId: null);
+        var result = await svc.GetConnectionsFromOthers(to.Id, packageId: null, cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().ContainSingle(r => r.Party.Id == from.Id);
     }
@@ -222,7 +222,7 @@ public class RelationServiceTest
         var (svc, _, fullRepo) = MakeSut();
         SetupFullGetExtended(fullRepo, Resp<ExtRelation>());
 
-        var result = await svc.GetPackagePermissionsFromOthers(Guid.NewGuid());
+        var result = await svc.GetPackagePermissionsFromOthers(Guid.NewGuid(), cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEmpty();
     }
@@ -234,7 +234,7 @@ public class RelationServiceTest
         var relation = FullRelation(Party(), Party(), "Direct", package: null);
         SetupFullGetExtended(fullRepo, Resp(relation));
 
-        var result = await svc.GetPackagePermissionsFromOthers(Guid.NewGuid());
+        var result = await svc.GetPackagePermissionsFromOthers(Guid.NewGuid(), cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEmpty();
     }
@@ -248,7 +248,7 @@ public class RelationServiceTest
         var r2 = FullRelation(Party(), Party(), "Direct", package: pkg);
         SetupFullGetExtended(fullRepo, Resp(r1, r2));
 
-        var result = await svc.GetPackagePermissionsFromOthers(Guid.NewGuid());
+        var result = await svc.GetPackagePermissionsFromOthers(Guid.NewGuid(), cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().ContainSingle(p => p.Package.Id == pkg.Id)
             .Which.Permissions.Should().HaveCount(2);
@@ -264,7 +264,7 @@ public class RelationServiceTest
         var (svc, _, fullRepo) = MakeSut();
         SetupFullGetExtended(fullRepo, Resp<ExtRelation>());
 
-        var result = await svc.GetPackagePermissionsToOthers(Guid.NewGuid());
+        var result = await svc.GetPackagePermissionsToOthers(Guid.NewGuid(), cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEmpty();
     }
@@ -276,7 +276,7 @@ public class RelationServiceTest
         var pkg = Package();
         SetupFullGetExtended(fullRepo, Resp(FullRelation(Party(), Party(), "Direct", package: pkg)));
 
-        var result = await svc.GetPackagePermissionsToOthers(Guid.NewGuid());
+        var result = await svc.GetPackagePermissionsToOthers(Guid.NewGuid(), cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().ContainSingle(p => p.Package.Id == pkg.Id);
     }
@@ -291,7 +291,7 @@ public class RelationServiceTest
         var (svc, _, fullRepo) = MakeSut();
         SetupFullGetExtended(fullRepo, Resp<ExtRelation>());
 
-        var result = await svc.GetResourcePermissionsFromOthers(Guid.NewGuid());
+        var result = await svc.GetResourcePermissionsFromOthers(Guid.NewGuid(), cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEmpty();
     }
@@ -305,7 +305,7 @@ public class RelationServiceTest
         var relation = FullRelation(Party(), Party(), "Direct", package: null, resource: Resource());
         SetupFullGetExtended(fullRepo, Resp(relation));
 
-        var result = await svc.GetResourcePermissionsFromOthers(Guid.NewGuid());
+        var result = await svc.GetResourcePermissionsFromOthers(Guid.NewGuid(), cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEmpty();
     }
@@ -318,7 +318,7 @@ public class RelationServiceTest
         var res = Resource();
         SetupFullGetExtended(fullRepo, Resp(FullRelation(Party(), Party(), "Direct", package: pkg, resource: res)));
 
-        var result = await svc.GetResourcePermissionsFromOthers(Guid.NewGuid());
+        var result = await svc.GetResourcePermissionsFromOthers(Guid.NewGuid(), cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().ContainSingle(r => r.Resource.Id == res.Id);
     }
@@ -333,7 +333,7 @@ public class RelationServiceTest
         var (svc, _, fullRepo) = MakeSut();
         SetupFullGetExtended(fullRepo, Resp<ExtRelation>());
 
-        var result = await svc.GetResourcePermissionsToOthers(Guid.NewGuid());
+        var result = await svc.GetResourcePermissionsToOthers(Guid.NewGuid(), cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEmpty();
     }
@@ -346,7 +346,7 @@ public class RelationServiceTest
         var res = Resource();
         SetupFullGetExtended(fullRepo, Resp(FullRelation(Party(), Party(), "Direct", package: pkg, resource: res)));
 
-        var result = await svc.GetResourcePermissionsToOthers(Guid.NewGuid());
+        var result = await svc.GetResourcePermissionsToOthers(Guid.NewGuid(), cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().ContainSingle(r => r.Resource.Id == res.Id);
     }
@@ -365,7 +365,7 @@ public class RelationServiceTest
         fullRepo.Setup(r => r.GetAssignableAccessPackages(fromId, partyId, It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResult);
 
-        var result = await svc.GetAssignablePackagePermissions(partyId, fromId);
+        var result = await svc.GetAssignablePackagePermissions(partyId, fromId, cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEquivalentTo(expectedResult);
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/RequestServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/RequestServiceTests.cs
@@ -127,7 +127,7 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     public async Task CreateRequestAssignmentResource_WithValidInput_CreatesDraftRequest()
     {
         var resource = await SeedUniqueResource();
-        var result = await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Draft);
+        var result = await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Draft, TestContext.Current.CancellationToken);
 
         Assert.False(result.IsProblem);
         Assert.Equal(RequestStatus.Draft, result.Value.Status);
@@ -140,8 +140,8 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     {
         var resource = await SeedUniqueResource();
 
-        var first = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Pending)).Value;
-        var second = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Pending)).Value;
+        var first = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Pending, TestContext.Current.CancellationToken)).Value;
+        var second = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Pending, TestContext.Current.CancellationToken)).Value;
 
         Assert.Equal(first.Id, second.Id);
     }
@@ -153,9 +153,9 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     public async Task GetRequest_WithResourceRequestId_ReturnsRequestDto()
     {
         var resource = await SeedUniqueResource();
-        var created = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Draft)).Value;
+        var created = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Draft, TestContext.Current.CancellationToken)).Value;
 
-        var result = await _requestService.GetRequest(created.Id);
+        var result = await _requestService.GetRequest(created.Id, TestContext.Current.CancellationToken);
 
         Assert.Equal(created.Id, result.Value.Id);
         Assert.Equal(RequestStatus.Draft, result.Value.Status);
@@ -164,9 +164,9 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     [Fact]
     public async Task GetRequest_WithPackageRequestId_ReturnsRequestDto()
     {
-        var created = (await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft)).Value;
+        var created = (await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft, TestContext.Current.CancellationToken)).Value;
 
-        var result = await _requestService.GetRequest(created.Id);
+        var result = await _requestService.GetRequest(created.Id, TestContext.Current.CancellationToken);
 
         Assert.Equal(created.Id, result.Value.Id);
         Assert.Equal(RequestStatus.Draft, result.Value.Status);
@@ -175,7 +175,7 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     [Fact]
     public async Task GetRequest_WithNonExistingId_ReturnsNull()
     {
-        var result = await _requestService.GetRequest(Guid.CreateVersion7());
+        var result = await _requestService.GetRequest(Guid.CreateVersion7(), TestContext.Current.CancellationToken);
 
         Assert.Null(result.Value);
     }
@@ -187,9 +187,9 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     public async Task GetSentRequests_ReturnsOnlyMatchingRequests()
     {
         var resource = await SeedUniqueResource();
-        var created = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Pending)).Value;
+        var created = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Pending, TestContext.Current.CancellationToken)).Value;
 
-        var results = await _requestService.GetSentRequests(partyId: PersonTo.Id, toId: OrgFrom.Id, status: null, type: null, ct: default);
+        var results = await _requestService.GetSentRequests(partyId: PersonTo.Id, toId: OrgFrom.Id, status: null, type: null, ct: TestContext.Current.CancellationToken);
 
         Assert.NotEmpty(results.Value);
         Assert.All(results.Value, r => Assert.Equal(OrgFrom.Id, r.To.Id));
@@ -199,9 +199,9 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     public async Task GetReceivedRequests_ReturnsOnlyMatchingRequests()
     {
         var resource = await SeedUniqueResource();
-        var created = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Pending)).Value;
+        var created = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Pending, TestContext.Current.CancellationToken)).Value;
 
-        var results = await _requestService.GetReceivedRequests(partyId: OrgFrom.Id, fromId: PersonTo.Id, status: null, type: null, ct: default);
+        var results = await _requestService.GetReceivedRequests(partyId: OrgFrom.Id, fromId: PersonTo.Id, status: null, type: null, ct: TestContext.Current.CancellationToken);
 
         Assert.NotEmpty(results.Value);
         Assert.All(results.Value, r => Assert.Equal(PersonTo.Id, r.From.Id));
@@ -214,7 +214,7 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     [Fact]
     public async Task CreateRequestAssignmentPackage_WithValidInput_CreatesDraftRequest()
     {
-        var result = await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft);
+        var result = await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft, TestContext.Current.CancellationToken);
 
         Assert.False(result.IsProblem);
         Assert.Equal(RequestStatus.Draft, result.Value.Status);
@@ -224,8 +224,8 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     [Fact]
     public async Task CreateRequestAssignmentPackage_CalledTwice_ReturnsExistingPendingRequest()
     {
-        var first = (await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft)).Value;
-        var second = (await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft)).Value;
+        var first = (await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft, TestContext.Current.CancellationToken)).Value;
+        var second = (await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft, TestContext.Current.CancellationToken)).Value;
 
         Assert.Equal(first.Id, second.Id);
     }
@@ -237,7 +237,7 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     public async Task ResourceRequest_EnduserCreate_CreatesPendingRequest()
     {
         var resource = await SeedUniqueResource();
-        var result = await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Pending);
+        var result = await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Pending, TestContext.Current.CancellationToken);
 
         Assert.False(result.IsProblem);
         Assert.Equal(RequestStatus.Pending, result.Value.Status);
@@ -249,25 +249,25 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
         var resource = await SeedUniqueResource();
 
         // 1. ServiceOwner creates request — status should be Draft
-        var created = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Draft)).Value;
+        var created = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Draft, TestContext.Current.CancellationToken)).Value;
 
         Assert.Equal(RequestStatus.Draft, created.Status);
 
         // 2. Enduser sets status to Pending (acknowledges the request)
-        var pending = (await _requestService.UpdateRequest(PersonTo.Id, created.Id, RequestStatus.Pending)).Value;
+        var pending = (await _requestService.UpdateRequest(PersonTo.Id, created.Id, RequestStatus.Pending, TestContext.Current.CancellationToken)).Value;
         Assert.Equal(RequestStatus.Pending, pending.Status);
 
         // 3. ServiceOwner checks that status has changed from Draft
-        var afterPending = await _requestService.GetRequest(created.Id);
+        var afterPending = await _requestService.GetRequest(created.Id, TestContext.Current.CancellationToken);
         Assert.NotEqual(RequestStatus.Draft, afterPending.Value.Status);
         Assert.Equal(RequestStatus.Pending, afterPending.Value.Status);
 
         // 4. Enduser fetches the request
-        var fetched = await _requestService.GetRequest(created.Id);
+        var fetched = await _requestService.GetRequest(created.Id, TestContext.Current.CancellationToken);
         Assert.Equal(created.Id, fetched.Value.Id);
 
         // 5. Enduser accepts
-        var accepted = (await _requestService.UpdateRequest(OrgFrom.Id, created.Id, RequestStatus.Approved)).Value;
+        var accepted = (await _requestService.UpdateRequest(OrgFrom.Id, created.Id, RequestStatus.Approved, TestContext.Current.CancellationToken)).Value;
         Assert.Equal(RequestStatus.Approved, accepted.Status);
     }
 
@@ -275,25 +275,25 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
     public async Task PackageRequest_FullLifecycle_DraftToPendingToAccepted()
     {
         // 1. ServiceOwner creates request — status should be Draft
-        var created = (await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft)).Value;
+        var created = (await _requestService.CreatePackageRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, PackageConstants.Agriculture.Id, RequestStatus.Draft, TestContext.Current.CancellationToken)).Value;
         Assert.Equal(RequestStatus.Draft, created.Status);
 
         // 2. Enduser sets status to Pending (acknowledges the request)
-        var pendingResult = await _requestService.UpdateRequest(PersonTo.Id, created.Id, RequestStatus.Pending);
+        var pendingResult = await _requestService.UpdateRequest(PersonTo.Id, created.Id, RequestStatus.Pending, TestContext.Current.CancellationToken);
         Assert.False(pendingResult.IsProblem);
         Assert.Equal(RequestStatus.Pending, pendingResult.Value.Status);
 
         // 3. ServiceOwner checks that status has changed from Draft
-        var afterPending = await _requestService.GetRequest(created.Id);
+        var afterPending = await _requestService.GetRequest(created.Id, TestContext.Current.CancellationToken);
         Assert.NotEqual(RequestStatus.Draft, afterPending.Value.Status);
         Assert.Equal(RequestStatus.Pending, afterPending.Value.Status);
 
         // 4. Enduser fetches the request
-        var fetched = await _requestService.GetRequest(created.Id);
+        var fetched = await _requestService.GetRequest(created.Id, TestContext.Current.CancellationToken);
         Assert.Equal(created.Id, fetched.Value.Id);
 
         // 5. Enduser accepts
-        var accepted = (await _requestService.UpdateRequest(OrgFrom.Id, created.Id, RequestStatus.Approved)).Value;
+        var accepted = (await _requestService.UpdateRequest(OrgFrom.Id, created.Id, RequestStatus.Approved, TestContext.Current.CancellationToken)).Value;
         Assert.Equal(RequestStatus.Approved, accepted.Status);
     }
 
@@ -303,24 +303,24 @@ public class RequestServiceTests : IClassFixture<PostgresFixture>
         var resource = await SeedUniqueResource();
 
         // 1. ServiceOwner creates request — status should be Draft
-        var created = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Draft)).Value;
+        var created = (await _requestService.CreateResourceRequest(OrgFrom.Id, PersonTo.Id, PersonTo.Id, RoleConstants.Rightholder.Id, resource.Id, RequestStatus.Draft, TestContext.Current.CancellationToken)).Value;
         Assert.Equal(RequestStatus.Draft, created.Status);
 
         // 2. Enduser sets status to Pending (acknowledges the request)
-        var pending = (await _requestService.UpdateRequest(PersonTo.Id, created.Id, RequestStatus.Pending)).Value;
+        var pending = (await _requestService.UpdateRequest(PersonTo.Id, created.Id, RequestStatus.Pending, TestContext.Current.CancellationToken)).Value;
         Assert.Equal(RequestStatus.Pending, pending.Status);
 
         // 3. ServiceOwner checks that status has changed from Draft
-        var afterPending = await _requestService.GetRequest(created.Id);
+        var afterPending = await _requestService.GetRequest(created.Id, TestContext.Current.CancellationToken);
         Assert.NotEqual(RequestStatus.Draft, afterPending.Value.Status);
         Assert.Equal(RequestStatus.Pending, afterPending.Value.Status);
 
         // 4. Enduser fetches the request
-        var fetched = await _requestService.GetRequest(created.Id);
+        var fetched = await _requestService.GetRequest(created.Id, TestContext.Current.CancellationToken);
         Assert.Equal(created.Id, fetched.Value.Id);
 
         // 5. Enduser rejects
-        var rejected = (await _requestService.UpdateRequest(OrgFrom.Id, created.Id, RequestStatus.Rejected)).Value;
+        var rejected = (await _requestService.UpdateRequest(OrgFrom.Id, created.Id, RequestStatus.Rejected, TestContext.Current.CancellationToken)).Value;
         Assert.Equal(RequestStatus.Rejected, rejected.Status);
     }
     #endregion

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/TranslationServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/TranslationServiceTests.cs
@@ -466,11 +466,11 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
         };
 
         // Act
-        await _translationService.UpsertTranslationAsync(translationEntry, AuditDefaults.StaticDataIngest, AuditDefaults.StaticDataIngest);
+        await _translationService.UpsertTranslationAsync(translationEntry, AuditDefaults.StaticDataIngest, AuditDefaults.StaticDataIngest, TestContext.Current.CancellationToken);
 
         // Assert
         var saved = await _db.TranslationEntries
-            .FirstOrDefaultAsync(t => t.Id == customId && t.LanguageCode == "eng" && t.FieldName == "Name");
+            .FirstOrDefaultAsync(t => t.Id == customId && t.LanguageCode == "eng" && t.FieldName == "Name", cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(saved);
         Assert.Equal("Test Translation", saved.Value);
     }
@@ -489,17 +489,17 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             Value = "Original"
         };
 
-        await _translationService.UpsertTranslationAsync(translationEntry, AuditDefaults.StaticDataIngest, AuditDefaults.StaticDataIngest);
+        await _translationService.UpsertTranslationAsync(translationEntry, AuditDefaults.StaticDataIngest, AuditDefaults.StaticDataIngest, TestContext.Current.CancellationToken);
 
         // Update the value
         translationEntry.Value = "Updated";
 
         // Act
-        await _translationService.UpsertTranslationAsync(translationEntry, AuditDefaults.StaticDataIngest, AuditDefaults.StaticDataIngest);
+        await _translationService.UpsertTranslationAsync(translationEntry, AuditDefaults.StaticDataIngest, AuditDefaults.StaticDataIngest, TestContext.Current.CancellationToken);
 
         // Assert
         var saved = await _db.TranslationEntries
-            .FirstOrDefaultAsync(t => t.Id == customId && t.LanguageCode == "eng" && t.FieldName == "Name");
+            .FirstOrDefaultAsync(t => t.Id == customId && t.LanguageCode == "eng" && t.FieldName == "Name", cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(saved);
         Assert.Equal("Updated", saved.Value);
     }
@@ -517,7 +517,7 @@ public class TranslationServiceTests : IClassFixture<PostgresFixture>
             FieldName = "Name",
             Value = "Cached Translation"
         };
-        await _translationService.UpsertTranslationAsync(translationEntry, AuditDefaults.StaticDataIngest, AuditDefaults.StaticDataIngest);
+        await _translationService.UpsertTranslationAsync(translationEntry, AuditDefaults.StaticDataIngest, AuditDefaults.StaticDataIngest, TestContext.Current.CancellationToken);
 
         var role = new RoleDto
         {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/InternalConnectionsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/InternalConnectionsControllerTest.cs
@@ -39,7 +39,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.Get(Party, Party, To, true, true, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<IEnumerable<ConnectionDto>>([]));
 
-        var result = await CreateSut(svc.Object).GetConnections(Connection, new PagingInput());
+        var result = await CreateSut(svc.Object).GetConnections(Connection, new PagingInput(), TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -51,7 +51,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.Get(Party, Party, To, true, true, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetConnections(Connection, new PagingInput());
+        var result = await CreateSut(svc.Object).GetConnections(Connection, new PagingInput(), TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -67,7 +67,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.AddRightholder(Party, To, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<AssignmentDto>(new AssignmentDto()));
 
-        var result = await CreateSut(svc.Object).AddAssignment(Connection);
+        var result = await CreateSut(svc.Object).AddAssignment(Connection, TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -79,7 +79,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.AddRightholder(Party, To, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).AddAssignment(Connection);
+        var result = await CreateSut(svc.Object).AddAssignment(Connection, TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -95,7 +95,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.RemoveAssignment(Party, To, false, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync((ValidationProblemInstance)null);
 
-        var result = await CreateSut(svc.Object).RemoveAssignment(Connection);
+        var result = await CreateSut(svc.Object).RemoveAssignment(Connection, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -107,7 +107,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.RemoveAssignment(Party, To, false, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).RemoveAssignment(Connection);
+        var result = await CreateSut(svc.Object).RemoveAssignment(Connection, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<NoContentResult>(result);
     }
@@ -123,7 +123,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.GetPackages(Party, Party, To, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<IEnumerable<PackagePermissionDto>>([]));
 
-        var result = await CreateSut(svc.Object).GetPackages(Connection, new PagingInput());
+        var result = await CreateSut(svc.Object).GetPackages(Connection, new PagingInput(), TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -135,7 +135,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.GetPackages(Party, Party, To, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetPackages(Connection, new PagingInput());
+        var result = await CreateSut(svc.Object).GetPackages(Connection, new PagingInput(), TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -152,7 +152,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.AddPackage(Party, To, packageId, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<AssignmentPackageDto>(new AssignmentPackageDto()));
 
-        var result = await CreateSut(svc.Object).AddPackages(Connection, packageId, null);
+        var result = await CreateSut(svc.Object).AddPackages(Connection, packageId, null, TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -164,7 +164,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.AddPackage(Party, To, "urn:some:package", It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<AssignmentPackageDto>(new AssignmentPackageDto()));
 
-        var result = await CreateSut(svc.Object).AddPackages(Connection, null, "urn:some:package");
+        var result = await CreateSut(svc.Object).AddPackages(Connection, null, "urn:some:package", TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -176,7 +176,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.AddPackage(Party, To, "urn:some:package", It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).AddPackages(Connection, null, "urn:some:package");
+        var result = await CreateSut(svc.Object).AddPackages(Connection, null, "urn:some:package", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -193,7 +193,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.RemovePackage(Party, To, packageId, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync((ValidationProblemInstance)null);
 
-        var result = await CreateSut(svc.Object).RemovePackages(Connection, packageId, null);
+        var result = await CreateSut(svc.Object).RemovePackages(Connection, packageId, null, TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -205,7 +205,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.RemovePackage(Party, To, "urn:some:package", It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync((ValidationProblemInstance)null);
 
-        var result = await CreateSut(svc.Object).RemovePackages(Connection, null, "urn:some:package");
+        var result = await CreateSut(svc.Object).RemovePackages(Connection, null, "urn:some:package", TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -217,7 +217,7 @@ public class InternalConnectionsControllerTest
         svc.Setup(s => s.RemovePackage(Party, To, "urn:some:package", It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).RemovePackages(Connection, null, "urn:some:package");
+        var result = await CreateSut(svc.Object).RemovePackages(Connection, null, "urn:some:package", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<NoContentResult>(result);
     }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/PartyControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/PartyControllerTest.cs
@@ -50,7 +50,7 @@ public class PartyControllerTest
     [Fact]
     public async Task AddParty_NullToken_ReturnsUnauthorized()
     {
-        var result = await CreateSut(new Mock<IPartyService>().Object).AddParty(SampleParty, null);
+        var result = await CreateSut(new Mock<IPartyService>().Object).AddParty(SampleParty, null, TestContext.Current.CancellationToken);
 
         Assert.IsType<UnauthorizedObjectResult>(result.Result);
     }
@@ -60,7 +60,7 @@ public class PartyControllerTest
     {
         var token = MakeToken(appClaimValue: null);
 
-        var result = await CreateSut(new Mock<IPartyService>().Object).AddParty(SampleParty, token);
+        var result = await CreateSut(new Mock<IPartyService>().Object).AddParty(SampleParty, token, TestContext.Current.CancellationToken);
 
         Assert.IsType<UnauthorizedObjectResult>(result.Result);
     }
@@ -70,7 +70,7 @@ public class PartyControllerTest
     {
         var token = MakeToken("not-authentication");
 
-        var result = await CreateSut(new Mock<IPartyService>().Object).AddParty(SampleParty, token);
+        var result = await CreateSut(new Mock<IPartyService>().Object).AddParty(SampleParty, token, TestContext.Current.CancellationToken);
 
         Assert.IsType<UnauthorizedObjectResult>(result.Result);
     }
@@ -83,7 +83,7 @@ public class PartyControllerTest
         svc.Setup(s => s.AddParty(SampleParty, It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<AddPartyResultDto>(MakeValidationProblem()));
 
-        var result = await CreateSut(svc.Object).AddParty(SampleParty, token);
+        var result = await CreateSut(svc.Object).AddParty(SampleParty, token, TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result.Result);
         Assert.IsNotType<CreatedAtActionResult>(result.Result);
@@ -98,7 +98,7 @@ public class PartyControllerTest
         svc.Setup(s => s.AddParty(SampleParty, It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<AddPartyResultDto>(dto));
 
-        var result = await CreateSut(svc.Object).AddParty(SampleParty, token);
+        var result = await CreateSut(svc.Object).AddParty(SampleParty, token, TestContext.Current.CancellationToken);
 
         Assert.IsType<CreatedAtActionResult>(result.Result);
     }
@@ -112,7 +112,7 @@ public class PartyControllerTest
         svc.Setup(s => s.AddParty(SampleParty, It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<AddPartyResultDto>(dto));
 
-        var result = await CreateSut(svc.Object).AddParty(SampleParty, token);
+        var result = await CreateSut(svc.Object).AddParty(SampleParty, token, TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
     }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
@@ -44,7 +44,7 @@ public class SystemUserClientDelegationControllerTest
     [Fact]
     public async Task GetClients_InvalidRole_ReturnsBadRequest()
     {
-        var result = await CreateSut().GetClients(Party, roles: ["not-a-valid-role"]);
+        var result = await CreateSut().GetClients(Party, roles: ["not-a-valid-role"], cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result.Result);
     }
@@ -57,7 +57,7 @@ public class SystemUserClientDelegationControllerTest
                      .ReturnsAsync([]);
 
         var result = await CreateSut(assignmentSvc: assignmentSvc.Object)
-            .GetClients(Party, roles: [RoleConstants.Accountant.Entity.Code]);
+            .GetClients(Party, roles: [RoleConstants.Accountant.Entity.Code], cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
     }
@@ -69,7 +69,7 @@ public class SystemUserClientDelegationControllerTest
         assignmentSvc.Setup(s => s.GetClients(Party, It.IsAny<string[]>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
                      .ReturnsAsync([]);
 
-        var result = await CreateSut(assignmentSvc: assignmentSvc.Object).GetClients(Party);
+        var result = await CreateSut(assignmentSvc: assignmentSvc.Object).GetClients(Party, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
     }
@@ -86,7 +86,7 @@ public class SystemUserClientDelegationControllerTest
                      .ReturnsAsync([]);
 
         var result = await CreateSut(connectionSvc: connectionSvc.Object)
-            .GetClientDelegations(Party, SystemUser, Client);
+            .GetClientDelegations(Party, SystemUser, Client, TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
     }
@@ -103,7 +103,7 @@ public class SystemUserClientDelegationControllerTest
                      .ReturnsAsync([]);
 
         var result = await CreateSut(delegationSvc: delegationSvc.Object)
-            .PostClientDelegation(Party, new CreateSystemDelegationRequestDto());
+            .PostClientDelegation(Party, new CreateSystemDelegationRequestDto(), TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result.Result);
     }
@@ -120,7 +120,7 @@ public class SystemUserClientDelegationControllerTest
                      .Returns(Task.FromResult<Delegation>(null));
 
         var result = await CreateSut(delegationSvc: delegationSvc.Object)
-            .DeleteDelegation(Party, DelegationId);
+            .DeleteDelegation(Party, DelegationId, TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result);
     }
@@ -134,7 +134,7 @@ public class SystemUserClientDelegationControllerTest
                      .Returns(Task.FromResult(delegation));
 
         var result = await CreateSut(delegationSvc: delegationSvc.Object)
-            .DeleteDelegation(Party, DelegationId);
+            .DeleteDelegation(Party, DelegationId, TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result);
     }
@@ -154,7 +154,7 @@ public class SystemUserClientDelegationControllerTest
                      .Returns(Task.FromResult(assignment));
 
         var result = await CreateSut(assignmentSvc: assignmentSvc.Object, delegationSvc: delegationSvc.Object)
-            .DeleteDelegation(Party, DelegationId);
+            .DeleteDelegation(Party, DelegationId, TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result);
     }
@@ -176,7 +176,7 @@ public class SystemUserClientDelegationControllerTest
                      .Returns(Task.FromResult(assignment));
 
         var result = await CreateSut(assignmentSvc: assignmentSvc.Object, delegationSvc: delegationSvc.Object)
-            .DeleteDelegation(Party, DelegationId);
+            .DeleteDelegation(Party, DelegationId, TestContext.Current.CancellationToken);
 
         Assert.IsType<OkResult>(result);
     }
@@ -193,7 +193,7 @@ public class SystemUserClientDelegationControllerTest
                      .Returns(Task.FromResult<Assignment>(null));
 
         var result = await CreateSut(assignmentSvc: assignmentSvc.Object)
-            .DeleteAssignment(Party, AssignmentId);
+            .DeleteAssignment(Party, AssignmentId, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result);
     }
@@ -207,7 +207,7 @@ public class SystemUserClientDelegationControllerTest
                      .Returns(Task.FromResult(assignment));
 
         var result = await CreateSut(assignmentSvc: assignmentSvc.Object)
-            .DeleteAssignment(Party, AssignmentId);
+            .DeleteAssignment(Party, AssignmentId, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequestObjectResult>(result);
     }
@@ -226,7 +226,7 @@ public class SystemUserClientDelegationControllerTest
                      .Returns(Task.FromResult<Assignment>(assignment));
 
         var result = await CreateSut(assignmentSvc: assignmentSvc.Object)
-            .DeleteAssignment(Party, AssignmentId);
+            .DeleteAssignment(Party, AssignmentId, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<ObjectResult>(result);
     }
@@ -247,7 +247,7 @@ public class SystemUserClientDelegationControllerTest
                      .Returns(Task.FromResult<ProblemInstance>(null));
 
         var result = await CreateSut(assignmentSvc: assignmentSvc.Object)
-            .DeleteAssignment(Party, AssignmentId);
+            .DeleteAssignment(Party, AssignmentId, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkResult>(result);
     }
@@ -268,7 +268,7 @@ public class SystemUserClientDelegationControllerTest
                      .Returns(Task.FromResult<ProblemInstance>(MakeProblem()));
 
         var result = await CreateSut(assignmentSvc: assignmentSvc.Object)
-            .DeleteAssignment(Party, AssignmentId);
+            .DeleteAssignment(Party, AssignmentId, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<ObjectResult>(result);
     }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/MaskinportenControllersTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/MaskinportenControllersTest.cs
@@ -43,7 +43,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetConsumers(Party, null, It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<IEnumerable<ConnectionDto>>([]));
 
-        var result = await CreateSut(svc.Object).GetConsumers(Party);
+        var result = await CreateSut(svc.Object).GetConsumers(Party, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -55,7 +55,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetConsumers(Party, null, It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetConsumers(Party);
+        var result = await CreateSut(svc.Object).GetConsumers(Party, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -67,7 +67,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetEntity("123456789", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetConsumers(Party, consumer: "123456789");
+        var result = await CreateSut(svc.Object).GetConsumers(Party, consumer: "123456789", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -81,7 +81,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetConsumers(Party, EntityId, It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<IEnumerable<ConnectionDto>>([]));
 
-        var result = await CreateSut(svc.Object).GetConsumers(Party, consumer: "123456789");
+        var result = await CreateSut(svc.Object).GetConsumers(Party, consumer: "123456789", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -97,7 +97,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetEntity("org1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).RemoveConsumer(Party, "org1");
+        var result = await CreateSut(svc.Object).RemoveConsumer(Party, "org1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<NoContentResult>(result);
     }
@@ -111,7 +111,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.RemoveSupplier(EntityId, Party, false, It.IsAny<CancellationToken>()))
            .ReturnsAsync((ValidationProblemInstance)null);
 
-        var result = await CreateSut(svc.Object).RemoveConsumer(Party, "org1");
+        var result = await CreateSut(svc.Object).RemoveConsumer(Party, "org1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -125,7 +125,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.RemoveSupplier(EntityId, Party, false, It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).RemoveConsumer(Party, "org1");
+        var result = await CreateSut(svc.Object).RemoveConsumer(Party, "org1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<NoContentResult>(result);
     }
@@ -141,7 +141,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetConsumerResources(Party, null, null, It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<IEnumerable<ResourcePermissionDto>>([]));
 
-        var result = await CreateSut(svc.Object).GetResources(Party);
+        var result = await CreateSut(svc.Object).GetResources(Party, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -153,7 +153,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetConsumerResources(Party, null, null, It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetResources(Party);
+        var result = await CreateSut(svc.Object).GetResources(Party, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -165,7 +165,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetEntity("org1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetResources(Party, consumer: "org1");
+        var result = await CreateSut(svc.Object).GetResources(Party, consumer: "org1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -177,7 +177,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetResourceByRefId("res1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetResources(Party, resource: "res1");
+        var result = await CreateSut(svc.Object).GetResources(Party, resource: "res1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -193,7 +193,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetConsumerResources(Party, EntityId, ResourceId, It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<IEnumerable<ResourcePermissionDto>>([]));
 
-        var result = await CreateSut(svc.Object).GetResources(Party, consumer: "org1", resource: "res1");
+        var result = await CreateSut(svc.Object).GetResources(Party, consumer: "org1", resource: "res1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -209,7 +209,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.GetEntity("org1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1");
+        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<NoContentResult>(result);
     }
@@ -223,7 +223,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.RemoveResource(EntityId, Party, "res1", It.IsAny<CancellationToken>()))
            .ReturnsAsync((ValidationProblemInstance)null);
 
-        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1");
+        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1", TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -237,7 +237,7 @@ public class MaskinportenConsumersControllerTest
         svc.Setup(s => s.RemoveResource(EntityId, Party, "res1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1");
+        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<NoContentResult>(result);
     }
@@ -287,7 +287,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetEntity("org1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).AddSupplier(Party, "org1");
+        var result = await CreateSut(svc.Object).AddSupplier(Party, "org1", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -301,7 +301,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.AddSupplier(Party, EntityId, It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<AssignmentDto>(new AssignmentDto()));
 
-        var result = await CreateSut(svc.Object).AddSupplier(Party, "org1");
+        var result = await CreateSut(svc.Object).AddSupplier(Party, "org1", TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -315,7 +315,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.AddSupplier(Party, EntityId, It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).AddSupplier(Party, "org1");
+        var result = await CreateSut(svc.Object).AddSupplier(Party, "org1", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -331,7 +331,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetSuppliers(Party, null, It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<IEnumerable<ConnectionDto>>([]));
 
-        var result = await CreateSut(svc.Object).GetSuppliers(Party);
+        var result = await CreateSut(svc.Object).GetSuppliers(Party, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -343,7 +343,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetSuppliers(Party, null, It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetSuppliers(Party);
+        var result = await CreateSut(svc.Object).GetSuppliers(Party, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -355,7 +355,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetEntity("org1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetSuppliers(Party, supplier: "org1");
+        var result = await CreateSut(svc.Object).GetSuppliers(Party, supplier: "org1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -371,7 +371,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetEntity("org1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).RemoveSupplier(Party, "org1");
+        var result = await CreateSut(svc.Object).RemoveSupplier(Party, "org1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<NoContentResult>(result);
     }
@@ -385,7 +385,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.RemoveSupplier(Party, EntityId, false, It.IsAny<CancellationToken>()))
            .ReturnsAsync((ValidationProblemInstance)null);
 
-        var result = await CreateSut(svc.Object).RemoveSupplier(Party, "org1");
+        var result = await CreateSut(svc.Object).RemoveSupplier(Party, "org1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -399,7 +399,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.RemoveSupplier(Party, EntityId, false, It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).RemoveSupplier(Party, "org1");
+        var result = await CreateSut(svc.Object).RemoveSupplier(Party, "org1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<NoContentResult>(result);
     }
@@ -415,7 +415,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.ResourceDelegationCheck(UserUuid, Party, "res1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<ResourceCheckDto>(new ResourceCheckDto { Resource = new ResourceDto(), Rights = [] }));
 
-        var result = await CreateSutWithClaim(svc.Object, UserUuid).DelegationCheck(Party, "res1");
+        var result = await CreateSutWithClaim(svc.Object, UserUuid).DelegationCheck(Party, "res1", TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -427,7 +427,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.ResourceDelegationCheck(UserUuid, Party, "res1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSutWithClaim(svc.Object, UserUuid).DelegationCheck(Party, "res1");
+        var result = await CreateSutWithClaim(svc.Object, UserUuid).DelegationCheck(Party, "res1", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -443,7 +443,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetEntity("org1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).AddResource(Party, "org1", "res1");
+        var result = await CreateSut(svc.Object).AddResource(Party, "org1", "res1", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -457,7 +457,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.AddResource(Party, EntityId, "res1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<bool>(true));
 
-        var result = await CreateSut(svc.Object).AddResource(Party, "org1", "res1");
+        var result = await CreateSut(svc.Object).AddResource(Party, "org1", "res1", TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -471,7 +471,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.AddResource(Party, EntityId, "res1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).AddResource(Party, "org1", "res1");
+        var result = await CreateSut(svc.Object).AddResource(Party, "org1", "res1", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -487,7 +487,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetSupplierResources(Party, null, null, It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<IEnumerable<ResourcePermissionDto>>([]));
 
-        var result = await CreateSut(svc.Object).GetResources(Party);
+        var result = await CreateSut(svc.Object).GetResources(Party, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsType<OkObjectResult>(result);
     }
@@ -499,7 +499,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetSupplierResources(Party, null, null, It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetResources(Party);
+        var result = await CreateSut(svc.Object).GetResources(Party, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -511,7 +511,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetEntity("org1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetResources(Party, supplier: "org1");
+        var result = await CreateSut(svc.Object).GetResources(Party, supplier: "org1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -523,7 +523,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetResourceByRefId("res1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).GetResources(Party, resource: "res1");
+        var result = await CreateSut(svc.Object).GetResources(Party, resource: "res1", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.IsNotType<OkObjectResult>(result);
     }
@@ -539,7 +539,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.GetEntity("org1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1");
+        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<NoContentResult>(result);
     }
@@ -553,7 +553,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.RemoveResource(Party, EntityId, "res1", It.IsAny<CancellationToken>()))
            .ReturnsAsync((ValidationProblemInstance)null);
 
-        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1");
+        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1", TestContext.Current.CancellationToken);
 
         Assert.IsType<NoContentResult>(result);
     }
@@ -567,7 +567,7 @@ public class MaskinportenSuppliersControllerTest
         svc.Setup(s => s.RemoveResource(Party, EntityId, "res1", It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
-        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1");
+        var result = await CreateSut(svc.Object).RemoveResource(Party, "org1", "res1", TestContext.Current.CancellationToken);
 
         Assert.IsNotType<NoContentResult>(result);
     }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/RightsInternalDelegateAndRevokeInstanceDelegation.RevokeInstance.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/RightsInternalDelegateAndRevokeInstanceDelegation.RevokeInstance.cs
@@ -104,7 +104,7 @@ public class RightsInternalDelegateAndRevokeInstanceDelegation : IClassFixture<A
         var client = CreateClient();
 
         // Create the delegation first
-        var delegationResponse = await client.PostAsync(RouteDelegation, delegationContent);
+        var delegationResponse = await client.PostAsync(RouteDelegation, delegationContent, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.Created, delegationResponse.StatusCode);
 
         // Verify

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AccessListAuthorizationControllerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AccessListAuthorizationControllerTest.cs
@@ -29,7 +29,7 @@ public class AccessListAuthorizationControllerTest : IClassFixture<Authorization
     public async Task AccessList_Authorization_Unauthorized_MissingPlatformAccessToken()
     {
         // Act
-        HttpResponseMessage response = await _client.SendAsync(GetPostRequestMessage("Permit_WithoutActionFilter"));
+        HttpResponseMessage response = await _client.SendAsync(GetPostRequestMessage("Permit_WithoutActionFilter"), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -45,8 +45,8 @@ public class AccessListAuthorizationControllerTest : IClassFixture<Authorization
         AccessListAuthorizationResponse expected = GetExpectedResponse("Permit_WithoutActionFilter");
 
         // Act
-        HttpResponseMessage response = await _client.SendAsync(GetPostRequestMessage(testCase, PrincipalUtil.GetAccessToken("access-management", "platform")));
-        string responseContent = await response.Content.ReadAsStringAsync();
+        HttpResponseMessage response = await _client.SendAsync(GetPostRequestMessage(testCase, PrincipalUtil.GetAccessToken("access-management", "platform")), TestContext.Current.CancellationToken);
+        string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AccessListAuthorizationTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AccessListAuthorizationTest.cs
@@ -38,7 +38,7 @@ public class AccessListAuthorizationTest
             .ReturnsAsync((IEnumerable<AccessListResourceMembershipWithActionFilterDto>)null);
 
         // Act
-        var result = await _sut.Authorize(request);
+        var result = await _sut.Authorize(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsSuccess);
@@ -55,7 +55,7 @@ public class AccessListAuthorizationTest
             .ReturnsAsync(Array.Empty<AccessListResourceMembershipWithActionFilterDto>());
 
         // Act
-        var result = await _sut.Authorize(request);
+        var result = await _sut.Authorize(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsSuccess);
@@ -73,7 +73,7 @@ public class AccessListAuthorizationTest
             .ReturnsAsync(new[] { membership });
 
         // Act
-        var result = await _sut.Authorize(request);
+        var result = await _sut.Authorize(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsSuccess);
@@ -91,7 +91,7 @@ public class AccessListAuthorizationTest
             .ReturnsAsync(new[] { membership });
 
         // Act
-        var result = await _sut.Authorize(request);
+        var result = await _sut.Authorize(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsSuccess);
@@ -109,7 +109,7 @@ public class AccessListAuthorizationTest
             .ReturnsAsync(new[] { membership });
 
         // Act
-        var result = await _sut.Authorize(request);
+        var result = await _sut.Authorize(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result.IsSuccess);

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ContextHandlerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ContextHandlerTest.cs
@@ -70,7 +70,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(enrichedRequest);
@@ -99,7 +99,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(enrichedRequest);
@@ -128,7 +128,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(enrichedRequest);
@@ -157,7 +157,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(enrichedRequest);
@@ -186,7 +186,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(enrichedRequest);
@@ -215,7 +215,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.NotNull(enrichedRequest);

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ContextHandlerUnitTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ContextHandlerUnitTest.cs
@@ -318,7 +318,7 @@ public class ContextHandlerUnitTest : IDisposable
         var resourceAttrs = new XacmlResourceAttributes { OrganizationNumber = "910514318" };
         var contextAttrs = CreateResourceAttributes();
 
-        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, false);
+        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, false, TestContext.Current.CancellationToken);
 
         Assert.Equal("50001337", resourceAttrs.ResourcePartyValue);
         Assert.Contains(contextAttrs.Attributes, a =>
@@ -337,7 +337,7 @@ public class ContextHandlerUnitTest : IDisposable
         var resourceAttrs = new XacmlResourceAttributes { PersonId = "01017012345" };
         var contextAttrs = CreateResourceAttributes();
 
-        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, true);
+        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, true, TestContext.Current.CancellationToken);
 
         Assert.Equal("50001338", resourceAttrs.ResourcePartyValue);
     }
@@ -349,7 +349,7 @@ public class ContextHandlerUnitTest : IDisposable
         var contextAttrs = CreateResourceAttributes();
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
-            _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, false));
+            _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, false, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -364,7 +364,7 @@ public class ContextHandlerUnitTest : IDisposable
         var resourceAttrs = new XacmlResourceAttributes { PartyUuid = uuid };
         var contextAttrs = CreateResourceAttributes();
 
-        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, false);
+        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, false, TestContext.Current.CancellationToken);
 
         Assert.Equal("50001339", resourceAttrs.ResourcePartyValue);
     }
@@ -375,7 +375,7 @@ public class ContextHandlerUnitTest : IDisposable
         var resourceAttrs = new XacmlResourceAttributes { ResourcePartyValue = "50001337" };
         var contextAttrs = CreateResourceAttributes();
 
-        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, false);
+        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, false, TestContext.Current.CancellationToken);
 
         _registerServiceMock.Verify(r => r.PartyLookup(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -407,13 +407,13 @@ public class ContextHandlerUnitTest : IDisposable
         };
         _profileMock.Setup(p => p.GetUserProfile(42, It.IsAny<CancellationToken>())).ReturnsAsync(profile);
 
-        var result = await _sut.TestGetUserProfileByUserId(42);
+        var result = await _sut.TestGetUserProfileByUserId(42, TestContext.Current.CancellationToken);
 
         Assert.Equal(42, result.UserId);
         _profileMock.Verify(p => p.GetUserProfile(42, It.IsAny<CancellationToken>()), Times.Once);
 
         // Second call should come from cache
-        var cached = await _sut.TestGetUserProfileByUserId(42);
+        var cached = await _sut.TestGetUserProfileByUserId(42, TestContext.Current.CancellationToken);
         Assert.Same(result, cached);
         _profileMock.Verify(p => p.GetUserProfile(42, It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -428,12 +428,12 @@ public class ContextHandlerUnitTest : IDisposable
         };
         _profileMock.Setup(p => p.GetUserProfileByPersonId("01017012345", It.IsAny<CancellationToken>())).ReturnsAsync(profile);
 
-        var result = await _sut.TestGetUserProfileByPersonId("01017012345");
+        var result = await _sut.TestGetUserProfileByPersonId("01017012345", TestContext.Current.CancellationToken);
 
         Assert.Equal(42, result.UserId);
 
         // Second call should come from cache
-        var cached = await _sut.TestGetUserProfileByPersonId("01017012345");
+        var cached = await _sut.TestGetUserProfileByPersonId("01017012345", TestContext.Current.CancellationToken);
         Assert.Same(result, cached);
         _profileMock.Verify(p => p.GetUserProfileByPersonId("01017012345", It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -443,8 +443,8 @@ public class ContextHandlerUnitTest : IDisposable
     {
         _partiesMock.Setup(p => p.GetKeyRoleParties(1, It.IsAny<CancellationToken>())).ReturnsAsync(new List<int> { 100, 200 });
 
-        var first = await _sut.TestGetKeyRolePartyIds(1);
-        var second = await _sut.TestGetKeyRolePartyIds(1);
+        var first = await _sut.TestGetKeyRolePartyIds(1, TestContext.Current.CancellationToken);
+        var second = await _sut.TestGetKeyRolePartyIds(1, TestContext.Current.CancellationToken);
 
         Assert.Same(first, second);
         _partiesMock.Verify(p => p.GetKeyRoleParties(1, It.IsAny<CancellationToken>()), Times.Once);
@@ -456,8 +456,8 @@ public class ContextHandlerUnitTest : IDisposable
         _partiesMock.Setup(p => p.GetMainUnits(It.IsAny<MainUnitQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<MainUnit> { new MainUnit { PartyId = 10 } });
 
-        var first = await _sut.TestGetMainUnits(1);
-        var second = await _sut.TestGetMainUnits(1);
+        var first = await _sut.TestGetMainUnits(1, TestContext.Current.CancellationToken);
+        var second = await _sut.TestGetMainUnits(1, TestContext.Current.CancellationToken);
 
         Assert.Same(first, second);
         _partiesMock.Verify(p => p.GetMainUnits(It.IsAny<MainUnitQuery>(), It.IsAny<CancellationToken>()), Times.Once);

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventLogServiceTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventLogServiceTest.cs
@@ -31,7 +31,7 @@ public class EventLogServiceTest
         var httpContext = new DefaultHttpContext();
 
         var service = CreateService();
-        await service.CreateAuthorizationEvent(_featureManagerMock.Object, request, httpContext, response);
+        await service.CreateAuthorizationEvent(_featureManagerMock.Object, request, httpContext, response, TestContext.Current.CancellationToken);
 
         _queueClientMock.Verify(
             q => q.EnqueueAuthorizationEvent(It.IsAny<Altinn.Platform.Authorization.Models.EventLog.AuthorizationEvent>(), It.IsAny<CancellationToken>()),
@@ -48,7 +48,7 @@ public class EventLogServiceTest
         var httpContext = new DefaultHttpContext();
 
         var service = CreateService();
-        await service.CreateAuthorizationEvent(_featureManagerMock.Object, request, httpContext, response);
+        await service.CreateAuthorizationEvent(_featureManagerMock.Object, request, httpContext, response, TestContext.Current.CancellationToken);
 
         _queueClientMock.Verify(
             q => q.EnqueueAuthorizationEvent(It.IsAny<Altinn.Platform.Authorization.Models.EventLog.AuthorizationEvent>(), It.IsAny<CancellationToken>()),

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventsQueueClientTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventsQueueClientTests.cs
@@ -50,7 +50,7 @@ namespace Altinn.Authorization.Tests
             };
 
             // Act
-            var receipt = await client.EnqueueAuthorizationEvent(evt);
+            var receipt = await client.EnqueueAuthorizationEvent(evt, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(receipt.Success);
@@ -99,7 +99,7 @@ namespace Altinn.Authorization.Tests
             };
 
             // Act
-            var receipt = await client.EnqueueAuthorizationEvent(evt);
+            var receipt = await client.EnqueueAuthorizationEvent(evt, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(receipt.Success);
@@ -147,7 +147,7 @@ namespace Altinn.Authorization.Tests
             };
 
             // Act
-            var receipt = await client.EnqueueAuthorizationEvent(evt);
+            var receipt = await client.EnqueueAuthorizationEvent(evt, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(receipt.Success);

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExtensionTests/HttpClientExtensionTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExtensionTests/HttpClientExtensionTest.cs
@@ -12,7 +12,7 @@ public class HttpClientExtensionTest
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
 
-        await client.PostAsync("/api/test", new StringContent("body"));
+        await client.PostAsync("/api/test", new StringContent("body"), TestContext.Current.CancellationToken);
 
         Assert.NotNull(handler.Request);
         Assert.False(handler.Request.Headers.Contains("Authorization"));
@@ -25,7 +25,7 @@ public class HttpClientExtensionTest
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
 
-        await client.PostAsync("/api/test", new StringContent("body"), authorizationToken: "jwt-token");
+        await client.PostAsync("/api/test", new StringContent("body"), authorizationToken: "jwt-token", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(handler.Request.Headers.Contains("Authorization"));
         Assert.Equal("Bearer jwt-token", handler.Request.Headers.GetValues("Authorization").Single());
@@ -37,7 +37,7 @@ public class HttpClientExtensionTest
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
 
-        await client.PostAsync("/api/test", new StringContent("body"), platformAccessToken: "platform-token");
+        await client.PostAsync("/api/test", new StringContent("body"), platformAccessToken: "platform-token", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(handler.Request.Headers.Contains("PlatformAccessToken"));
         Assert.Equal("platform-token", handler.Request.Headers.GetValues("PlatformAccessToken").Single());
@@ -49,7 +49,7 @@ public class HttpClientExtensionTest
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
 
-        await client.PostAsync("/api/test", new StringContent("body"), "jwt-token", "platform-token");
+        await client.PostAsync("/api/test", new StringContent("body"), "jwt-token", "platform-token", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(handler.Request.Headers.Contains("Authorization"));
         Assert.True(handler.Request.Headers.Contains("PlatformAccessToken"));
@@ -61,7 +61,7 @@ public class HttpClientExtensionTest
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
 
-        await client.PostAsync("/api/test", new StringContent("body"));
+        await client.PostAsync("/api/test", new StringContent("body"), TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpMethod.Post, handler.Request.Method);
     }
@@ -73,7 +73,7 @@ public class HttpClientExtensionTest
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
 
-        await client.GetAsync("https://example.com/api/test");
+        await client.GetAsync("https://example.com/api/test", TestContext.Current.CancellationToken);
 
         Assert.NotNull(handler.Request);
         Assert.False(handler.Request.Headers.Contains("Authorization"));
@@ -86,7 +86,7 @@ public class HttpClientExtensionTest
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
 
-        await client.GetAsync("https://example.com/api/test", authorizationToken: "jwt-token");
+        await client.GetAsync("https://example.com/api/test", authorizationToken: "jwt-token", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(handler.Request.Headers.Contains("Authorization"));
         Assert.Equal("Bearer jwt-token", handler.Request.Headers.GetValues("Authorization").Single());
@@ -98,7 +98,7 @@ public class HttpClientExtensionTest
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
 
-        await client.GetAsync("https://example.com/api/test", platformAccessToken: "platform-token");
+        await client.GetAsync("https://example.com/api/test", platformAccessToken: "platform-token", cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(handler.Request.Headers.Contains("PlatformAccessToken"));
         Assert.Equal("platform-token", handler.Request.Headers.GetValues("PlatformAccessToken").Single());
@@ -110,7 +110,7 @@ public class HttpClientExtensionTest
         var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK));
         using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.com") };
 
-        await client.GetAsync("https://example.com/api/test");
+        await client.GetAsync("https://example.com/api/test", TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpMethod.Get, handler.Request.Method);
     }

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Health/HealthCheckTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Health/HealthCheckTests.cs
@@ -31,8 +31,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Health
         {
             HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "/health");
 
-            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage);
-            string content = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+            string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
     }

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PartiesControllerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PartiesControllerTest.cs
@@ -28,11 +28,11 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties?userid=20000490");
+            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties?userid=20000490", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            var partiesList = await response.Content.ReadFromJsonAsync<List<Party>>();
+            var partiesList = await response.Content.ReadFromJsonAsync<List<Party>>(cancellationToken: TestContext.Current.CancellationToken);
             Assert.NotNull(partiesList);
         }
 
@@ -48,7 +48,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties");
+            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -66,7 +66,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties?userid=1337");
+            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties?userid=1337", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -84,11 +84,11 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties/50002598/validate?userid=20000490");
+            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties/50002598/validate?userid=20000490", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.True(await response.Content.ReadFromJsonAsync<bool>());
+            Assert.True(await response.Content.ReadFromJsonAsync<bool>(cancellationToken: TestContext.Current.CancellationToken));
         }
 
         /// <summary>
@@ -103,11 +103,11 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties/50074838/validate?userid=20000490");
+            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties/50074838/validate?userid=20000490", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.True(await response.Content.ReadFromJsonAsync<bool>());
+            Assert.True(await response.Content.ReadFromJsonAsync<bool>(cancellationToken: TestContext.Current.CancellationToken));
         }
 
         /// <summary>
@@ -122,11 +122,11 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties/1337/validate?userid=20000490");
+            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties/1337/validate?userid=20000490", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.False(await response.Content.ReadFromJsonAsync<bool>());
+            Assert.False(await response.Content.ReadFromJsonAsync<bool>(cancellationToken: TestContext.Current.CancellationToken));
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties/50002598/validate?userid=1337");
+            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties/50002598/validate?userid=1337", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -159,7 +159,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties/50002598/validate");
+            HttpResponseMessage response = await _client.GetAsync("authorization/api/v1/parties/50002598/validate", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyControllerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyControllerTest.cs
@@ -49,7 +49,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?org=org&app=app", content);
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?org=org&app=app", content, TestContext.Current.CancellationToken);
 
             TestSetupUtil.DeleteAppBlobData("org", "app");
 
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?org=org&app=app", content);
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?org=org&app=app", content, TestContext.Current.CancellationToken);
 
             TestSetupUtil.DeleteAppBlobData("org", "app");
 
@@ -92,7 +92,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Arrange & Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?org=org&app=app", null);
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?org=org&app=app", null, TestContext.Current.CancellationToken);
             TestSetupUtil.DeleteAppBlobData("org", "app");
 
             // Assert
@@ -115,7 +115,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?app=app", content);
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?app=app", content, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -137,7 +137,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?org=org", content);
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?org=org", content, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -159,7 +159,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?org=org&app=app", content);
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies?org=org&app=app", content, TestContext.Current.CancellationToken);
 
             TestSetupUtil.DeleteAppBlobData("org", "app");
 
@@ -179,8 +179,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             string app = "taxreport";
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"authorization/api/v1/policies/roleswithaccess/{org}/{app}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"authorization/api/v1/policies/roleswithaccess/{org}/{app}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<string> roleCodes = (List<string>)JsonConvert.DeserializeObject(responseContent, typeof(List<string>));
 
             // Assert
@@ -202,7 +202,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             string app = "doesntexisit";
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"authorization/api/v1/policies/roleswithaccess/{org}/{app}");
+            HttpResponseMessage response = await _client.GetAsync($"authorization/api/v1/policies/roleswithaccess/{org}/{app}", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -220,7 +220,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             string app = "doesntexisit";
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"authorization/api/v1/policies/roleswithaccess/{org}/{app}");
+            HttpResponseMessage response = await _client.GetAsync($"authorization/api/v1/policies/roleswithaccess/{org}/{app}", TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -238,8 +238,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             string app = "testapp";
 
             // Act
-            HttpResponseMessage response = await _client.GetAsync($"authorization/api/v1/policies/roleswithaccess/{org}/{app}");
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.GetAsync($"authorization/api/v1/policies/roleswithaccess/{org}/{app}", TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<string> roleCodes = (List<string>)JsonConvert.DeserializeObject(responseContent, typeof(List<string>));
 
             // Assert
@@ -274,8 +274,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<ResourcePolicyResponse> actualResourcePolicyResponses = JsonConvert.DeserializeObject<List<ResourcePolicyResponse>>(responseContent);
 
             // Assert
@@ -309,8 +309,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<ResourcePolicyResponse> actualResourcePolicyResponses = JsonConvert.DeserializeObject<List<ResourcePolicyResponse>>(responseContent);
 
             // Assert
@@ -343,8 +343,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<ResourcePolicyResponse> actualResourcePolicyResponses = JsonConvert.DeserializeObject<List<ResourcePolicyResponse>>(responseContent);
 
             // Assert
@@ -377,8 +377,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<ResourcePolicyResponse> actualResourcePolicyResponses = JsonConvert.DeserializeObject<List<ResourcePolicyResponse>>(responseContent);
 
             // Assert
@@ -413,8 +413,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             };
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<ResourcePolicyResponse> actualResourcePolicyResponses = JsonConvert.DeserializeObject<List<ResourcePolicyResponse>>(responseContent);
 
             // Assert
@@ -435,8 +435,8 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             // Act
-            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content);
-            string responseContent = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await _client.PostAsync("authorization/api/v1/policies/GetPolicies", content, TestContext.Current.CancellationToken);
+            string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             List<ResourcePolicyResponse> actualResourcePolicyResponses = JsonConvert.DeserializeObject<List<ResourcePolicyResponse>>(responseContent);
 
             // Assert

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Lease.Tests/StorageAccount/StorageAccountLeaseTest.cs
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Lease.Tests/StorageAccount/StorageAccountLeaseTest.cs
@@ -58,18 +58,18 @@ namespace Altinn.Authorization.Host.Lease.Tests
         [Fact(Skip = "Need a valid storage account")]
         public async Task TestLeaseAutoRefresh()
         {
-            await using var lease = await Lease.TryAcquireNonBlocking("lease_test");
+            await using var lease = await Lease.TryAcquireNonBlocking("lease_test", TestContext.Current.CancellationToken);
 
             for (var i = 0; i < 100; i++)
             {
                 await lease.Update(new LeaseData()
                 {
                     Counter = i,
-                });
+                }, TestContext.Current.CancellationToken);
             }
 
             await Task.Delay(TimeSpan.FromSeconds(90), CancellationToken.None);
-            var result = await lease.Get<LeaseData>(default);
+            var result = await lease.Get<LeaseData>(TestContext.Current.CancellationToken);
             Assert.Equal(99, result.Counter);
         }
     }


### PR DESCRIPTION
## Result

42 files, +868/-868. Build green (0 errors). Clears all 1,736 xUnit1051 warnings — every `await ...` in test code that accepts a `CancellationToken` now threads `TestContext.Current.CancellationToken` through. Cancelled test runs (CI cancellation, IDE-triggered cancellation) unwind immediately instead of waiting for `Task.Delay` / `SaveChangesAsync` / HTTP calls to time out on their own clock.

## What changed

- **Bulk** — `dotnet format analyzers --diagnostics xUnit1051 --severity warn` applied the xUnit codefix provider to ~1,710 sites across 42 files. Mechanical token-threading; no behavior change beyond responsiveness to cancellation.
- **Hand-fix** — 13 remaining `await Task.WhenAny(serviceTask, Task.Delay(1000))` sites in `ConsentMigrationHostedServiceTests.cs` that the codefix provider couldn't reach inside the `Task.WhenAny` call. Fixed with a sed pass to add the token as the second argument to the inner `Task.Delay`.

Closes #3054

## Test plan

- [ ] CI green