### PR TITLE
chore: triage SonarCloud rule severities in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -121,7 +121,8 @@ dotnet_diagnostic.S1006.severity = warning
 
 # S2589: Boolean expressions should not be gratuitous
 # (some false positives from null-flow analysis; warning is the right
-# starting point — flip individual cases with `// SuppressMessage` if needed)
+# starting point — suppress individual cases with `[SuppressMessage(...)]`
+# or `#pragma warning disable S2589` if needed)
 dotnet_diagnostic.S2589.severity = warning
 
 # S927: Parameter names should match the base / interface declaration
@@ -206,7 +207,7 @@ dotnet_diagnostic.S1172.severity = suggestion
 # S4136: Method overloads should be grouped together
 dotnet_diagnostic.S4136.severity = suggestion
 
-# --- Accepted convention (no — won't show up at all) ---
+# --- Accepted convention (none — won't show up at all) ---
 
 # S1135: Track uses of "TODO" tags
 # (TODO is the team's normal way to mark deferred work in code)

--- a/.editorconfig
+++ b/.editorconfig
@@ -42,41 +42,53 @@ dotnet_diagnostic.CA1822.severity = none
 # rules (each <10 instances) keep their default severity.
 #
 # Categories:
-#   error      — bug-class defects we want CI to gate on
-#   warning    — code smells worth fixing; visible in build output
+#   warning    — bug-class defects + code smells worth fixing; visible in
+#                build output. SonarCloud's quality gate still enforces these
+#                on new code at PR time.
 #   suggestion — IDE-only nudge; doesn't add to build noise
 #   none       — accepted convention / false-positive-prone for this codebase
+#
+# `error` severity is intentionally NOT used here. With dotnet-sonarscanner
+# loading these analyzers in CI, an `error` on a rule that fires on existing
+# code would fail every PR's build until the underlying violations are
+# cleared — blocking the whole team. Each followup sweep PR (one rule per PR,
+# mechanical fix of every occurrence) flips its rule from `warning` to
+# `error` in the same commit so enforcement tightens gradually instead of
+# being switched on top-down.
 # ----------------------------------------------------------------------------
 
-# --- Bug-class rules (gate CI) ---
+# --- Bug-class rules (warning for now — promote to error per-rule once the
+#     existing violations are cleared in a sweep PR) ---
 
-# S2259: Null pointers should not be dereferenced
-dotnet_diagnostic.S2259.severity = error
+# S2259: Null pointers should not be dereferenced (17 existing instances)
+dotnet_diagnostic.S2259.severity = warning
 
 # S6678: Use PascalCase for named placeholders in logging templates
 # (Microsoft.Extensions.Logging — mismatched / wrong-cased templates produce
-# wrong structured-log output, real defect)
-dotnet_diagnostic.S6678.severity = error
+# wrong structured-log output, real defect; 112 existing instances)
+dotnet_diagnostic.S6678.severity = warning
 
 # S6674: Logger arguments should match the placeholders in the template
-dotnet_diagnostic.S6674.severity = error
+# (12 existing instances)
+dotnet_diagnostic.S6674.severity = warning
 
 # S2955: Generic parameters not constrained to reference types should not be
-# compared to "null" (silent runtime mismatch)
-dotnet_diagnostic.S2955.severity = error
+# compared to "null" (silent runtime mismatch; 4 existing instances)
+dotnet_diagnostic.S2955.severity = warning
 
 # S3265: Non-flags enums should not be used in bitwise operations
-dotnet_diagnostic.S3265.severity = error
+# (58 existing instances)
+dotnet_diagnostic.S3265.severity = warning
 
 # S1699: Constructors should only call non-overridable methods (virtual call
-# in ctor is a known C# footgun)
-dotnet_diagnostic.S1699.severity = error
+# in ctor is a known C# footgun; 17 existing instances)
+dotnet_diagnostic.S1699.severity = warning
 
-# S3949: Calculations on integers should not overflow
-dotnet_diagnostic.S3949.severity = error
+# S3949: Calculations on integers should not overflow (1 existing instance)
+dotnet_diagnostic.S3949.severity = warning
 
-# S2583: Conditionally executed code should be reachable
-dotnet_diagnostic.S2583.severity = error
+# S2583: Conditionally executed code should be reachable (1 existing instance)
+dotnet_diagnostic.S2583.severity = warning
 
 # --- Mechanical / high-volume code smells (worth fixing, visible in build) ---
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -33,6 +33,173 @@ dotnet_diagnostic.FAA0002.severity = none
 # CA1822: Mark members as static
 dotnet_diagnostic.CA1822.severity = none
 
+# ----------------------------------------------------------------------------
+# SonarAnalyzer (csharpsquid) severity map.
+#
+# Triaged from a live SonarCloud snapshot of `Authorization_AccessManagement`
+# (2,177 issues) and `Authorization_Authorization` (371 issues). Covers the
+# top rules by occurrence count plus every bug-class rule. Lower-volume
+# rules (each <10 instances) keep their default severity.
+#
+# Categories:
+#   error      — bug-class defects we want CI to gate on
+#   warning    — code smells worth fixing; visible in build output
+#   suggestion — IDE-only nudge; doesn't add to build noise
+#   none       — accepted convention / false-positive-prone for this codebase
+# ----------------------------------------------------------------------------
+
+# --- Bug-class rules (gate CI) ---
+
+# S2259: Null pointers should not be dereferenced
+dotnet_diagnostic.S2259.severity = error
+
+# S6678: Use PascalCase for named placeholders in logging templates
+# (Microsoft.Extensions.Logging — mismatched / wrong-cased templates produce
+# wrong structured-log output, real defect)
+dotnet_diagnostic.S6678.severity = error
+
+# S6674: Logger arguments should match the placeholders in the template
+dotnet_diagnostic.S6674.severity = error
+
+# S2955: Generic parameters not constrained to reference types should not be
+# compared to "null" (silent runtime mismatch)
+dotnet_diagnostic.S2955.severity = error
+
+# S3265: Non-flags enums should not be used in bitwise operations
+dotnet_diagnostic.S3265.severity = error
+
+# S1699: Constructors should only call non-overridable methods (virtual call
+# in ctor is a known C# footgun)
+dotnet_diagnostic.S1699.severity = error
+
+# S3949: Calculations on integers should not overflow
+dotnet_diagnostic.S3949.severity = error
+
+# S2583: Conditionally executed code should be reachable
+dotnet_diagnostic.S2583.severity = error
+
+# --- Mechanical / high-volume code smells (worth fixing, visible in build) ---
+
+# S1192: String literals should not be duplicated → extract to constants
+dotnet_diagnostic.S1192.severity = warning
+
+# S125: Sections of code should not be commented out
+dotnet_diagnostic.S125.severity = warning
+
+# S1481: Unused local variables should be removed
+dotnet_diagnostic.S1481.severity = warning
+
+# S1144: Unused private types or members should be removed
+dotnet_diagnostic.S1144.severity = warning
+
+# S2325: Methods and properties that don't access instance data should be static
+dotnet_diagnostic.S2325.severity = warning
+
+# S1854: Dead stores (unread assignments) should be removed
+dotnet_diagnostic.S1854.severity = warning
+
+# S1118: Utility classes should not have public constructors
+dotnet_diagnostic.S1118.severity = warning
+
+# S2094: Classes should not be empty
+dotnet_diagnostic.S2094.severity = warning
+
+# S1006: Method overrides should not change parameter defaults
+dotnet_diagnostic.S1006.severity = warning
+
+# S2589: Boolean expressions should not be gratuitous
+# (some false positives from null-flow analysis; warning is the right
+# starting point — flip individual cases with `// SuppressMessage` if needed)
+dotnet_diagnostic.S2589.severity = warning
+
+# S927: Parameter names should match the base / interface declaration
+dotnet_diagnostic.S927.severity = warning
+
+# S2479: Whitespace and control characters in string literals should be explicit
+dotnet_diagnostic.S2479.severity = warning
+
+# S3358: Ternary operators should not be nested
+dotnet_diagnostic.S3358.severity = warning
+
+# S6580: Use a format provider when parsing dates/numbers
+dotnet_diagnostic.S6580.severity = warning
+
+# S6664: Use compile-time logging source generators where possible
+dotnet_diagnostic.S6664.severity = warning
+
+# S101: Types should be named in PascalCase
+dotnet_diagnostic.S101.severity = warning
+
+# S2139: Exceptions should be either logged or rethrown but not both
+dotnet_diagnostic.S2139.severity = warning
+
+# S1155: "Any()" should be used instead of ".Count == 0"
+dotnet_diagnostic.S1155.severity = warning
+
+# S6960: Controllers should not have mixed responsibilities (multiple actions
+# on the same HTTP verb / route)
+dotnet_diagnostic.S6960.severity = warning
+
+# S3236: Methods with caller info attributes should not be invoked with explicit args
+dotnet_diagnostic.S3236.severity = warning
+
+# S1125: Boolean literals should not be redundant
+dotnet_diagnostic.S1125.severity = warning
+
+# S2292: Trivial properties should be auto-implemented
+dotnet_diagnostic.S2292.severity = warning
+
+# --- Design / refactoring rules (suggestion — IDE nudge only) ---
+
+# S3776: Cognitive complexity of methods should not be too high
+# (real code-quality signal but each fix is a thoughtful refactor; doesn't
+# belong in mechanical sweep PRs)
+dotnet_diagnostic.S3776.severity = suggestion
+
+# S107: Methods should not have too many parameters
+# (DI-heavy ctors regularly exceed the threshold; bumping to suggestion
+# stops it from drowning out signal)
+dotnet_diagnostic.S107.severity = suggestion
+
+# S112: General exceptions should not be thrown by user code
+# (sometimes pragmatic in middleware / fallback paths; visible in IDE but
+# not in build)
+dotnet_diagnostic.S112.severity = suggestion
+
+# S3267: Loops should be simplified with LINQ where possible (style choice)
+dotnet_diagnostic.S3267.severity = suggestion
+
+# S1066: Mergeable "if" statements should be combined
+dotnet_diagnostic.S1066.severity = suggestion
+
+# S3878: Arrays should not be created for params arguments
+dotnet_diagnostic.S3878.severity = suggestion
+
+# S6608: Prefer indexing over LINQ "First/Last" for indexable collections
+dotnet_diagnostic.S6608.severity = suggestion
+
+# S6966: Use async overloads where available
+dotnet_diagnostic.S6966.severity = suggestion
+
+# S6672: Use the LoggerMessage source generator instead of ILogger extension methods
+dotnet_diagnostic.S6672.severity = suggestion
+
+# S1133: Deprecated code should be removed (just a remind-by date, not actionable today)
+dotnet_diagnostic.S1133.severity = suggestion
+
+# S1172: Unused method parameters should be removed
+# (interface-required params don't fit this rule's check; suggestion avoids noise)
+dotnet_diagnostic.S1172.severity = suggestion
+
+# S4136: Method overloads should be grouped together
+dotnet_diagnostic.S4136.severity = suggestion
+
+# --- Accepted convention (no — won't show up at all) ---
+
+# S1135: Track uses of "TODO" tags
+# (TODO is the team's normal way to mark deferred work in code)
+dotnet_diagnostic.S1135.severity = none
+
 # Test projects: documentation not required (test names are self-documenting)
 [**/test/**/*.cs]
 


### PR DESCRIPTION
## Summary

SonarCloud reports **2,177** issues on `Authorization_AccessManagement` and **371** on `Authorization_Authorization`. Most of that volume is concentrated in a handful of high-noise rules (duplicate strings, commented-out code, unused locals, "should be static") with a real-but-small layer of bug-class defects underneath (null deref, logging-template mismatches, virtual calls in constructors).

Without a documented stance on which rules matter, every Sonar cleanup PR ends up debating "is this rule even worth fixing" rule-by-rule. This PR triages the top ~35 rules by occurrence (covers >90% of issues across both verticals) into three severity buckets in `.editorconfig`, mirroring the pattern already in place for `SA1117` / `SA1316` / `SA1600` / `CA1822` / `VSTHRD200` / `FAA0002` / `SA1001`.

**No code changes.** Pure policy. Each non-obvious choice is annotated in the file so the rationale is co-located with the rule rather than buried in PR history.

## Why no `error` severities

The first revision of this PR set bug-class rules (S2259, S6678, S6674, S2955, S3265, S1699, S3949, S2583) to `error`. That would fail every CI build going through `dotnet-sonarscanner` until the ~222 existing violations were cleared — blocking the whole team while sweep PRs landed.

Bug-class rules are at `warning` instead. They still surface in build output and SonarCloud's quality gate still enforces them on new code at PR time. Each followup sweep PR (one rule per PR, mechanical fix of every occurrence) flips its rule's severity from `warning` to `error` in the same commit, so enforcement tightens gradually as the existing violations are cleared instead of switching on top-down.

## Severity buckets

**`warning` — bug-class defects + mechanical cleanups (visible in build, SonarCloud quality gate enforces on new code)**

Bug-class (promote to `error` per-rule once cleared):
| Rule | Existing count | What it flags |
|---|---:|---|
| S2259 | 17 | Null pointer dereference |
| S6678 | 112 | Logging template casing / placeholder mismatches |
| S6674 | 12 | Logging template/arg count mismatch |
| S2955 | 4 | `null` comparison on unconstrained generic |
| S3265 | 58 | Bitwise op on non-`[Flags]` enum |
| S1699 | 17 | Virtual member call in constructor |
| S3949 | 1 | Integer overflow |
| S2583 | 1 | Conditional always true/false |

Mechanical cleanups (bulk PRs unblock these):
S1192 (duplicate strings), S125 (commented-out code), S1481 (unused locals), S1144 (unused private members), S2325 (should be static), S1854 (dead stores), S1118, S2094, S1006, S2589, S927, S2479, S3358, S6580, S6664, S101, S2139, S1155, S6960, S3236, S1125, S2292.

**`suggestion` — IDE nudge only**

S3776 (cognitive complexity — refactor case-by-case, not bundleable), S107 (too many parameters — DI ctors regularly exceed), S112 (generic exceptions — sometimes pragmatic), S3267, S1066, S3878, S6608, S6966, S6672, S1133, S1172, S4136.

**`none` — accepted convention**

S1135 (TODO comments — team's normal way to mark deferred work).

## Where this takes effect

`.editorconfig` is consulted by **SonarLint** in the IDE and by **`dotnet-sonarscanner`** in CI (which loads the `SonarAnalyzer.CSharp` analyzer). Neither is in the local `dotnet build` path, so this PR doesn't change `dotnet build` warning output. It does change:

- IDE squiggle severity for everyone running SonarLint.
- CI Sonar scan results — `none` rules stop reporting; `warning` rules go through SonarCloud's quality gate (which is set up to fail on new issues on changed code).

## Tech-lead review callouts

A few choices are judgment calls. Worth eyeballing before merge:

- **S112** (generic `Exception` thrown / caught, 178 instances) → `suggestion`. Cleaner would be `warning`, but middleware / fallback paths legitimately use `Exception` and forcing typed exceptions everywhere is a bigger design conversation. Suggestion preserves the IDE nudge without flooding build output.
- **S1135** (TODO tags) → `none`. Different teams treat TODOs differently; if you'd prefer them to surface, change to `suggestion` or `warning` — the file is one-line edits per rule.
- **S3776** (cognitive complexity) → `suggestion`. Each fix is a thoughtful refactor, not bundleable into mechanical sweeps. If you want them visible in build output to keep pressure on, flip to `warning`.
- **S6664** (compile-time logging source generators) → `warning`. Real perf/allocation win in hot paths but pervasive ripple if enforced across the whole logging surface. Fine to downgrade if the migration scope feels too big.

## Followups unblocked by this PR

Each becomes a focused single-rule sweep PR with mechanical changes, easy to review. Bug-class sweeps additionally flip the rule's severity from `warning` to `error` in the same commit:

- **S125** (78) — delete commented-out code
- **S1481** (64) — drop unused locals
- **S2325** (98) — apply `static` modifier
- **S6678** + **S6674** (124 combined) — fix logging-template mismatches (highest-value bug rule)
- **S1192** (372) — extract duplicate strings to constants (split per project)
- **S2259** + **S2955** (21) — null-deref / null-compare bugs sweep

## Test plan

- [x] `dotnet build src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement` — 0 errors, 38 unchanged pre-existing warnings (SonarAnalyzer isn't in the local build path).
- [ ] CI Sonar scan after merge will reflect the new severity surface; existing violations stay reported as `warning` (don't block CI), `none` rules stop reporting entirely.

Closes #3072.