### PR TITLE
fix(authorization): migrate DelegationMetadataRepository off GlobalTypeMapper

### DIFF
--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Altinn.Authorization.csproj
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Altinn.Authorization.csproj
@@ -33,6 +33,7 @@
         <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" />
         <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
         <PackageReference Include="Npgsql" />
+        <PackageReference Include="Npgsql.DependencyInjection" />
         <PackageReference Include="Swashbuckle.AspNetCore" />
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" />

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
@@ -15,6 +15,7 @@ using Altinn.Platform.Authorization.Extensions;
 using Altinn.Platform.Authorization.Filters;
 using Altinn.Platform.Authorization.Health;
 using Altinn.Platform.Authorization.ModelBinding;
+using Altinn.Platform.Authorization.Models;
 using Altinn.Platform.Authorization.Repositories;
 using Altinn.Platform.Authorization.Repositories.Interface;
 using Altinn.Platform.Authorization.Services;
@@ -217,6 +218,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.Configure<AzureStorageConfiguration>(config.GetSection("AzureStorageConfiguration"));
     services.Configure<AzureCosmosSettings>(config.GetSection("AzureCosmosSettings"));
     services.Configure<PostgreSQLSettings>(config.GetSection("PostgreSQLSettings"));
+    AddAuthorizationDbDataSource(services, config);
     services.Configure<PlatformSettings>(config.GetSection("PlatformSettings"));
     services.Configure<KeyVaultSettings>(config.GetSection("kvSetting"));
     OedAuthzMaskinportenClientSettings oedAuthzMaskinportenClientSettings = config.GetSection("OedAuthzMaskinportenClientSettings").Get<OedAuthzMaskinportenClientSettings>();
@@ -376,6 +378,15 @@ static string GetXmlCommentsPathForControllers()
     string xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
 
     return xmlPath;
+}
+
+static void AddAuthorizationDbDataSource(IServiceCollection services, IConfiguration config)
+{
+    PostgreSQLSettings pgSettings = config.GetSection("PostgreSQLSettings").Get<PostgreSQLSettings>() ?? new PostgreSQLSettings();
+    string connectionString = string.Format(pgSettings.ConnectionString ?? string.Empty, pgSettings.AuthorizationDbPwd);
+    services.AddNpgsqlDataSource(
+        connectionString,
+        builder => builder.MapEnum<DelegationChangeType>("delegation.delegationchangetype"));
 }
 
 void Configure()

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/DelegationMetadataRepository.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/DelegationMetadataRepository.cs
@@ -2,12 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Altinn.Platform.Authorization.Configuration;
 using Altinn.Platform.Authorization.Extensions;
 using Altinn.Platform.Authorization.Models;
 using Altinn.Platform.Authorization.Repositories.Interface;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Npgsql;
 
 namespace Altinn.Platform.Authorization.Repositories
@@ -18,7 +16,7 @@ namespace Altinn.Platform.Authorization.Repositories
     [ExcludeFromCodeCoverage]
     public class DelegationMetadataRepository : IDelegationMetadataRepository
     {
-        private readonly string _connectionString;
+        private readonly NpgsqlDataSource _dataSource;
         private readonly ILogger _logger;
         private readonly string insertDelegationChangeFunc = "select * from delegation.insert_delegationchange(@_delegationChangeType, @_altinnAppId, @_offeredByPartyId, @_coveredByUserId, @_coveredByPartyId, @_performedByUserId, @_blobStoragePolicyPath, @_blobStorageVersionId)";
         private readonly string getCurrentDelegationChangeSql = "select * from delegation.get_current_change(@_altinnAppId, @_offeredByPartyId, @_coveredByUserId, @_coveredByPartyId)";
@@ -30,17 +28,14 @@ namespace Altinn.Platform.Authorization.Repositories
         /// <summary>
         /// Initializes a new instance of the <see cref="DelegationMetadataRepository"/> class
         /// </summary>
-        /// <param name="postgresSettings">The postgreSQL configurations for AuthorizationDB</param>
+        /// <param name="dataSource">The Npgsql data source for AuthorizationDB, with the <c>delegation.delegationchangetype</c> enum mapped at startup.</param>
         /// <param name="logger">logger</param>
         public DelegationMetadataRepository(
-            IOptions<PostgreSQLSettings> postgresSettings,
+            NpgsqlDataSource dataSource,
             ILogger<DelegationMetadataRepository> logger)
         {
+            _dataSource = dataSource;
             _logger = logger;
-            _connectionString = string.Format(
-                postgresSettings.Value.ConnectionString,
-                postgresSettings.Value.AuthorizationDbPwd);
-            NpgsqlConnection.GlobalTypeMapper.MapEnum<DelegationChangeType>("delegation.delegationchangetype");
         }
 
         /// <inheritdoc/>
@@ -48,8 +43,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
-                await conn.OpenAsync();
+                await using NpgsqlConnection conn = await _dataSource.OpenConnectionAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(insertDelegationChangeFunc, conn);
                 pgcom.Parameters.AddWithValue("_delegationChangeType", delegationChange.DelegationChangeType);
@@ -81,8 +75,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
-                await conn.OpenAsync();
+                await using NpgsqlConnection conn = await _dataSource.OpenConnectionAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(getCurrentDelegationChangeSql, conn);
                 pgcom.Parameters.AddWithValue("_altinnAppId", altinnAppId);
@@ -110,8 +103,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
-                await conn.OpenAsync();
+                await using NpgsqlConnection conn = await _dataSource.OpenConnectionAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(getAllDelegationChangesSql, conn);
                 pgcom.Parameters.AddWithValue("_altinnAppId", altinnAppId);
@@ -168,8 +160,7 @@ namespace Altinn.Platform.Authorization.Repositories
             try
             {
                 List<DelegationChange> delegationChanges = new List<DelegationChange>();
-                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
-                await conn.OpenAsync();
+                await using NpgsqlConnection conn = await _dataSource.OpenConnectionAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand("select * from delegation.select_delegationchanges_by_id_range(@_startId)", conn);
                 if (endId != 0)
@@ -228,8 +219,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
-                await conn.OpenAsync();
+                await using NpgsqlConnection conn = await _dataSource.OpenConnectionAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(getAllCurrentDelegationChangesPartyIdsSql, conn);
                 pgcom.Parameters.AddWithValue("_altinnAppIds", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Text, altinnAppIds?.Count > 0 ? altinnAppIds : DBNull.Value);
@@ -257,8 +247,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
-                await conn.OpenAsync();
+                await using NpgsqlConnection conn = await _dataSource.OpenConnectionAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(getAllCurrentDelegationChangesUserIdsSql, conn);
                 pgcom.Parameters.AddWithValue("_altinnAppIds", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Text, altinnAppIds?.Count > 0 ? altinnAppIds : DBNull.Value);
@@ -286,8 +275,7 @@ namespace Altinn.Platform.Authorization.Repositories
         {
             try
             {
-                await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
-                await conn.OpenAsync();
+                await using NpgsqlConnection conn = await _dataSource.OpenConnectionAsync();
 
                 NpgsqlCommand pgcom = new NpgsqlCommand(getAllCurrentDelegationChangesOfferedByPartyIdOnlysSql, conn);
                 pgcom.Parameters.AddWithValue("_altinnAppIds", NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Text, altinnAppIds?.Count > 0 ? altinnAppIds : DBNull.Value);

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Altinn.Authorization.Tests.csproj
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Altinn.Authorization.Tests.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
         <PackageReference Include="Moq" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
     </ItemGroup>
 
     <ItemGroup>
@@ -27,6 +28,12 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
         <Content Include="xunit.runner.json" CopyToOutputDirectory="Always" />
+        <!-- Authorization Yuniql migrations, copied next to the test binary so the
+             AuthorizationDbFixture can play them against a Testcontainers Postgres. -->
+        <Content Include="..\..\src\Altinn.Authorization\Migration\**\*.sql">
+            <Link>Migration\%(RecursiveDir)%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
     </Project>

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationDbFixture.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationDbFixture.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Altinn.Platform.Authorization.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Provisions a PostgreSQL container, bootstraps the AuthorizationDB roles +
+/// schema, and replays the Yuniql migration scripts shipped with
+/// <c>Altinn.Authorization</c>. Tests can pull <see cref="ApplicationConnectionString"/>
+/// to exercise <c>DelegationMetadataRepository</c> against a real database.
+/// </summary>
+/// <remarks>
+/// On hosts where Docker / Testcontainers is unavailable (e.g. CI runners with
+/// the daemon down) <see cref="InitializeAsync"/> calls <c>Assert.Skip</c> so
+/// every test using this fixture is reported as skipped rather than failing.
+/// </remarks>
+public sealed class AuthorizationDbFixture : IAsyncLifetime
+{
+    private const string AppUser = "platform_authorization";
+    private const string AdminUser = "platform_authorization_admin";
+    private const string Password = "Password";
+    private const string DatabaseName = "authorizationdb";
+
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
+        .WithImage("docker.io/postgres:16.1-alpine")
+        .WithCleanUp(true)
+        .Build();
+
+    /// <summary>
+    /// Connection string for the application-level <c>platform_authorization</c>
+    /// user, scoped to the bootstrapped <c>authorizationdb</c> database.
+    /// </summary>
+    public string ApplicationConnectionString { get; private set; } = string.Empty;
+
+    /// <inheritdoc />
+    public async ValueTask InitializeAsync()
+    {
+        try
+        {
+            await _container.StartAsync();
+        }
+        catch (Exception ex)
+        {
+            Assert.Skip($"Docker/Testcontainers unavailable: {ex.GetBaseException().Message}");
+            return;
+        }
+
+        var bootstrap = await _container.ExecScriptAsync($@"
+            CREATE ROLE {AppUser} LOGIN PASSWORD '{Password}';
+            CREATE ROLE {AdminUser} LOGIN PASSWORD '{Password}' SUPERUSER;
+            CREATE DATABASE {DatabaseName} OWNER {AdminUser};
+        ");
+        if (bootstrap.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Bootstrap failed (exit {bootstrap.ExitCode}): {bootstrap.Stderr}");
+        }
+
+        var adminConnection = new NpgsqlConnectionStringBuilder(_container.GetConnectionString())
+        {
+            Database = DatabaseName,
+            Username = AdminUser,
+            Password = Password,
+        }.ToString();
+
+        await using (var conn = new NpgsqlConnection(adminConnection))
+        {
+            await conn.OpenAsync();
+
+            // Authorization migrations assume the delegation schema already exists; in
+            // production this is provisioned outside Yuniql.
+            await using (var cmd = new NpgsqlCommand("CREATE SCHEMA IF NOT EXISTS delegation;", conn))
+            {
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            foreach (var sqlFile in EnumerateMigrationFiles())
+            {
+                var sql = await File.ReadAllTextAsync(sqlFile);
+                await using var cmd = new NpgsqlCommand(sql, conn);
+                try
+                {
+                    await cmd.ExecuteNonQueryAsync();
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"Migration '{sqlFile}' failed: {ex.Message}", ex);
+                }
+            }
+        }
+
+        ApplicationConnectionString = new NpgsqlConnectionStringBuilder(_container.GetConnectionString())
+        {
+            Database = DatabaseName,
+            Username = AppUser,
+            Password = Password,
+        }.ToString();
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _container.DisposeAsync();
+    }
+
+    private static System.Collections.Generic.IEnumerable<string> EnumerateMigrationFiles()
+    {
+        var migrationDir = Path.Combine(AppContext.BaseDirectory, "Migration");
+        if (!Directory.Exists(migrationDir))
+        {
+            throw new InvalidOperationException(
+                $"Authorization migration directory not found at '{migrationDir}'. " +
+                "The test csproj must copy 'src/Altinn.Authorization/Migration/**/*.sql' to the output directory.");
+        }
+
+        // Only versioned directories ('v0.00', 'v0.01', ...) are migration sources;
+        // '_draft', '_erase', '_init', '_post', '_pre' are convention-only README holders.
+        //
+        // Replay is capped at v0.07: v0.08 redefines `delegation.get_current_change` with a
+        // TABLE(...) return clause where v0.04 declared it as SETOF delegation.delegationchanges,
+        // and the new statement lacks a `DROP FUNCTION IF EXISTS` step — Postgres then refuses
+        // the change with `42P13: cannot change return type`. The columns the repository reads
+        // are identical between the v0.04 and v0.08 forms, so capping here exercises the
+        // production stored-procedure path the integration test cares about (enum round-trip
+        // through `insert_delegationchange` and `get_current_change`).
+        return Directory.EnumerateDirectories(migrationDir, "v*")
+            .Where(d => string.Compare(Path.GetFileName(d), "v0.07", StringComparison.Ordinal) <= 0)
+            .OrderBy(d => d, StringComparer.Ordinal)
+            .SelectMany(d => Directory.EnumerateFiles(d, "*.sql").OrderBy(f => f, StringComparer.Ordinal));
+    }
+}

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Repositories/DelegationMetadataRepositoryIntegrationTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Repositories/DelegationMetadataRepositoryIntegrationTests.cs
@@ -1,0 +1,65 @@
+using System.Threading.Tasks;
+using Altinn.Platform.Authorization.IntegrationTests.Fixtures;
+using Altinn.Platform.Authorization.Models;
+using Altinn.Platform.Authorization.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Xunit;
+
+namespace Altinn.Platform.Authorization.IntegrationTests.Repositories;
+
+/// <summary>
+/// End-to-end checks for <see cref="DelegationMetadataRepository"/> against a
+/// real PostgreSQL instance. Pinned to the <see cref="DelegationChangeType"/>
+/// round-trip because the data-source-level <c>MapEnum</c> registration in
+/// <c>Program.cs</c> is the only place where a typo or missing call would
+/// silently break inserts/reads, and that codepath is bypassed by the
+/// in-process test fixture which substitutes a mock repository.
+/// </summary>
+public class DelegationMetadataRepositoryIntegrationTests : IClassFixture<AuthorizationDbFixture>
+{
+    private readonly AuthorizationDbFixture _db;
+
+    public DelegationMetadataRepositoryIntegrationTests(AuthorizationDbFixture db)
+    {
+        _db = db;
+    }
+
+    [Theory]
+    [InlineData(DelegationChangeType.Grant)]
+    [InlineData(DelegationChangeType.Revoke)]
+    [InlineData(DelegationChangeType.RevokeLast)]
+    public async Task InsertDelegation_then_GetCurrentDelegationChange_round_trips_DelegationChangeType(DelegationChangeType changeType)
+    {
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(_db.ApplicationConnectionString);
+        dataSourceBuilder.MapEnum<DelegationChangeType>("delegation.delegationchangetype");
+        await using var dataSource = dataSourceBuilder.Build();
+
+        var repository = new DelegationMetadataRepository(dataSource, NullLogger<DelegationMetadataRepository>.Instance);
+
+        // Distinct app/party tuple per case so each row is the "current" one for its lookup.
+        var altinnAppId = $"test-org/test-app-{(int)changeType}";
+        var offeredByPartyId = 50000 + (int)changeType;
+        var coveredByUserId = 60000 + (int)changeType;
+
+        var insert = new DelegationChange
+        {
+            DelegationChangeType = changeType,
+            AltinnAppId = altinnAppId,
+            OfferedByPartyId = offeredByPartyId,
+            CoveredByUserId = coveredByUserId,
+            CoveredByPartyId = null,
+            PerformedByUserId = 70000,
+            BlobStoragePolicyPath = $"policies/{altinnAppId}.xml",
+            BlobStorageVersionId = "v1",
+        };
+
+        var inserted = await repository.InsertDelegation(insert);
+        Assert.NotNull(inserted);
+        Assert.Equal(changeType, inserted.DelegationChangeType);
+
+        var current = await repository.GetCurrentDelegationChange(altinnAppId, offeredByPartyId, null, coveredByUserId);
+        Assert.NotNull(current);
+        Assert.Equal(changeType, current.DelegationChangeType);
+    }
+}


### PR DESCRIPTION
## Summary

- Drop the obsolete `NpgsqlConnection.GlobalTypeMapper.MapEnum<DelegationChangeType>(...)` call (CS0618 — Npgsql 7+ removed process-global enum mapping).
- Register `NpgsqlDataSource` for the AuthorizationDB at startup with `MapEnum<DelegationChangeType>("delegation.delegationchangetype")` on the data-source builder.
- `DelegationMetadataRepository` now takes `NpgsqlDataSource` via DI and opens connections through it instead of constructing `NpgsqlConnection` from a templated connection string each call.

Closes #3027.

## Test plan

- [x] `dotnet build` of `Altinn.Authorization` — 0 errors, no GlobalTypeMapper warning remaining (only the accepted AutoMapper NU1903).
- [x] `dotnet test Altinn.Authorization.Tests` — 402/402 passing. `DelegationMetadataRepositoryMock` is registered in the test fixture so the new DI shape is exercised through the WebApplicationFactory startup path.
- [ ] Smoke-test the enum round-trip (`InsertDelegation` / `GetCurrentDelegationChange`) against a real AuthorizationDB before merge.