### PR TITLE
bugfix: connection query to others does not take include-filters into account

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
@@ -925,7 +925,7 @@ public partial class ConnectionService(
         };
 
         var connections = await connectionQuery.GetConnectionsAsync(filter, direction, true, cancellationToken);
-        return connections.GroupBy(r => r.RoleId).Select(connection =>
+        return connections.Where(c => c.AssignmentId.HasValue).GroupBy(r => r.RoleId).Select(connection =>
         {
             var role = connection.First().Role;
             return new RolePermissionDto

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -705,7 +705,7 @@ public class ConnectionQuery(AppDbContext db)
             };
 
         /*
-        Combine main and subunit assignments based on filter request
+        Combine direct and mainunit assignments based on filter request
         */
         var allAssignments = filter.IncludeMainUnitConnections ? direct.Union(mainAssignments) : direct;
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -778,18 +778,18 @@ public class ConnectionQuery(AppDbContext db)
         /*
         Combine everything
         */
-        IQueryable<ConnectionQueryBaseRecord> allCombinded = allAssignments.Union(roleMapAssignments);
+        IQueryable<ConnectionQueryBaseRecord> allCombined = allAssignments.Union(roleMapAssignments);
         if (filter.IncludeDelegation)
         {
-            allCombinded = allCombinded.Union(clientDelegations);
+            allCombined = allCombined.Union(clientDelegations);
         }
 
         if (filter.IncludeKeyRole)
         {
-            allCombinded = allCombinded.Union(keyRoleAssignments);
+            allCombined = allCombined.Union(keyRoleAssignments);
         }
 
-        return allCombinded
+        return allCombined
             .ToIdContains(toSet)
             .ViaIdContains(viaSet)
             .ViaRoleIdContains(viaRoleSet)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -705,12 +705,12 @@ public class ConnectionQuery(AppDbContext db)
             };
 
         /*
-        Combine main and subunit assignments 
+        Combine main and subunit assignments based on filter request
         */
-        var allAssignments = direct.Union(mainAssignments);
+        var allAssignments = filter.IncludeMainUnitConnections ? direct.Union(mainAssignments) : direct;
 
         /*
-        Add RoleMpa roles to allAssignments 
+        Add RoleMap roles to allAssignments 
         */
         var roleMapAssignments =
            from assignment in allAssignments
@@ -733,7 +733,7 @@ public class ConnectionQuery(AppDbContext db)
         /*
         Add Delegations from AllAssignments
         */
-        var directDelegations =
+        var clientDelegations =
            from delegation in db.Delegations
            join fromAssignment in allAssignments on delegation.FromId equals fromAssignment.AssignmentId
            join toAssignment in db.Assignments.WhereIf(!FeatureFlags.UseInstanceDelegationEF, t => t.Audit_ChangedBySystem != SystemEntityConstants.InstanceRightImportSystem) on delegation.ToId equals toAssignment.Id
@@ -778,10 +778,18 @@ public class ConnectionQuery(AppDbContext db)
         /*
         Combine everything
         */
-        return allAssignments
-            .Union(roleMapAssignments)
-            .Union(directDelegations)
-            .Union(keyRoleAssignments)
+        IQueryable<ConnectionQueryBaseRecord> allCombinded = allAssignments.Union(roleMapAssignments);
+        if (filter.IncludeDelegation)
+        {
+            allCombinded = allCombinded.Union(clientDelegations);
+        }
+
+        if (filter.IncludeKeyRole)
+        {
+            allCombinded = allCombinded.Union(keyRoleAssignments);
+        }
+
+        return allCombinded
             .ToIdContains(toSet)
             .ViaIdContains(viaSet)
             .ViaRoleIdContains(viaRoleSet)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This makes GET enduser/connections/roles which has includeDelegations=false to still include client-roles as if the agent-user has these roles directly for the client.

Also, for good measure, added Where(c => c.AssignmentId.HasValue) on connection result which would also exclude delegations.


## Related Issue(s)
- #3075

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

