### PR TITLE
fix(persistence-ef): localize EF1001 around CustomMigrationsSqlGenerator

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/CustomMigrationsSqlGenerator.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/CustomMigrationsSqlGenerator.cs
@@ -11,10 +11,30 @@ namespace Altinn.AccessMgmt.PersistenceEF.Extensions;
 
 public class CustomMigrationsSqlGenerator : NpgsqlMigrationsSqlGenerator
 {
+    /// <summary>
+    /// Initializes the custom migration SQL generator. The audit-trigger DDL
+    /// emitted alongside each operation has no public-API equivalent in EF Core
+    /// (annotations, conventions, and value converters all run at a different
+    /// layer than per-operation SQL emission), so subclassing the Npgsql
+    /// generator is the only available extension point.
+    /// </summary>
+    /// <param name="dependencies">Standard EF Core migration-generator dependencies.</param>
+    /// <param name="npgsqlOptions">
+    /// The Npgsql provider's singleton-options surface. The interface lives in
+    /// <c>Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal</c> and is
+    /// flagged internal API by Npgsql (EF1001) — it can move or be removed across
+    /// minor / patch upgrades of <c>Npgsql.EntityFrameworkCore.PostgreSQL</c>. The
+    /// reference is unavoidable: the base constructor only accepts this type.
+    /// <c>CustomMigrationsSqlGeneratorContractTests.NpgsqlMigrationsSqlGenerator_keeps_INpgsqlSingletonOptions_constructor</c>
+    /// pins the contract and fails loudly if a future package upgrade breaks it,
+    /// at which point this class needs to be re-shaped (or the package pinned).
+    /// </param>
+#pragma warning disable EF1001 // Internal Npgsql provider API — see XML doc above; covered by a regression test in PersistenceEF.Tests.
     public CustomMigrationsSqlGenerator(
         MigrationsSqlGeneratorDependencies dependencies,
         INpgsqlSingletonOptions npgsqlOptions)
         : base(dependencies, npgsqlOptions) { }
+#pragma warning restore EF1001
 
     protected override void Generate(CreateTableOperation operation, IModel? model, MigrationCommandListBuilder builder, bool terminate = true)
     {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Extensions/CustomMigrationsSqlGeneratorContractTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Extensions/CustomMigrationsSqlGeneratorContractTests.cs
@@ -6,18 +6,32 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Migrations;
 namespace Altinn.AccessMgmt.PersistenceEF.Tests.Extensions;
 
 /// <summary>
-/// Pins the EF1001 contract that <see cref="CustomMigrationsSqlGenerator"/>
+/// Documents the EF1001 contract that <see cref="CustomMigrationsSqlGenerator"/>
 /// depends on. The base class' constructor takes
 /// <c>Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal.INpgsqlSingletonOptions</c>,
-/// which Npgsql has marked internal — meaning it can move or be removed
-/// without notice on a minor / patch upgrade of
-/// <c>Npgsql.EntityFrameworkCore.PostgreSQL</c>. If that happens the
-/// production project would still need to compile (it pins the type via the
-/// generator subclass), so the failure mode is silent until something at
-/// runtime trips. These tests run in CI on every package change and surface
-/// the breakage as an explicit signal: re-shape the generator, find a
-/// replacement extension point, or pin the package version.
+/// which Npgsql has marked internal — meaning it can move, be renamed, or be
+/// removed without notice on a minor / patch upgrade of
+/// <c>Npgsql.EntityFrameworkCore.PostgreSQL</c>.
 /// </summary>
+/// <remarks>
+/// Most such breakages already surface as a compile error in the production
+/// project (which references the type directly via a <c>using</c> directive
+/// and the constructor parameter); these tests don't replace that signal.
+/// What they add is twofold:
+/// <list type="bullet">
+///   <item>An executable record of the dependency in the test suite, so the
+///   constraint is searchable by anyone auditing "what breaks on an Npgsql
+///   upgrade" rather than discoverable only by tracing a build failure.</item>
+///   <item>A metadata-level full-name canary in
+///   <see cref="NpgsqlMigrationsSqlGenerator_keeps_INpgsqlSingletonOptions_constructor"/>
+///   for the narrow case where Npgsql renames the type but ships a
+///   backwards-compatible alias — the production build would stay green,
+///   but the assertion would catch it.</item>
+/// </list>
+/// On any failure here the upgrade needs an explicit re-evaluation: re-shape
+/// the generator around a replacement type, find a public-surface
+/// alternative, or pin the package version.
+/// </remarks>
 public class CustomMigrationsSqlGeneratorContractTests
 {
     private const string InternalOptionsTypeFullName =
@@ -40,10 +54,13 @@ public class CustomMigrationsSqlGeneratorContractTests
     [Fact]
     public void NpgsqlMigrationsSqlGenerator_keeps_INpgsqlSingletonOptions_constructor()
     {
-        // The base constructor is what we forward our argument into. If a future
-        // Npgsql upgrade renames or removes the internal options type, this lookup
-        // returns null before the production project's compile fails — same
-        // failure mode, but framed as a test rather than a build error.
+        // A removal, rename, or namespace move of INpgsqlSingletonOptions also
+        // surfaces as a compile error in the production project, which references
+        // the type directly. This assembly-level lookup is the canary for the
+        // narrow case where Npgsql renames the type but ships a backwards-
+        // compatible alias — the build would stay green, but `GetType` would
+        // return null because the literal full name is no longer the canonical
+        // type definition in the assembly's metadata.
         var optionsType = typeof(NpgsqlMigrationsSqlGenerator).Assembly
             .GetType(InternalOptionsTypeFullName);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Extensions/CustomMigrationsSqlGeneratorContractTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Extensions/CustomMigrationsSqlGeneratorContractTests.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using Altinn.AccessMgmt.PersistenceEF.Extensions;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Migrations;
+
+namespace Altinn.AccessMgmt.PersistenceEF.Tests.Extensions;
+
+/// <summary>
+/// Pins the EF1001 contract that <see cref="CustomMigrationsSqlGenerator"/>
+/// depends on. The base class' constructor takes
+/// <c>Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal.INpgsqlSingletonOptions</c>,
+/// which Npgsql has marked internal — meaning it can move or be removed
+/// without notice on a minor / patch upgrade of
+/// <c>Npgsql.EntityFrameworkCore.PostgreSQL</c>. If that happens the
+/// production project would still need to compile (it pins the type via the
+/// generator subclass), so the failure mode is silent until something at
+/// runtime trips. These tests run in CI on every package change and surface
+/// the breakage as an explicit signal: re-shape the generator, find a
+/// replacement extension point, or pin the package version.
+/// </summary>
+public class CustomMigrationsSqlGeneratorContractTests
+{
+    private const string InternalOptionsTypeFullName =
+        "Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal.INpgsqlSingletonOptions";
+
+    [Fact]
+    public void CustomMigrationsSqlGenerator_constructor_signature_pins_INpgsqlSingletonOptions()
+    {
+        var ctors = typeof(CustomMigrationsSqlGenerator).GetConstructors(
+            BindingFlags.Public | BindingFlags.Instance);
+
+        var ctor = Assert.Single(ctors);
+        var parameters = ctor.GetParameters();
+
+        Assert.Equal(2, parameters.Length);
+        Assert.Equal(typeof(MigrationsSqlGeneratorDependencies), parameters[0].ParameterType);
+        Assert.Equal(InternalOptionsTypeFullName, parameters[1].ParameterType.FullName);
+    }
+
+    [Fact]
+    public void NpgsqlMigrationsSqlGenerator_keeps_INpgsqlSingletonOptions_constructor()
+    {
+        // The base constructor is what we forward our argument into. If a future
+        // Npgsql upgrade renames or removes the internal options type, this lookup
+        // returns null before the production project's compile fails — same
+        // failure mode, but framed as a test rather than a build error.
+        var optionsType = typeof(NpgsqlMigrationsSqlGenerator).Assembly
+            .GetType(InternalOptionsTypeFullName);
+
+        Assert.NotNull(optionsType);
+
+        var ctor = typeof(NpgsqlMigrationsSqlGenerator).GetConstructor(
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            types: [typeof(MigrationsSqlGeneratorDependencies), optionsType!],
+            modifiers: null);
+
+        Assert.NotNull(ctor);
+    }
+}


### PR DESCRIPTION
## Summary

`CustomMigrationsSqlGenerator` extends `NpgsqlMigrationsSqlGenerator` to inject audit-trigger DDL after each migration operation. The base class' only public constructor mandates `INpgsqlSingletonOptions` from `Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal` — flagged internal API by Npgsql (EF1001), can move or be removed across minor / patch upgrades.

EF Core's public extensibility (model conventions, annotation providers, value converters) all run at a different layer than per-operation SQL emission, so the subclass is the only surface for what this class does. The fix isn't to remove the dependency — it's to make the dependency explicit and the upgrade-break loud.

- **Localize the suppression**: `#pragma warning disable EF1001` / `restore` around the constructor only, with an XML `<remarks>` block on the constructor explaining why and what to do if the type moves.
- **Add a regression test** (`CustomMigrationsSqlGeneratorContractTests` in `Altinn.AccessMgmt.PersistenceEF.Tests`):
  - Pins the production class' constructor signature.
  - Pins that `NpgsqlMigrationsSqlGenerator` still exposes a constructor taking `INpgsqlSingletonOptions` by full type name. Either failing on a future Npgsql.EFC bump is the explicit signal to either re-shape `CustomMigrationsSqlGenerator`, find a public-surface alternative if EF Core has caught up, or pin the package.

Closes #3028.

## Test plan

- [x] `dotnet build src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF` — 0 EF1001 warnings (was 1, on the constructor parameter).
- [x] `dotnet test src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests` — 43 passed (was 41, +2 new contract tests).