### PR TITLE
fix(authorization): make Yuniql migrations replay-safe on a fresh database

### DIFF
--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Migration/v0.08/01-setup-procedures.sql
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Migration/v0.08/01-setup-procedures.sql
@@ -39,6 +39,12 @@ AS $BODY$
 $BODY$;
 
 -- Function: update delegation.get_current_change for correct select order coveredByPartyId before coveredByUserId to match delegation.delegationchanges column order
+-- The previous v0.04 definition declared `RETURNS SETOF delegation.delegationchanges`; this version
+-- switches to a `RETURNS TABLE(...)` clause, which Postgres treats as a return-type change and
+-- rejects via `CREATE OR REPLACE FUNCTION` (42P13). Drop the existing function first so a fresh-DB
+-- replay (new environments, integration tests) succeeds.
+DROP FUNCTION IF EXISTS delegation.get_current_change(character varying, integer, integer, integer);
+
 CREATE OR REPLACE FUNCTION delegation.get_current_change(
 	_altinnappid character varying,
 	_offeredbypartyid integer,

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationDbFixture.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationDbFixture.cs
@@ -15,9 +15,13 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Fixtures;
 /// to exercise <c>DelegationMetadataRepository</c> against a real database.
 /// </summary>
 /// <remarks>
-/// On hosts where Docker / Testcontainers is unavailable (e.g. CI runners with
-/// the daemon down) <see cref="InitializeAsync"/> calls <c>Assert.Skip</c> so
-/// every test using this fixture is reported as skipped rather than failing.
+/// On hosts where Docker / Testcontainers is unavailable, <see cref="SkipReason"/>
+/// is populated and <see cref="ApplicationConnectionString"/> is left empty.
+/// Tests should call <c>Assert.SkipWhen(fixture.SkipReason is not null, fixture.SkipReason!)</c>
+/// at the top of their body — <c>Assert.Skip</c> raised from
+/// <see cref="IAsyncLifetime.InitializeAsync"/> propagates as a fixture-init
+/// failure rather than a test skip in xUnit v3, so the check has to live on the
+/// per-test path.
 /// </remarks>
 public sealed class AuthorizationDbFixture : IAsyncLifetime
 {
@@ -26,27 +30,45 @@ public sealed class AuthorizationDbFixture : IAsyncLifetime
     private const string Password = "Password";
     private const string DatabaseName = "authorizationdb";
 
-    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
-        .WithImage("docker.io/postgres:16.1-alpine")
-        .WithCleanUp(true)
-        .Build();
+    private PostgreSqlContainer? _container;
 
     /// <summary>
     /// Connection string for the application-level <c>platform_authorization</c>
     /// user, scoped to the bootstrapped <c>authorizationdb</c> database.
+    /// Empty when <see cref="SkipReason"/> is set.
     /// </summary>
     public string ApplicationConnectionString { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Set when the fixture cannot provision a real PostgreSQL container
+    /// (typically: Docker daemon not running). Tests that depend on the
+    /// fixture should call <c>Assert.SkipWhen</c> on this value before doing
+    /// any work that requires <see cref="ApplicationConnectionString"/>.
+    /// </summary>
+    public string? SkipReason { get; private set; }
 
     /// <inheritdoc />
     public async ValueTask InitializeAsync()
     {
         try
         {
+            // Both the builder's `.Build()` and `StartAsync` reach for the Docker
+            // daemon, so the construction has to live inside the try/catch — running
+            // it as a field initializer would surface a fixture-construction
+            // failure that no test-level skip can intercept.
+            _container = new PostgreSqlBuilder()
+                .WithImage("docker.io/postgres:16.1-alpine")
+                .WithCleanUp(true)
+                .Build();
             await _container.StartAsync();
         }
         catch (Exception ex)
         {
-            Assert.Skip($"Docker/Testcontainers unavailable: {ex.GetBaseException().Message}");
+            // Throwing — including via Assert.Skip — from IAsyncLifetime.InitializeAsync
+            // surfaces as a fixture-init failure (every dependent test is reported
+            // failed with "Class fixture type ... threw"), not as a skip. Stash the
+            // reason and let each test convert it to a skip via Assert.SkipWhen.
+            SkipReason = $"Docker/Testcontainers unavailable: {ex.GetBaseException().Message}";
             return;
         }
 
@@ -104,7 +126,10 @@ public sealed class AuthorizationDbFixture : IAsyncLifetime
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        await _container.DisposeAsync();
+        if (_container is not null)
+        {
+            await _container.DisposeAsync();
+        }
     }
 
     private static System.Collections.Generic.IEnumerable<string> EnumerateMigrationFiles()
@@ -119,16 +144,7 @@ public sealed class AuthorizationDbFixture : IAsyncLifetime
 
         // Only versioned directories ('v0.00', 'v0.01', ...) are migration sources;
         // '_draft', '_erase', '_init', '_post', '_pre' are convention-only README holders.
-        //
-        // Replay is capped at v0.07: v0.08 redefines `delegation.get_current_change` with a
-        // TABLE(...) return clause where v0.04 declared it as SETOF delegation.delegationchanges,
-        // and the new statement lacks a `DROP FUNCTION IF EXISTS` step — Postgres then refuses
-        // the change with `42P13: cannot change return type`. The columns the repository reads
-        // are identical between the v0.04 and v0.08 forms, so capping here exercises the
-        // production stored-procedure path the integration test cares about (enum round-trip
-        // through `insert_delegationchange` and `get_current_change`).
         return Directory.EnumerateDirectories(migrationDir, "v*")
-            .Where(d => string.Compare(Path.GetFileName(d), "v0.07", StringComparison.Ordinal) <= 0)
             .OrderBy(d => d, StringComparer.Ordinal)
             .SelectMany(d => Directory.EnumerateFiles(d, "*.sql").OrderBy(f => f, StringComparer.Ordinal));
     }

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Repositories/DelegationMetadataRepositoryIntegrationTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Repositories/DelegationMetadataRepositoryIntegrationTests.cs
@@ -31,6 +31,8 @@ public class DelegationMetadataRepositoryIntegrationTests : IClassFixture<Author
     [InlineData(DelegationChangeType.RevokeLast)]
     public async Task InsertDelegation_then_GetCurrentDelegationChange_round_trips_DelegationChangeType(DelegationChangeType changeType)
     {
+        Assert.SkipWhen(_db.SkipReason is not null, _db.SkipReason ?? string.Empty);
+
         var dataSourceBuilder = new NpgsqlDataSourceBuilder(_db.ApplicationConnectionString);
         dataSourceBuilder.MapEnum<DelegationChangeType>("delegation.delegationchangetype");
         await using var dataSource = dataSourceBuilder.Build();


### PR DESCRIPTION
## Summary

- Add `DROP FUNCTION IF EXISTS delegation.get_current_change(character varying, integer, integer, integer);` ahead of v0.08's redefinition of that function. The new declaration switches from `RETURNS SETOF delegation.delegationchanges` (v0.04) to `RETURNS TABLE(...)`, which `CREATE OR REPLACE FUNCTION` rejects with `42P13: cannot change return type of existing function`. Production DBs are fine because they migrated incrementally and the v0.08 step ran against a DB where the old function existed but with the new return-type contract not yet imposed; fresh-DB replays — disaster recovery, new `at`-environments, local dev, the integration test below — currently fail.
- Lift the `v0.07` replay cap in `AuthorizationDbFixture` so the integration test added in #3056 runs the full production migration set.
- Fix two latent defects in that fixture surfaced by running it on a Docker-less host:
  - `PostgreSqlBuilder.Build()` reaches the daemon eagerly. Construct the container inside `InitializeAsync` so the same try/catch handles it.
  - `Assert.Skip` from `IAsyncLifetime.InitializeAsync` propagates as a fixture-init failure, not a skip. Stash `SkipReason` on the fixture and have the test call `Assert.SkipWhen` at the top.

Closes #3057.

## Test plan

- [x] `dotnet test src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests` with Docker down: 402 passed + 3 skipped (was 3 failed).
- [ ] Same command with Docker up — CI exercises this against the full unfiltered migration set; local re-verification needs the daemon back up.
- [x] Pattern-matched the fix against the existing `DROP FUNCTION IF EXISTS delegation.select_delegationchanges_by_id_range(...)` block in v0.08 / v0.09 (same shape).