### PR TITLE
fix(authorization): clear S6674 logger template/arg mismatches

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -69,8 +69,9 @@ dotnet_diagnostic.S2259.severity = warning
 dotnet_diagnostic.S6678.severity = warning
 
 # S6674: Logger arguments should match the placeholders in the template
-# (12 existing instances)
-dotnet_diagnostic.S6674.severity = warning
+# (cleared in the sweep that introduced this `error` severity; any new
+# violation is a regression that should fail CI's Sonar scan)
+dotnet_diagnostic.S6674.severity = error
 
 # S2955: Generic parameters not constrained to reference types should not be
 # compared to "null" (silent runtime mismatch; 4 existing instances)

--- a/.editorconfig
+++ b/.editorconfig
@@ -48,17 +48,18 @@ dotnet_diagnostic.CA1822.severity = none
 #   suggestion — IDE-only nudge; doesn't add to build noise
 #   none       — accepted convention / false-positive-prone for this codebase
 #
-# `error` severity is intentionally NOT used here. With dotnet-sonarscanner
-# loading these analyzers in CI, an `error` on a rule that fires on existing
-# code would fail every PR's build until the underlying violations are
-# cleared — blocking the whole team. Each followup sweep PR (one rule per PR,
-# mechanical fix of every occurrence) flips its rule from `warning` to
-# `error` in the same commit so enforcement tightens gradually instead of
-# being switched on top-down.
+# `error` severity is intentionally not used here. The longer-term plan is
+# to curate the SonarCloud ruleset itself (quality profile, server-side) so
+# the rules surfacing in this file are the ones the team has agreed to
+# enforce, rather than escalating individual rules to `error` from the
+# client side. Sweep PRs that clear a rule's existing violations leave the
+# severity here at whatever this map already set — they don't promote to
+# `error`. Strict CI enforcement of any given rule belongs in the
+# SonarCloud quality profile.
 # ----------------------------------------------------------------------------
 
-# --- Bug-class rules (warning for now — promote to error per-rule once the
-#     existing violations are cleared in a sweep PR) ---
+# --- Bug-class rules (each cleared by per-rule sweep PRs; severity stays
+#     here, ruleset curation happens server-side) ---
 
 # S2259: Null pointers should not be dereferenced (17 existing instances)
 dotnet_diagnostic.S2259.severity = warning
@@ -69,9 +70,9 @@ dotnet_diagnostic.S2259.severity = warning
 dotnet_diagnostic.S6678.severity = warning
 
 # S6674: Logger arguments should match the placeholders in the template
-# (cleared in the sweep that introduced this `error` severity; any new
-# violation is a regression that should fail CI's Sonar scan)
-dotnet_diagnostic.S6674.severity = error
+# (cleared by the sweep in #3077; severity stays at `warning` per the
+# convention at the top of this section)
+dotnet_diagnostic.S6674.severity = warning
 
 # S2955: Generic parameters not constrained to reference types should not be
 # compared to "null" (silent runtime mismatch; 4 existing instances)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyAdministrationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyAdministrationPoint.cs
@@ -734,7 +734,7 @@ namespace Altinn.AccessManagement.Core.Services
                     Response httpResponse = blobResponse.GetRawResponse();
                     if (httpResponse.Status != (int)HttpStatusCode.Created)
                     {
-                        _logger.LogError("Writing of delegation policy at path: {policyPath} failed. Response Status Code:\n{httpResponse.Status}. Response Reason Phrase:\n{httpResponse.ReasonPhrase}", policyPath, httpResponse.Status, httpResponse.ReasonPhrase);
+                        _logger.LogError("Writing of delegation policy at path: {PolicyPath} failed. Response Status Code:\n{HttpStatus}. Response Reason Phrase:\n{HttpReasonPhrase}", policyPath, httpResponse.Status, httpResponse.ReasonPhrase);
                         return false;
                     }
 
@@ -928,7 +928,7 @@ namespace Altinn.AccessManagement.Core.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Not possible to build policy path for: {resourceId} CoveredBy: {coveredBy} OfferedBy: {policyToDelete.PolicyMatch.OfferedByPartyId}", resourceId, coveredBy, policyToDelete.PolicyMatch.OfferedByPartyId);
+                _logger.LogError(ex, "Not possible to build policy path for: {ResourceId} CoveredBy: {CoveredBy} OfferedBy: {OfferedByPartyId}", resourceId, coveredBy, policyToDelete.PolicyMatch.OfferedByPartyId);
                 return null;
             }
 
@@ -952,7 +952,7 @@ namespace Altinn.AccessManagement.Core.Services
 
                 if (currentChange.DelegationChangeType == DelegationChangeType.RevokeLast)
                 {
-                    _logger.LogWarning("The policy is already deleted for: {resourceId} CoveredBy: {coveredBy} OfferedBy: {policyToDelete.PolicyMatch.OfferedByPartyId}", resourceId, coveredBy, policyToDelete.PolicyMatch.OfferedByPartyId);
+                    _logger.LogWarning("The policy is already deleted for: {ResourceId} CoveredBy: {CoveredBy} OfferedBy: {OfferedByPartyId}", resourceId, coveredBy, policyToDelete.PolicyMatch.OfferedByPartyId);
                     return null;
                 }
 
@@ -1048,7 +1048,7 @@ namespace Altinn.AccessManagement.Core.Services
             catch (Exception ex)
             {
                 string rulesToDeleteString = string.Join(", ", rulesToDelete.RuleIds);
-                _logger.LogError(ex, "Not possible to build policy path for: {resourceId} CoveredBy: {coveredBy} OfferedBy: {policyToDelete.PolicyMatch.OfferedByPartyId} RuleIds: {rulesToDeleteString}", resourceId, coveredBy, rulesToDelete.PolicyMatch.OfferedByPartyId, rulesToDeleteString);
+                _logger.LogError(ex, "Not possible to build policy path for: {ResourceId} CoveredBy: {CoveredBy} OfferedBy: {OfferedByPartyId} RuleIds: {RuleIds}", resourceId, coveredBy, rulesToDelete.PolicyMatch.OfferedByPartyId, rulesToDeleteString);
                 return null;
             }
 

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/PartiesWrapper.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/PartiesWrapper.cs
@@ -79,7 +79,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     return JsonConvert.DeserializeObject<List<int>>(responseBody);
                 }
 
-                _logger.LogError("SBL-Bridge // PartiesWrapper // partieswithkeyroleaccess // Failed // Unexpected HttpStatusCode: {response.StatusCode}\n {responseBody}", response.StatusCode, responseBody);
+                _logger.LogError("SBL-Bridge // PartiesWrapper // partieswithkeyroleaccess // Failed // Unexpected HttpStatusCode: {StatusCode}\n {ResponseBody}", response.StatusCode, responseBody);
             }
             catch (Exception ex)
             {
@@ -112,7 +112,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     return JsonConvert.DeserializeObject<List<MainUnit>>(responseBody);
                 }
 
-                _logger.LogError("SBL-Bridge // PartiesWrapper // partyparents // Failed // Unexpected HttpStatusCode: {response.StatusCode}\n {responseBody}", response.StatusCode, responseBody);
+                _logger.LogError("SBL-Bridge // PartiesWrapper // partyparents // Failed // Unexpected HttpStatusCode: {StatusCode}\n {ResponseBody}", response.StatusCode, responseBody);
             }
             catch (Exception ex)
             {

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/PolicyAdministrationPoint.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/PolicyAdministrationPoint.cs
@@ -238,7 +238,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     Response httpResponse = blobResponse.GetRawResponse();
                     if (httpResponse.Status != (int)HttpStatusCode.Created)
                     {
-                        _logger.LogError("Writing of delegation policy at path: {policyPath} failed. Response Status Code:\n{httpResponse.Status}. Response Reason Phrase:\n{httpResponse.ReasonPhrase}", policyPath, httpResponse.Status, httpResponse.ReasonPhrase);
+                        _logger.LogError("Writing of delegation policy at path: {PolicyPath} failed. Response Status Code:\n{HttpStatus}. Response Reason Phrase:\n{HttpReasonPhrase}", policyPath, httpResponse.Status, httpResponse.ReasonPhrase);
                         return false;
                     }
 
@@ -402,7 +402,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Not possible to build policy path App: {org}/{app} CoveredBy: {coveredBy} OfferedBy: {policyToDelete.PolicyMatch.OfferedByPartyId}", org, app, coveredBy, policyToDelete.PolicyMatch.OfferedByPartyId);
+                _logger.LogError(ex, "Not possible to build policy path App: {Org}/{App} CoveredBy: {CoveredBy} OfferedBy: {OfferedByPartyId}", org, app, coveredBy, policyToDelete.PolicyMatch.OfferedByPartyId);
                 return null;
             }
 
@@ -425,7 +425,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
                 if (currentChange.DelegationChangeType == DelegationChangeType.RevokeLast)
                 {
-                    _logger.LogWarning("The policy is already deleted for App: {org}/{app} CoveredBy: {coveredBy} OfferedBy: {policyToDelete.PolicyMatch.OfferedByPartyId}", org, app, coveredBy, policyToDelete.PolicyMatch.OfferedByPartyId);
+                    _logger.LogWarning("The policy is already deleted for App: {Org}/{App} CoveredBy: {CoveredBy} OfferedBy: {OfferedByPartyId}", org, app, coveredBy, policyToDelete.PolicyMatch.OfferedByPartyId);
                     return null;
                 }
 
@@ -508,7 +508,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             catch (Exception ex)
             {
                 string rulesToDeleteString = string.Join(", ", rulesToDelete.RuleIds);
-                _logger.LogError(ex, "Not possible to build policy path App: {org}/{app} CoveredBy: {coveredBy} OfferedBy: {policyToDelete.PolicyMatch.OfferedByPartyId} RuleIds: {rulesToDeleteString}", org, app, coveredBy, rulesToDelete.PolicyMatch.OfferedByPartyId, rulesToDeleteString);
+                _logger.LogError(ex, "Not possible to build policy path App: {Org}/{App} CoveredBy: {CoveredBy} OfferedBy: {OfferedByPartyId} RuleIds: {RuleIds}", org, app, coveredBy, rulesToDelete.PolicyMatch.OfferedByPartyId, rulesToDeleteString);
                 return null;
             }
 


### PR DESCRIPTION
## Summary

First per-rule sweep enabled by the severity triage in #3074. SonarCloud flags 12 instances of `csharpsquid:S6674` ("Logger arguments should match the placeholders in the template") across both verticals — all of them are dotted-property placeholder names like `{response.StatusCode}` or `{policyToDelete.PolicyMatch.OfferedByPartyId}` that `Microsoft.Extensions.Logging` parses as the whole literal string. Result: structured-log sinks see an ugly key (`response.StatusCode`) instead of the intended short name (`StatusCode`).

Six distinct logger calls across three files:

| File | Line | Fix shape |
|---|---:|---|
| `Authorization/Services/Implementation/PartiesWrapper.cs` | 82 | `{response.StatusCode}\n {responseBody}` → `{StatusCode}\n {ResponseBody}` |
| `Authorization/Services/Implementation/PartiesWrapper.cs` | 115 | same as :82 |
| `Authorization/Services/Implementation/PolicyAdministrationPoint.cs` | 241 | `{policyPath}` / `{httpResponse.Status}` / `{httpResponse.ReasonPhrase}` → `{PolicyPath}` / `{HttpStatus}` / `{HttpReasonPhrase}` |
| `Authorization/Services/Implementation/PolicyAdministrationPoint.cs` | 405 / 428 / 511 | `{org}/{app}/{coveredBy}/{policyToDelete.PolicyMatch.OfferedByPartyId}` (+ `{rulesToDeleteString}` on 511) PascalCase'd |
| `AccessManagement.Core/Services/PolicyAdministrationPoint.cs` | 737 | same as Auth :241 |
| `AccessManagement.Core/Services/PolicyAdministrationPoint.cs` | 931 / 955 / 1051 | `{resourceId}/{coveredBy}/{policyToDelete.PolicyMatch.OfferedByPartyId}` (+ `{rulesToDeleteString}` on 1051) PascalCase'd |

Args stay positional. Lowercase placeholders co-located on the same lines (which would otherwise fire S6678) are cleaned up incidentally — no scope creep.

## Severity stays at `warning`

The first revision of this PR also flipped `dotnet_diagnostic.S6674.severity` from `warning` to `error` in `.editorconfig`. That's been reverted: stricter CI enforcement of individual Sonar rules will land via the SonarCloud quality profile (server-side ruleset curation), not by promoting individual rules to `error` from `.editorconfig`. The convention block at the top of the SonarAnalyzer section now reflects that direction.

## Test plan

- [x] `dotnet build` clean on both verticals (Authorization 3 warnings, AccessManagement 38 — same pre-existing surface as origin/main).
- [x] `dotnet test src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests` — 402 passed + 3 skipped (Docker-down baseline; integration tests skip cleanly).
- [x] Final grep confirms no remaining dotted-property placeholders in `_logger.Log*(...)` calls anywhere in `src/apps/Altinn.Authorization/src/` or `src/apps/Altinn.AccessManagement/src/`.
- [ ] CI Sonar scan after merge: `S6674` count goes 12 → 0.

## Note on the structured-log impact

These keys ship to Application Insights / Sonar log search. The change renames them — an ops dashboard or log-search alert keyed on `response.StatusCode` (with the dot) would stop matching after this lands. None of the touched logger calls are in production hot paths (all are error/warning messages on failure paths), but worth flagging if alerts exist on those literal key names.

Closes #3076.