### PR TITLE
fix: PascalCase logger placeholders across both verticals (S6678)

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/MaskinportenSchemaService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/MaskinportenSchemaService.cs
@@ -170,7 +170,7 @@ namespace Altinn.AccessManagement.Core.Services
             else if (delegationResult.Any(r => r.CreatedSuccessfully))
             {
                 // Partial delegation of rules should not really be possible. Return success but log error?
-                _logger.LogError("One or more rules could not be delegated.\n{result}", delegationResult);
+                _logger.LogError("One or more rules could not be delegated.\n{Result}", delegationResult);
                 result.Rights = DelegationHelper.GetRightDelegationResultsFromRules(delegationResult);
                 return await Task.FromResult(result);
             }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyAdministrationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyAdministrationPoint.cs
@@ -99,7 +99,7 @@ namespace Altinn.AccessManagement.Core.Services
                         int status = httpResponse.Status;
                         string reasonPhrase = httpResponse.ReasonPhrase;
                         _logger.LogError(
-                            "Writing of delegation policy at path: {policyPath} failed. Response Status Code:\n{status}. Response Reason Phrase:\n{reasonPhrase}",
+                            "Writing of delegation policy at path: {PolicyPath} failed. Response Status Code:\n{Status}. Response Reason Phrase:\n{ReasonPhrase}",
                             policyPath,
                             status,
                             reasonPhrase);
@@ -134,11 +134,11 @@ namespace Altinn.AccessManagement.Core.Services
         {
             if (logAsError)
             {
-                _logger.LogError("Could not acquire blob lease lock on delegation policy at path: {policyPath}", policyPath);
+                _logger.LogError("Could not acquire blob lease lock on delegation policy at path: {PolicyPath}", policyPath);
             }
             else
             {
-                _logger.LogInformation("Could not acquire blob lease lock on delegation policy at path: {policyPath}", policyPath);
+                _logger.LogInformation("Could not acquire blob lease lock on delegation policy at path: {PolicyPath}", policyPath);
             }
         }
 
@@ -173,7 +173,7 @@ namespace Altinn.AccessManagement.Core.Services
                         int status = httpResponse.Status;
                         string reasonPhrase = httpResponse.ReasonPhrase;
                         _logger.LogError(
-                            "Writing of delegation policy at path: {policyPath} failed. Response Status Code:\n{status}. Response Reason Phrase:\n{reasonPhrase}",
+                            "Writing of delegation policy at path: {PolicyPath} failed. Response Status Code:\n{Status}. Response Reason Phrase:\n{ReasonPhrase}",
                             policyPath,
                             status,
                             reasonPhrase);
@@ -223,7 +223,7 @@ namespace Altinn.AccessManagement.Core.Services
                 // This means that the current version of the root blob is no longer in sync with changes in authorization postgresql delegation.delegatedpolicy table.
                 // The root blob is in effect orphaned/ignored as the delegation policies are always to be read by version, and will be overritten by the next delegation change.
                 _logger.LogError(
-                    "Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {policyPath}",
+                    "Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {PolicyPath}",
                     policyPath);
                 return false;
             }
@@ -331,7 +331,7 @@ namespace Altinn.AccessManagement.Core.Services
                 {
                     _logger.LogError(
                         ex,
-                        "An exception occured while processing authorization rules for delegation on delegation policy path: {path}",
+                        "An exception occured while processing authorization rules for delegation on delegation policy path: {Path}",
                         path);
                 }
 
@@ -351,7 +351,7 @@ namespace Altinn.AccessManagement.Core.Services
             else
             {
                 string unsortablesJson = JsonSerializer.Serialize(rules);
-                _logger.LogError("One or more rules could not be processed because of incomplete input:\n{unsortablesJson}", unsortablesJson);
+                _logger.LogError("One or more rules could not be processed because of incomplete input:\n{UnsortablesJson}", unsortablesJson);
             }
 
             return rules;
@@ -383,12 +383,12 @@ namespace Altinn.AccessManagement.Core.Services
 
                 if (validPath)
                 {
-                    _logger.LogError(ex, "An exception occured while processing authorization rules for delegation on delegation policy path: {path}", path);
+                    _logger.LogError(ex, "An exception occured while processing authorization rules for delegation on delegation policy path: {Path}", path);
                 }
                 else
                 {
                     string unsortablesJson = JsonSerializer.Serialize(rules);
-                    _logger.LogError("One or more rules could not be processed because of incomplete input:\n{unsortablesJson}", unsortablesJson);
+                    _logger.LogError("One or more rules could not be processed because of incomplete input:\n{UnsortablesJson}", unsortablesJson);
                 }
             }
 
@@ -421,7 +421,7 @@ namespace Altinn.AccessManagement.Core.Services
             {
                 string resourceId = rights[0].ResourceId;
                 string instanceId = rights[0].InstanceId;
-                _logger.LogError(e, "One or more rules could not be processed when writing policy files ResourceId: {resourceId}, InstanceId: {instanceId}", resourceId, instanceId);
+                _logger.LogError(e, "One or more rules could not be processed when writing policy files ResourceId: {ResourceId}, InstanceId: {InstanceId}", resourceId, instanceId);
             }
 
             foreach (InstanceRight rules in rights)
@@ -487,7 +487,7 @@ namespace Altinn.AccessManagement.Core.Services
                             int status = httpResponse.Status;
                             string reasonPhrase = httpResponse.ReasonPhrase;
                             _logger.LogError(
-                                "Writing of delegation policy at path: {policyPath} failed. Response Status Code:\n{status}. Response Reason Phrase:\n{reasonPhrase}",
+                                "Writing of delegation policy at path: {PolicyPath} failed. Response Status Code:\n{Status}. Response Reason Phrase:\n{ReasonPhrase}",
                                 currentPolicyWrite.PolicyPath,
                                 status,
                                 reasonPhrase);
@@ -532,7 +532,7 @@ namespace Altinn.AccessManagement.Core.Services
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "An exception occured while processing authorization rules for delegation on delegation policy path: {delegationPolicypath}", delegationPolicypath);
+                    _logger.LogError(ex, "An exception occured while processing authorization rules for delegation on delegation policy path: {DelegationPolicypath}", delegationPolicypath);
                 }
 
                 foreach (Rule rule in delegationDict[delegationPolicypath])
@@ -554,7 +554,7 @@ namespace Altinn.AccessManagement.Core.Services
             if (unsortables.Count > 0)
             {
                 string unsortablesJson = JsonSerializer.Serialize(unsortables);
-                _logger.LogError("One or more rules could not be processed because of incomplete input:\n{unsortablesJson}", unsortablesJson);
+                _logger.LogError("One or more rules could not be processed because of incomplete input:\n{UnsortablesJson}", unsortablesJson);
                 result.AddRange(unsortables);
             }
 
@@ -584,14 +584,14 @@ namespace Altinn.AccessManagement.Core.Services
             var policyClient = _policyFactory.Create(policyPath);
             if (!await policyClient.PolicyExistsAsync(cancellationToken))
             {
-                _logger.LogWarning("No blob was found for the expected path: {policyPath} this must be removed without upading the database", policyPath);
+                _logger.LogWarning("No blob was found for the expected path: {PolicyPath} this must be removed without upading the database", policyPath);
                 return null;
             }
 
             string leaseId = await policyClient.TryAcquireBlobLease(cancellationToken);
             if (leaseId == null)
             {
-                _logger.LogError("Could not acquire blob lease on delegation policy at path: {policyPath}", policyPath);
+                _logger.LogError("Could not acquire blob lease on delegation policy at path: {PolicyPath}", policyPath);
                 return null;
             }
 
@@ -608,7 +608,7 @@ namespace Altinn.AccessManagement.Core.Services
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Writing of delegation policy at path: {policyPath} failed. Is delegation blob storage account alive and well?}", policyPath);
+                    _logger.LogError(ex, "Writing of delegation policy at path: {PolicyPath} failed. Is delegation blob storage account alive and well?}", policyPath);
                     return null;
                 }
 
@@ -616,7 +616,7 @@ namespace Altinn.AccessManagement.Core.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An exception occured while processing rules to delete in policy: {policyPath}", policyPath);
+                _logger.LogError(ex, "An exception occured while processing rules to delete in policy: {PolicyPath}", policyPath);
                 return null;
             }
             finally
@@ -647,7 +647,7 @@ namespace Altinn.AccessManagement.Core.Services
             if (!DelegationHelper.TryGetDelegationParamsFromRule(rules[0], out ResourceAttributeMatchType resourceMatchType, out string resourceId, out string org, out string app, out int offeredByPartyId, out Guid? fromUuid, out UuidType fromUuidType, out Guid? toUuid, out UuidType toUuidType, out int? coveredByPartyId, out int? coveredByUserId, out int? delegatedByUserId, out int? delegatedByPartyId, out Guid? performedByUuid, out UuidType performedByUuidType, out DateTime delegatedDateTime)
                 || resourceMatchType == ResourceAttributeMatchType.None)
             {
-                _logger.LogWarning("This should not happen. Incomplete rule model received for delegation to delegation policy at: {policyPath}. Incomplete model should have been returned in unsortable rule set by TryWriteDelegationPolicyRules. DelegationHelper.SortRulesByDelegationPolicyPath might be broken.", policyPath);
+                _logger.LogWarning("This should not happen. Incomplete rule model received for delegation to delegation policy at: {PolicyPath}. Incomplete model should have been returned in unsortable rule set by TryWriteDelegationPolicyRules. DelegationHelper.SortRulesByDelegationPolicyPath might be broken.", policyPath);
                 return false;
             }
 
@@ -656,7 +656,7 @@ namespace Altinn.AccessManagement.Core.Services
                 XacmlPolicy resourcePolicy = await _prp.GetPolicyAsync(resourceId, cancellationToken);
                 if (resourcePolicy == null)
                 {
-                    _logger.LogWarning("No valid resource policy found for delegation policy path: {policyPath}", policyPath);
+                    _logger.LogWarning("No valid resource policy found for delegation policy path: {PolicyPath}", policyPath);
                     return false;
                 }
 
@@ -664,7 +664,7 @@ namespace Altinn.AccessManagement.Core.Services
                 {
                     if (!DelegationHelper.PolicyContainsMatchingRule(resourcePolicy, rule))
                     {
-                        _logger.LogWarning("Matching rule not found in resource policy. Action might not exist for Resource, or Resource itself might not exist. Delegation policy path: {policyPath}. Rule: {rule}", policyPath, rule);
+                        _logger.LogWarning("Matching rule not found in resource policy. Action might not exist for Resource, or Resource itself might not exist. Delegation policy path: {PolicyPath}. Rule: {Rule}", policyPath, rule);
                         return false;
                     }
                 }
@@ -674,7 +674,7 @@ namespace Altinn.AccessManagement.Core.Services
                 XacmlPolicy appPolicy = await _prp.GetPolicyAsync(org, app, cancellationToken);
                 if (appPolicy == null)
                 {
-                    _logger.LogWarning("No valid App policy found for delegation policy path: {policyPath}", policyPath);
+                    _logger.LogWarning("No valid App policy found for delegation policy path: {PolicyPath}", policyPath);
                     return false;
                 }
 
@@ -682,7 +682,7 @@ namespace Altinn.AccessManagement.Core.Services
                 {
                     if (!DelegationHelper.PolicyContainsMatchingRule(appPolicy, rule))
                     {
-                        _logger.LogWarning("Matching rule not found in app policy. Action might not exist for Resource, or Resource itself might not exist. Delegation policy path: {policyPath}. Rule: {rule}", policyPath, rule);
+                        _logger.LogWarning("Matching rule not found in app policy. Action might not exist for Resource, or Resource itself might not exist. Delegation policy path: {PolicyPath}. Rule: {Rule}", policyPath, rule);
                         return false;
                     }
                 }
@@ -765,7 +765,7 @@ namespace Altinn.AccessManagement.Core.Services
                         // Comment:
                         // This means that the current version of the root blob is no longer in sync with changes in authorization postgresql delegation.delegatedpolicy table.
                         // The root blob is in effect orphaned/ignored as the delegation policies are always to be read by version, and will be overritten by the next delegation change.
-                        _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {policyPath}", policyPath);
+                        _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {PolicyPath}", policyPath);
                         return false;
                     }
 
@@ -777,7 +777,7 @@ namespace Altinn.AccessManagement.Core.Services
                         }
                         catch (Exception ex)
                         {
-                            _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "AddRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
+                            _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "AddRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {Change}", change);
                         }
                     }
 
@@ -817,7 +817,7 @@ namespace Altinn.AccessManagement.Core.Services
                 XacmlPolicy existingDelegationPolicy = null;
                 if (currentChange.DelegationChangeType == DelegationChangeType.RevokeLast)
                 {
-                    _logger.LogWarning("The policy is already deleted for: {resourceId} CoveredBy: {coveredBy} OfferedBy: {offeredBy}", resourceId, coveredBy, offeredBy);
+                    _logger.LogWarning("The policy is already deleted for: {ResourceId} CoveredBy: {CoveredBy} OfferedBy: {OfferedBy}", resourceId, coveredBy, offeredBy);
                     return null;
                 }
 
@@ -828,7 +828,7 @@ namespace Altinn.AccessManagement.Core.Services
                     XacmlRule xacmlRuleToRemove = existingDelegationPolicy.Rules.FirstOrDefault(r => r.RuleId == ruleId);
                     if (xacmlRuleToRemove == null)
                     {
-                        _logger.LogWarning("The rule with id: {ruleId} does not exist in policy with path: {policyPath}", ruleId, policyPath);
+                        _logger.LogWarning("The rule with id: {RuleId} does not exist in policy with path: {PolicyPath}", ruleId, policyPath);
                         continue;
                     }
 
@@ -851,7 +851,7 @@ namespace Altinn.AccessManagement.Core.Services
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Writing of delegation policy at path: {policyPath} failed. Is delegation blob storage account alive and well?", policyPath);
+                        _logger.LogError(ex, "Writing of delegation policy at path: {PolicyPath} failed. Is delegation blob storage account alive and well?", policyPath);
                         return null;
                     }
 
@@ -880,7 +880,7 @@ namespace Altinn.AccessManagement.Core.Services
                         // Comment:
                         // This means that the current version of the root blob is no longer in sync with changes in authorization postgresql delegation.delegatedpolicy table.
                         // The root blob is in effect orphaned/ignored as the delegation policies are always to be read by version, and will be overritten by the next delegation change.
-                        _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {policyPath}. is authorization postgresql database alive and well?", policyPath);
+                        _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {PolicyPath}. is authorization postgresql database alive and well?", policyPath);
                         return null;
                     }
 
@@ -892,14 +892,14 @@ namespace Altinn.AccessManagement.Core.Services
                         }
                         catch (Exception ex)
                         {
-                            _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "DeleteRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
+                            _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "DeleteRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {Change}", change);
                         }
                     }
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An exception occured while processing rules to delete in policy: {policyPath}", policyPath);
+                _logger.LogError(ex, "An exception occured while processing rules to delete in policy: {PolicyPath}", policyPath);
                 return null;
             }
             finally
@@ -935,14 +935,14 @@ namespace Altinn.AccessManagement.Core.Services
             var policyClient = _policyFactory.Create(policyPath);
             if (!await policyClient.PolicyExistsAsync(cancellationToken))
             {
-                _logger.LogWarning("No blob was found for the expected path: {policyPath} this must be removed without upading the database", policyPath);
+                _logger.LogWarning("No blob was found for the expected path: {PolicyPath} this must be removed without upading the database", policyPath);
                 return null;
             }
 
             string leaseId = await policyClient.TryAcquireBlobLease(cancellationToken);
             if (leaseId == null)
             {
-                _logger.LogError("Could not acquire blob lease on delegation policy at path: {policyPath}", policyPath);
+                _logger.LogError("Could not acquire blob lease on delegation policy at path: {PolicyPath}", policyPath);
                 return null;
             }
 
@@ -973,7 +973,7 @@ namespace Altinn.AccessManagement.Core.Services
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Writing of delegation policy at path: {policyPath} failed. Is delegation blob storage account alive and well?}", policyPath);
+                    _logger.LogError(ex, "Writing of delegation policy at path: {PolicyPath} failed. Is delegation blob storage account alive and well?}", policyPath);
                     return null;
                 }
 
@@ -1001,7 +1001,7 @@ namespace Altinn.AccessManagement.Core.Services
                     // Comment:
                     // This means that the current version of the root blob is no longer in sync with changes in authorization postgresql delegation.delegatedpolicy table.
                     // The root blob is in effect orphaned/ignored as the delegation policies are always to be read by version, and will be overritten by the next delegation change.
-                    _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {policyPath}. is authorization postgresql database alive and well?", policyPath);
+                    _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {PolicyPath}. is authorization postgresql database alive and well?", policyPath);
                     return null;
                 }
 
@@ -1013,7 +1013,7 @@ namespace Altinn.AccessManagement.Core.Services
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "DeletePolicy could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
+                        _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "DeletePolicy could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {Change}", change);
                     }
                 }
 
@@ -1021,7 +1021,7 @@ namespace Altinn.AccessManagement.Core.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An exception occured while processing rules to delete in policy: {policyPath}", policyPath);
+                _logger.LogError(ex, "An exception occured while processing rules to delete in policy: {PolicyPath}", policyPath);
                 return null;
             }
             finally
@@ -1055,7 +1055,7 @@ namespace Altinn.AccessManagement.Core.Services
             var policyClient = _policyFactory.Create(policyPath);
             if (!await policyClient.PolicyExistsAsync(cancellationToken))
             {
-                _logger.LogWarning("No blob was found for the expected path: {policyPath} this must be removed without updating the database", policyPath);
+                _logger.LogWarning("No blob was found for the expected path: {PolicyPath} this must be removed without updating the database", policyPath);
                 return null;
             }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/UserProfileLookupService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/UserProfileLookupService.cs
@@ -46,7 +46,7 @@ namespace Altinn.AccessManagement.Core.Services
             if (failedAttempts >= _userProfileLookupSettings.MaximumFailedAttempts)
             {
                 _logger.LogInformation(
-                    "User {userId} has performed too many failed UserProfile lookup attempts.", authnUserId);
+                    "User {UserId} has performed too many failed UserProfile lookup attempts.", authnUserId);
 
                 throw new TooManyFailedLookupsException();
             }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/AccessListAuthorizationClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/AccessListAuthorizationClient.cs
@@ -77,7 +77,7 @@ namespace Altinn.AccessManagement.Integration.Clients
                 else
                 {
                     string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-                    _logger.LogError("AccessManagement // AccessListAuthorizationClient // AuthorizePartyForAccessList  // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+                    _logger.LogError("AccessManagement // AccessListAuthorizationClient // AuthorizePartyForAccessList  // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
                     return new() { Result = AccessListAuthorizationResult.NotAuthorized };
                 }
             }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/Altinn2ConsentClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/Altinn2ConsentClient.cs
@@ -77,7 +77,7 @@ public class Altinn2ConsentClient : IAltinn2ConsentClient
                 return JsonSerializer.Deserialize<List<Guid>>(responseContent, _serializerOptions);
             }
 
-            _logger.LogError("AccessManagement // Altinn2ConsentClient // GetConsent // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+            _logger.LogError("AccessManagement // Altinn2ConsentClient // GetConsent // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
             return null;
         }
         catch (Exception ex)
@@ -107,7 +107,7 @@ public class Altinn2ConsentClient : IAltinn2ConsentClient
                 return altinn2Consents;
             }
 
-            _logger.LogError("AccessManagement // Altinn2ConsentClient // GetConsent // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+            _logger.LogError("AccessManagement // Altinn2ConsentClient // GetConsent // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
             return null;
         }
         catch (Exception ex)
@@ -133,7 +133,7 @@ public class Altinn2ConsentClient : IAltinn2ConsentClient
                 return altinn2ConsentRequest;
             }
 
-            _logger.LogError("AccessManagement // Altinn2ConsentClient // GetConsent // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+            _logger.LogError("AccessManagement // Altinn2ConsentClient // GetConsent // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
             return null;
         }
         catch (Exception ex)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/Altinn2RightsClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/Altinn2RightsClient.cs
@@ -60,7 +60,7 @@ public class Altinn2RightsClient : IAltinn2RightsClient
             return delegationCheckResponse;
         }
 
-        _logger.LogError("AccessManagement // Altinn2RightsClient // PostDelegationCheck // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+        _logger.LogError("AccessManagement // Altinn2RightsClient // PostDelegationCheck // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
         if (response.StatusCode == HttpStatusCode.BadRequest)
         {
             SblValidationProblemResponse validationError = JsonSerializer.Deserialize<SblValidationProblemResponse>(responseContent, _serializerOptions);
@@ -95,7 +95,7 @@ public class Altinn2RightsClient : IAltinn2RightsClient
             return delegationResult;
         }
 
-        _logger.LogError("AccessManagement // Altinn2RightsClient // PostDelegation // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+        _logger.LogError("AccessManagement // Altinn2RightsClient // PostDelegation // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
         if (response.StatusCode == HttpStatusCode.BadRequest)
         {
             SblValidationProblemResponse validationError = JsonSerializer.Deserialize<SblValidationProblemResponse>(responseContent, _serializerOptions);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/AuthenticationClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/AuthenticationClient.cs
@@ -78,7 +78,7 @@ namespace Altinn.AccessManagement.Integration.Clients
                 else
                 {
                     string content = await response.Content.ReadAsStringAsync(cancellationToken);
-                    _logger.LogError("Fetching system user failed with status code: {statusCode}, details: {responseContent}", response.StatusCode, content);
+                    _logger.LogError("Fetching system user failed with status code: {StatusCode}, details: {ResponseContent}", response.StatusCode, content);
                 }
             }
             catch (Exception ex)
@@ -109,7 +109,7 @@ namespace Altinn.AccessManagement.Integration.Clients
                 else
                 {
                     string content = await response.Content.ReadAsStringAsync(cancellationToken);
-                    _logger.LogError("Fetching system user default rights failed with status code: {statusCode}, content: {content}", response.StatusCode, content);
+                    _logger.LogError("Fetching system user default rights failed with status code: {StatusCode}, content: {Content}", response.StatusCode, content);
                 }
             }
             catch (Exception ex)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/PartiesClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/PartiesClient.cs
@@ -75,7 +75,7 @@ public class PartiesClient : IPartiesClient
                 return JsonSerializer.Deserialize<Party>(responseContent, _serializerOptions);
             }
 
-            _logger.LogError("AccessManagement // PartiesClient // GetPartyAsync // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+            _logger.LogError("AccessManagement // PartiesClient // GetPartyAsync // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
             return null;
         }
         catch (Exception ex)
@@ -103,7 +103,7 @@ public class PartiesClient : IPartiesClient
                 return JsonSerializer.Deserialize<List<Party>>(responseContent, _serializerOptions);
             }
 
-            _logger.LogError("AccessManagement // PartiesClient // GetPartiesAsync // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+            _logger.LogError("AccessManagement // PartiesClient // GetPartiesAsync // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
             return new();
         }
         catch (Exception ex)
@@ -131,7 +131,7 @@ public class PartiesClient : IPartiesClient
                 return JsonSerializer.Deserialize<List<Party>>(responseContent, _serializerOptions);
             }
 
-            _logger.LogError("AccessManagement // PartiesClient // GetPartiesAsync // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+            _logger.LogError("AccessManagement // PartiesClient // GetPartiesAsync // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
             return new();
         }
         catch (Exception ex)
@@ -158,7 +158,7 @@ public class PartiesClient : IPartiesClient
                 return JsonSerializer.Deserialize<List<Party>>(responseContent, _serializerOptions);
             }
 
-            _logger.LogError("AccessManagement // PartiesClient // GetPartiesForUserAsync // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+            _logger.LogError("AccessManagement // PartiesClient // GetPartiesForUserAsync // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
             return new();
         }
         catch (Exception ex)
@@ -182,7 +182,7 @@ public class PartiesClient : IPartiesClient
                 return JsonSerializer.Deserialize<List<int>>(responseBody, _serializerOptions);
             }
 
-            _logger.LogError("AccessManagement // PartiesClient // GetKeyRoleParties // Failed // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseBody);
+            _logger.LogError("AccessManagement // PartiesClient // GetKeyRoleParties // Failed // Unexpected HttpStatusCode: {StatusCode}\n {ResponseBody}", response.StatusCode, responseBody);
             return new();
         }
         catch (Exception ex)
@@ -214,7 +214,7 @@ public class PartiesClient : IPartiesClient
                 return JsonSerializer.Deserialize<List<MainUnit>>(responseBody, _serializerOptions);
             }
 
-            _logger.LogError("AccessManagement // PartiesClient // GetMainUnits // Failed // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseBody);
+            _logger.LogError("AccessManagement // PartiesClient // GetMainUnits // Failed // Unexpected HttpStatusCode: {StatusCode}\n {ResponseBody}", response.StatusCode, responseBody);
             return new();
         }
         catch (Exception ex)
@@ -242,7 +242,7 @@ public class PartiesClient : IPartiesClient
                 return JsonSerializer.Deserialize<Party>(responseContent, _serializerOptions);
             }
 
-            _logger.LogError("AccessManagement // PartiesClient // LookupPartyBySSNOrOrgNo // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
+            _logger.LogError("AccessManagement // PartiesClient // LookupPartyBySSNOrOrgNo // Unexpected HttpStatusCode: {StatusCode}\n {ResponseBody}", response.StatusCode, responseContent);
             return null;
         }
         catch (Exception ex)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/ProfileClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/ProfileClient.cs
@@ -57,7 +57,7 @@ namespace Altinn.AccessManagement.Integration.Clients
             if (!response.IsSuccessStatusCode)
             {
                 string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-                _logger.LogError("Getting user profile failed with unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+                _logger.LogError("Getting user profile failed with unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
                 return null;
             }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
@@ -416,7 +416,7 @@ internal static partial class AccessManagementHost
         [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "Creating Altinn host.")]
         internal static partial void CreateAltinnHost(ILogger logger);
 
-        [LoggerMessage(EventId = 1, Level = LogLevel.Warning, Message = "Configuration setting '{field}' is null or empty.")]
+        [LoggerMessage(EventId = 1, Level = LogLevel.Warning, Message = "Configuration setting '{Field}' is null or empty.")]
         internal static partial void ConfigValueIsNullOrEmpty(ILogger logger, string field);
 
         [LoggerMessage(EventId = 2, Level = LogLevel.Debug, Message = "Connection string(s) for pgsql server are missing")]

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/DelegationsController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/DelegationsController.cs
@@ -75,7 +75,7 @@ namespace Altinn.AccessManagement.Controllers
             }
 
             string rulesJson = JsonSerializer.Serialize(rules);
-            _logger.LogInformation("Delegation could not be completed. None of the rules could be processed, indicating invalid or incomplete input:\n{rulesJson}", rulesJson);
+            _logger.LogInformation("Delegation could not be completed. None of the rules could be processed, indicating invalid or incomplete input:\n{RulesJson}", rulesJson);
             return BadRequest("Delegation could not be completed");
         }
 
@@ -172,11 +172,11 @@ namespace Altinn.AccessManagement.Controllers
             if (deletionResultsCount > 0)
             {
                 string deletionResultsSerialized = JsonSerializer.Serialize(deletionResults);
-                _logger.LogInformation("Partial deletion completed deleted {deletionResultsCount} of {ruleCountToDelete}.\n{rulesToDeleteSerialized}\n{deletionResultsSerialized}", deletionResultsCount, ruleCountToDelete, rulesToDeleteSerialized, deletionResultsSerialized);
+                _logger.LogInformation("Partial deletion completed deleted {DeletionResultsCount} of {RuleCountToDelete}.\n{RulesToDeleteSerialized}\n{DeletionResultsSerialized}", deletionResultsCount, ruleCountToDelete, rulesToDeleteSerialized, deletionResultsSerialized);
                 return StatusCode(206, deletionResults);
             }
 
-            _logger.LogInformation("Deletion could not be completed. None of the rules could be processed, indicating invalid or incomplete input:\n{rulesToDeleteSerialized}", rulesToDeleteSerialized);
+            _logger.LogInformation("Deletion could not be completed. None of the rules could be processed, indicating invalid or incomplete input:\n{RulesToDeleteSerialized}", rulesToDeleteSerialized);
             return StatusCode(400, $"Unable to complete deletion");
         }
 
@@ -211,11 +211,11 @@ namespace Altinn.AccessManagement.Controllers
             if (countPolicies > 0)
             {
                 string deletionResultsSerialized = JsonSerializer.Serialize(deletionResults);
-                _logger.LogInformation("Partial deletion completed deleted {countPolicies} of {policiesToDeleteCount}.\n{deletionResultsSerialized}", countPolicies, policiesToDeleteCount, deletionResultsSerialized);
+                _logger.LogInformation("Partial deletion completed deleted {CountPolicies} of {PoliciesToDeleteCount}.\n{DeletionResultsSerialized}", countPolicies, policiesToDeleteCount, deletionResultsSerialized);
                 return StatusCode(206, deletionResults);
             }
 
-            _logger.LogInformation("Deletion could not be completed. None of the rules could be processed, indicating invalid or incomplete input:\n{policiesToDeleteSerialized}", policiesToDeleteSerialized);
+            _logger.LogInformation("Deletion could not be completed. None of the rules could be processed, indicating invalid or incomplete input:\n{PoliciesToDeleteSerialized}", policiesToDeleteSerialized);
             return StatusCode(400, $"Unable to complete deletion");
         }
     }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/MaskinportenSchemaController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/MaskinportenSchemaController.cs
@@ -258,7 +258,7 @@ namespace Altinn.AccessManagement.Controllers
             catch (Exception ex)
             {
                 string errorMessage = ex.Message;
-                _logger.LogError(ex, "Failed to fetch offered delegations, See the error message for more details {errorMessage}", errorMessage);
+                _logger.LogError(ex, "Failed to fetch offered delegations, See the error message for more details {ErrorMessage}", errorMessage);
                 return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext));
             }
         }
@@ -350,7 +350,7 @@ namespace Altinn.AccessManagement.Controllers
             catch (Exception ex)
             {
                 string errorMessage = ex.Message;
-                _logger.LogError(ex, "Failed to fetch received delegations, See the error message for more details {errorMessage}", errorMessage);
+                _logger.LogError(ex, "Failed to fetch received delegations, See the error message for more details {ErrorMessage}", errorMessage);
                 return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext));
             }
         }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/ResourceController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Controllers/ResourceController.cs
@@ -58,7 +58,7 @@ namespace Altinn.AccessManagement.Controllers
             }
 
             string resourcesJson = JsonSerializer.Serialize(resources);
-            _logger.LogInformation("Delegation could not be completed. None of the rules could be processed, indicating invalid or incomplete input:\n{resourcesJson}", resourcesJson);
+            _logger.LogInformation("Delegation could not be completed. None of the rules could be processed, indicating invalid or incomplete input:\n{ResourcesJson}", resourcesJson);
             return BadRequest("Delegation could not be completed");
         }
     }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnAdminRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnAdminRoleSyncService.cs
@@ -107,7 +107,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                             if (revokes == 0)
                             {
                                 _logger.LogWarning(
-                                    "Failed to delete assignmentpackages for FromParty: {FromParty}, ToParty: {ToParty}, PackageUrns: {packageUrn}",
+                                    "Failed to delete assignmentpackages for FromParty: {FromParty}, ToParty: {ToParty}, PackageUrns: {PackageUrn}",
                                     item.FromPartyUuid,
                                     item.ToUserPartyUuid,
                                     string.Join(", ", packageUrns));
@@ -139,7 +139,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                             if (adds.Count == 0)
                             {
                                 _logger.LogWarning(
-                                    "Failed to import delegation for FromParty: {FromParty}, ToParty: {ToParty}, PackageUrns: {packageUrn}",
+                                    "Failed to import delegation for FromParty: {FromParty}, ToParty: {ToParty}, PackageUrns: {PackageUrn}",
                                     item.FromPartyUuid,
                                     item.ToUserPartyUuid,
                                     string.Join(", ", packageUrns));

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnClientRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnClientRoleSyncService.cs
@@ -89,7 +89,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                             if (deleted <= 0)
                             {
                                 _logger.LogWarning(
-                                    "Failed to delete delegation for FromParty: {FromParty}, ToParty: {ToParty}, Facilitator: {Facilitator}, PackageUrn: {packageUrn}",
+                                    "Failed to delete delegation for FromParty: {FromParty}, ToParty: {ToParty}, Facilitator: {Facilitator}, PackageUrn: {PackageUrn}",
                                     item.FromPartyUuid,
                                     item.ToUserPartyUuid,
                                     item.PerformedByPartyUuid,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/BaseSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/BaseSyncService.cs
@@ -13,16 +13,16 @@ public abstract class BaseSyncService { }
 /// </summary>
 public static partial class Log
 {
-    [LoggerMessage(EventId = 11, Level = LogLevel.Information, Message = "Failed to retrieve updated resources from resource register, got {statusCode}")]
+    [LoggerMessage(EventId = 11, Level = LogLevel.Information, Message = "Failed to retrieve updated resources from resource register, got {StatusCode}")]
     internal static partial void UpdatedResourceError(ILogger logger, HttpStatusCode statusCode);
 
-    [LoggerMessage(EventId = 10, Level = LogLevel.Information, Message = "Failed to retrieve service owners from resource register, got {statusCode}")]
+    [LoggerMessage(EventId = 10, Level = LogLevel.Information, Message = "Failed to retrieve service owners from resource register, got {StatusCode}")]
     internal static partial void ServiceOwnerError(ILogger logger, HttpStatusCode statusCode);
 
-    [LoggerMessage(EventId = 9, Level = LogLevel.Information, Message = "Error occured while fetching data from register, got {statusCode}")]
+    [LoggerMessage(EventId = 9, Level = LogLevel.Information, Message = "Error occured while fetching data from register, got {StatusCode}")]
     internal static partial void ResponseError(ILogger logger, HttpStatusCode statusCode);
 
-    [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Processing party with uuid {partyUuid} from register. RetryCount {count}")]
+    [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Processing party with uuid {PartyUuid} from register. RetryCount {Count}")]
     internal static partial void Party(ILogger logger, string partyUuid, int count);
 
     [LoggerMessage(EventId = 1, Level = LogLevel.Error, Message = "An error occured while streaming data from register")]
@@ -40,9 +40,9 @@ public static partial class Log
     [LoggerMessage(EventId = 23, Level = LogLevel.Information, Message = "Quit altinnrole hosted service")]
     internal static partial void QuitAltinnRoleSync(ILogger logger);
 
-    [LoggerMessage(EventId = 4, Level = LogLevel.Information, Message = "Assignment {action} from '{from}' to '{to}' with role '{role}'")]
+    [LoggerMessage(EventId = 4, Level = LogLevel.Information, Message = "Assignment {Action} from '{From}' to '{To}' with role '{Role}'")]
     internal static partial void AssignmentSuccess(ILogger logger, string action, string from, string to, string role);
 
-    [LoggerMessage(EventId = 5, Level = LogLevel.Warning, Message = "Failed to {action} assingment from '{from}' to '{to}' with role '{role}'")]
+    [LoggerMessage(EventId = 5, Level = LogLevel.Warning, Message = "Failed to {Action} assingment from '{From}' to '{To}' with role '{Role}'")]
     internal static partial void AssignmentFailed(ILogger logger, string action, string from, string to, string role);
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/ResourceSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/ResourceSyncService.cs
@@ -321,7 +321,7 @@ public partial class ResourceSyncService : IResourceSyncService
 
     private static partial class Log
     {
-        [LoggerMessage(EventId = 1, Level = LogLevel.Error, Message = "Unable to retrieve resource '{resource}' from the resource registry.")]
+        [LoggerMessage(EventId = 1, Level = LogLevel.Error, Message = "Unable to retrieve resource '{Resource}' from the resource registry.")]
         internal static partial void FailedToGetResource(ILogger logger, string resource);
 
         [LoggerMessage(EventId = 2, Level = LogLevel.Error, Message = "Failed to read stream of updated resources from the resource registry.")]
@@ -330,7 +330,7 @@ public partial class ResourceSyncService : IResourceSyncService
         [LoggerMessage(EventId = 3, Level = LogLevel.Error, Message = "Failed to retrieve list of service owners from the resource registry.")]
         internal static partial void FailedToReadResourceOwners(ILogger logger);
 
-        [LoggerMessage(EventId = 4, Level = LogLevel.Error, Message = "failed to write update subject {subjectUrn} for resource {resourceId} .")]
+        [LoggerMessage(EventId = 4, Level = LogLevel.Error, Message = "failed to write update subject {SubjectUrn} for resource {ResourceId} .")]
         internal static partial void FailedToWriteUpdateSubjectForResource(ILogger logger, Exception ex, string subjectUrn, string resourceId);
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleAppRightSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleAppRightSyncService.cs
@@ -111,7 +111,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                 if (revokes == 0)
                                 {
                                     _logger.LogWarning(
-                                        "Failed to delete assignmentresource for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {resource}",
+                                        "Failed to delete assignmentresource for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {Resource}",
                                         item.FromUuid,
                                         item.ToUuid,
                                         item.ResourceId);
@@ -132,7 +132,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                 if (adds == 0)
                                 {
                                     _logger.LogWarning(
-                                        "Failed to import delegation for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {resource}",
+                                        "Failed to import delegation for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {Resource}",
                                         item.FromUuid,
                                         item.ToUuid,
                                         item.ResourceId);
@@ -241,7 +241,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                         if (revokes == 0)
                         {
                             _logger.LogWarning(
-                                "Failed to delete assignmentresource for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {resource}",
+                                "Failed to delete assignmentresource for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {Resource}",
                                 element.FromUuid,
                                 element.ToUuid,
                                 element.ResourceId);
@@ -262,7 +262,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                         if (adds == 0)
                         {
                             _logger.LogWarning(
-                                "Failed to import delegation for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {resource}",
+                                "Failed to import delegation for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {Resource}",
                                 element.FromUuid,
                                 element.ToUuid,
                                 element.ResourceId);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleResourceRegistryRightSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleResourceRegistryRightSyncService.cs
@@ -111,7 +111,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                 if (revokes == 0)
                                 {
                                     _logger.LogWarning(
-                                        "Failed to delete assignmentresource for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {resource}",
+                                        "Failed to delete assignmentresource for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {Resource}",
                                         item.FromUuid,
                                         item.ToUuid,
                                         item.ResourceId);
@@ -132,7 +132,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                                 if (adds == 0)
                                 {
                                     _logger.LogWarning(
-                                        "Failed to import delegation for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {resource}",
+                                        "Failed to import delegation for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {Resource}",
                                         item.FromUuid,
                                         item.ToUuid,
                                         item.ResourceId);
@@ -241,7 +241,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                         if (revokes == 0)
                         {
                             _logger.LogWarning(
-                                "Failed to delete assignmentresource for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {resource}",
+                                "Failed to delete assignmentresource for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {Resource}",
                                 element.FromUuid,
                                 element.ToUuid,
                                 element.ResourceId);
@@ -262,7 +262,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                         if (adds == 0)
                         {
                             _logger.LogWarning(
-                                "Failed to import delegation for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {resource}",
+                                "Failed to import delegation for FromParty: {FromParty}, ToParty: {ToParty}, Resource: {Resource}",
                                 element.FromUuid,
                                 element.ToUuid,
                                 element.ResourceId);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Extensions/DbAccessHostExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Persistence/Extensions/DbAccessHostExtensions.cs
@@ -206,7 +206,7 @@ public static partial class DbAccessHostExtensions
     /// </summary>
     static partial class Log
     {
-        [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "Configuring {dbtype} database for access management")]
+        [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "Configuring {Dbtype} database for access management")]
         internal static partial void ConfigureDbType(ILogger logger, MgmtDbType dbtype);
 
         [LoggerMessage(EventId = 1, Level = LogLevel.Warning, Message = $"Database is not enabled make sure it's initialized by calling IHostApplicationBuilder.AddAccessMgmtDb.")]

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Clients/EventsQueueClient.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Clients/EventsQueueClient.cs
@@ -168,7 +168,7 @@ namespace Altinn.Platform.Authorization.Clients
 
         private static partial class Log
         {
-            [LoggerMessage(1, LogLevel.Warning, "Authorization event size {size} bytes exceeds maximum allowed size for queue messages.")]
+            [LoggerMessage(1, LogLevel.Warning, "Authorization event size {Size} bytes exceeds maximum allowed size for queue messages.")]
             public static partial void AuthorizationEventTooLarge(ILogger logger, long size);
 
             [LoggerMessage(2, LogLevel.Warning, "Operation was canceled.")]

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
@@ -298,7 +298,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
             .WithMetrics(metrics => metrics
                 .AddAzureMonitorMetricExporter(options => options.ConnectionString = applicationInsightsConnectionString));
 
-        logger.LogInformation("Startup // ApplicationInsightsConnectionString = {applicationInsightsConnectionString}", applicationInsightsConnectionString);
+        logger.LogInformation("Startup // ApplicationInsightsConnectionString = {ApplicationInsightsConnectionString}", applicationInsightsConnectionString);
     }
 
     services.AddSingleton<DecisionTelemetry>();

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/InstanceMetadataRepository.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/InstanceMetadataRepository.cs
@@ -47,7 +47,7 @@ namespace Altinn.Platform.Authorization.Repositories
             else
             {
                 string reason = await response.Content.ReadAsStringAsync();
-                logger.LogError("// InstanceMetadataRepository // GetAuthInfo // Failed to lookup auth info from storage. Response {response}. \n Reason {reason}.", response, reason);
+                logger.LogError("// InstanceMetadataRepository // GetAuthInfo // Failed to lookup auth info from storage. Response {Response}. \n Reason {Reason}.", response, reason);
 
                 throw await PlatformHttpException.CreateAsync(response);
             }

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/PolicyRepository.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Repositories/PolicyRepository.cs
@@ -101,11 +101,11 @@ namespace Altinn.Platform.Authorization.Repositories
             }
             catch (RequestFailedException ex)
             {
-                _logger.LogError(ex, "Failed to acquire blob lease for policy file at {filepath}. RequestFailedException", filepath);
+                _logger.LogError(ex, "Failed to acquire blob lease for policy file at {Filepath}. RequestFailedException", filepath);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to acquire blob lease for policy file at {filepath}. Unexpected error", filepath);
+                _logger.LogError(ex, "Failed to acquire blob lease for policy file at {Filepath}. Unexpected error", filepath);
             }
 
             return null;
@@ -129,7 +129,7 @@ namespace Altinn.Platform.Authorization.Repositories
             }
             catch (RequestFailedException ex)
             {
-                _logger.LogError(ex, "Failed to check if blob exists for policy file at {filepath}. RequestFailedException", filepath);
+                _logger.LogError(ex, "Failed to check if blob exists for policy file at {Filepath}. RequestFailedException", filepath);
             }
 
             return false;
@@ -148,16 +148,16 @@ namespace Altinn.Platform.Authorization.Repositories
             {
                 if (ex.Status == (int)HttpStatusCode.Forbidden && ex.ErrorCode == "OperationNotAllowedOnRootBlob")
                 {
-                    _logger.LogError(ex, "Failed to delete version {version} of policy file at {filepath}. Not allowed to delete current version.", version, filepath);
+                    _logger.LogError(ex, "Failed to delete version {Version} of policy file at {Filepath}. Not allowed to delete current version.", version, filepath);
                     throw;
                 }
 
-                _logger.LogError(ex, "Failed to delete version {version} of policy file at {filepath}. RequestFailedException", version, filepath);
+                _logger.LogError(ex, "Failed to delete version {Version} of policy file at {Filepath}. RequestFailedException", version, filepath);
                 throw;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to delete version {version} of policy file at {filepath}. Unexpected error", version, filepath);
+                _logger.LogError(ex, "Failed to delete version {Version} of policy file at {Filepath}. Unexpected error", version, filepath);
                 throw;
             }
         }

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/OedRoleAssignmentWrapper.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/OedRoleAssignmentWrapper.cs
@@ -71,7 +71,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 }
                 else
                 {
-                    _logger.LogError("OedAuthz // OedRoleAssignmentWrapper // GetOedRoleAssignments // Failed // Unexpected Exception // Unexpected HttpStatusCode: {statusCode}\n {responseContent}", response.StatusCode, responseContent);
+                    _logger.LogError("OedAuthz // OedRoleAssignmentWrapper // GetOedRoleAssignments // Failed // Unexpected Exception // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
                 }
 
                 return oedRoleAssignmentResponse.RoleAssignments;

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/PartiesWrapper.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/PartiesWrapper.cs
@@ -53,7 +53,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     return System.Text.Json.JsonSerializer.Deserialize<Party>(responseContent, _serializerOptions);
                 }
 
-                _logger.LogError("SBL-Bridge // PartiesWrapper // GetParty // Failed // Unexpected HttpStatusCode: {statusCode}\n {responseContent}", response.StatusCode, responseContent);
+                _logger.LogError("SBL-Bridge // PartiesWrapper // GetParty // Failed // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
                 return null;
             }
             catch (Exception ex)

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/PolicyAdministrationPoint.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/PolicyAdministrationPoint.cs
@@ -75,7 +75,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "An exception occured while processing authorization rules for delegation on delegation policy path: {delegationPolicypath}", delegationPolicypath);
+                    _logger.LogError(ex, "An exception occured while processing authorization rules for delegation on delegation policy path: {DelegationPolicypath}", delegationPolicypath);
                 }
 
                 foreach (Rule rule in delegationDict[delegationPolicypath])
@@ -97,7 +97,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             if (unsortables.Count > 0)
             {
                 string unsortablesJson = JsonSerializer.Serialize(unsortables);
-                _logger.LogError("One or more rules could not be processed because of incomplete input:\n{unsortablesJson}", unsortablesJson);
+                _logger.LogError("One or more rules could not be processed because of incomplete input:\n{UnsortablesJson}", unsortablesJson);
                 result.AddRange(unsortables);
             }
 
@@ -166,7 +166,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             }
             catch (Exception ex)
             {
-                _logger.LogError(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "ReplayDelegationChangeEvents could not push DelegationChangeEvent to DelegationChangeEventQueue. StartId: {startId}, EndId: {endId}, CurrentId: {currentId}", startId, endId, currentId);
+                _logger.LogError(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "ReplayDelegationChangeEvents could not push DelegationChangeEvent to DelegationChangeEventQueue. StartId: {StartId}, EndId: {EndId}, CurrentId: {CurrentId}", startId, endId, currentId);
                 return false;
             }
         }
@@ -175,14 +175,14 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         {
             if (!DelegationHelper.TryGetDelegationParamsFromRule(rules.First(), out string org, out string app, out int offeredByPartyId, out int? coveredByPartyId, out int? coveredByUserId, out int delegatedByUserId))
             {
-                _logger.LogWarning("This should not happen. Incomplete rule model received for delegation to delegation policy at: {policyPath}. Incomplete model should have been returned in unsortable rule set by TryWriteDelegationPolicyRules. DelegationHelper.SortRulesByDelegationPolicyPath might be broken.", policyPath);
+                _logger.LogWarning("This should not happen. Incomplete rule model received for delegation to delegation policy at: {PolicyPath}. Incomplete model should have been returned in unsortable rule set by TryWriteDelegationPolicyRules. DelegationHelper.SortRulesByDelegationPolicyPath might be broken.", policyPath);
                 return false;
             }
 
             XacmlPolicy appPolicy = await _prp.GetPolicyAsync(org, app);
             if (appPolicy == null)
             {
-                _logger.LogWarning("No valid App policy found for delegation policy path: {policyPath}", policyPath);
+                _logger.LogWarning("No valid App policy found for delegation policy path: {PolicyPath}", policyPath);
                 return false;
             }
 
@@ -190,7 +190,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             {
                 if (!DelegationHelper.PolicyContainsMatchingRule(appPolicy, rule))
                 {
-                    _logger.LogWarning("Matching rule not found in app policy. Action might not exist for Resource, or Resource itself might not exist. Delegation policy path: {policyPath}. Rule: {rule}", policyPath, rule);
+                    _logger.LogWarning("Matching rule not found in app policy. Action might not exist for Resource, or Resource itself might not exist. Delegation policy path: {PolicyPath}. Rule: {Rule}", policyPath, rule);
                     return false;
                 }
             }
@@ -261,7 +261,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                         // Comment:
                         // This means that the current version of the root blob is no longer in sync with changes in authorization postgresql delegation.delegatedpolicy table.
                         // The root blob is in effect orphaned/ignored as the delegation policies are always to be read by version, and will be overritten by the next delegation change.
-                        _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {policyPath}", policyPath);
+                        _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {PolicyPath}", policyPath);
                         return false;
                     }
 
@@ -271,7 +271,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "AddRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
+                        _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "AddRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {Change}", change);
                     }
 
                     return true;
@@ -282,7 +282,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 }
             }
 
-            _logger.LogInformation("Could not acquire blob lease lock on delegation policy at path: {policyPath}", policyPath);
+            _logger.LogInformation("Could not acquire blob lease lock on delegation policy at path: {PolicyPath}", policyPath);
             return false;
         }
 
@@ -292,7 +292,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             string leaseId = await _policyRepository.TryAcquireBlobLease(policyPath);
             if (leaseId == null)
             {
-                _logger.LogError("Could not acquire blob lease lock on delegation policy at path: {policyPath}", policyPath);
+                _logger.LogError("Could not acquire blob lease lock on delegation policy at path: {PolicyPath}", policyPath);
                 return null;
             }
 
@@ -306,7 +306,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 XacmlPolicy existingDelegationPolicy = null;
                 if (currentChange.DelegationChangeType == DelegationChangeType.RevokeLast)
                 {
-                    _logger.LogWarning("The policy is already deleted for App: {org}/{app} CoveredBy: {coveredBy} OfferedBy: {offeredBy}", org, app, coveredBy, offeredBy);
+                    _logger.LogWarning("The policy is already deleted for App: {Org}/{App} CoveredBy: {CoveredBy} OfferedBy: {OfferedBy}", org, app, coveredBy, offeredBy);
                     return null;
                 }
 
@@ -317,7 +317,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     XacmlRule xacmlRuleToRemove = existingDelegationPolicy.Rules.FirstOrDefault(r => r.RuleId == ruleId);
                     if (xacmlRuleToRemove == null)
                     {
-                        _logger.LogWarning("The rule with id: {ruleId} does not exist in policy with path: {policyPath}", ruleId, policyPath);
+                        _logger.LogWarning("The rule with id: {RuleId} does not exist in policy with path: {PolicyPath}", ruleId, policyPath);
                         continue;
                     }
 
@@ -340,7 +340,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Writing of delegation policy at path: {policyPath} failed. Is delegation blob storage account alive and well?", policyPath);
+                        _logger.LogError(ex, "Writing of delegation policy at path: {PolicyPath} failed. Is delegation blob storage account alive and well?", policyPath);
                         return null;
                     }
 
@@ -363,7 +363,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                         // Comment:
                         // This means that the current version of the root blob is no longer in sync with changes in authorization postgresql delegation.delegatedpolicy table.
                         // The root blob is in effect orphaned/ignored as the delegation policies are always to be read by version, and will be overritten by the next delegation change.
-                        _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {policyPath}. is authorization postgresql database alive and well?", policyPath);
+                        _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {PolicyPath}. is authorization postgresql database alive and well?", policyPath);
                         return null;
                     }
 
@@ -373,13 +373,13 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "DeleteRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
+                        _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "DeleteRules could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {Change}", change);
                     }
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An exception occured while processing rules to delete in policy: {policyPath}", policyPath);
+                _logger.LogError(ex, "An exception occured while processing rules to delete in policy: {PolicyPath}", policyPath);
                 return null;
             }
             finally
@@ -408,14 +408,14 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
             if (!await _policyRepository.PolicyExistsAsync(policyPath))
             {
-                _logger.LogWarning("No blob was found for the expected path: {policyPath} this must be removed without upading the database", policyPath);
+                _logger.LogWarning("No blob was found for the expected path: {PolicyPath} this must be removed without upading the database", policyPath);
                 return null;
             }
 
             string leaseId = await _policyRepository.TryAcquireBlobLease(policyPath);
             if (leaseId == null)
             {
-                _logger.LogError("Could not acquire blob lease on delegation policy at path: {policyPath}", policyPath);
+                _logger.LogError("Could not acquire blob lease on delegation policy at path: {PolicyPath}", policyPath);
                 return null;
             }
 
@@ -446,7 +446,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Writing of delegation policy at path: {policyPath} failed. Is delegation blob storage account alive and well?}", policyPath);
+                    _logger.LogError(ex, "Writing of delegation policy at path: {PolicyPath} failed. Is delegation blob storage account alive and well?}", policyPath);
                     return null;
                 }
 
@@ -468,7 +468,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     // Comment:
                     // This means that the current version of the root blob is no longer in sync with changes in authorization postgresql delegation.delegatedpolicy table.
                     // The root blob is in effect orphaned/ignored as the delegation policies are always to be read by version, and will be overritten by the next delegation change.
-                    _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {policyPath}. is authorization postgresql database alive and well?", policyPath);
+                    _logger.LogError("Writing of delegation change to authorization postgresql database failed for changes to delegation policy at path: {PolicyPath}. is authorization postgresql database alive and well?", policyPath);
                     return null;
                 }
 
@@ -478,14 +478,14 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "DeletePolicy could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {change}", change);
+                    _logger.LogCritical(new EventId(delegationChangeEventQueueErrorId, "DelegationChangeEventQueue.Push.Error"), ex, "DeletePolicy could not push DelegationChangeEvent to DelegationChangeEventQueue. DelegationChangeEvent must be retried for successful sync with SBL Authorization. DelegationChange: {Change}", change);
                 }
 
                 return currentPolicyRules;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An exception occured while processing rules to delete in policy: {policyPath}", policyPath);
+                _logger.LogError(ex, "An exception occured while processing rules to delete in policy: {PolicyPath}", policyPath);
                 return null;
             }
             finally
@@ -514,7 +514,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
             if (!await _policyRepository.PolicyExistsAsync(policyPath))
             {
-                _logger.LogWarning("No blob was found for the expected path: {policyPath} this must be removed without upading the database", policyPath);
+                _logger.LogWarning("No blob was found for the expected path: {PolicyPath} this must be removed without upading the database", policyPath);
                 return null;
             }
 

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ProfileWrapper.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ProfileWrapper.cs
@@ -48,7 +48,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     return JsonSerializer.Deserialize<UserProfile>(responseContent, _serializerOptions);
                 }
 
-                _logger.LogError("ProfileAPI // ProfileWrapper // GetUserProfile // Failed // Unexpected HttpStatusCode: {statusCode}\n {responseContent}", response.StatusCode, responseContent);
+                _logger.LogError("ProfileAPI // ProfileWrapper // GetUserProfile // Failed // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
                 return null;
             }
             catch (Exception ex)
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     return JsonSerializer.Deserialize<UserProfile>(responseContent, _serializerOptions);
                 }
 
-                _logger.LogError("ProfileAPI // ProfileWrapper // GetUserProfile // Failed // Unexpected HttpStatusCode: {statusCode}\n {responseContent}", response.StatusCode, responseContent);
+                _logger.LogError("ProfileAPI // ProfileWrapper // GetUserProfile // Failed // Unexpected HttpStatusCode: {StatusCode}\n {ResponseContent}", response.StatusCode, responseContent);
                 return null;
             }
             catch (Exception ex)

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/RegisterService.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/RegisterService.cs
@@ -214,7 +214,7 @@ namespace Altinn.Platform.Authorization.Services
                 else
                 {
                     string reason = await response.Content.ReadAsStringAsync(cancellationToken);
-                    _logger.LogError("// RegisterService // PartyLookup // Failed to lookup party in platform register. Response {response}. \n Reason {reason}.", response, reason);
+                    _logger.LogError("// RegisterService // PartyLookup // Failed to lookup party in platform register. Response {Response}. \n Reason {Reason}.", response, reason);
 
                     throw await PlatformHttpException.CreateAsync(response);
                 }

--- a/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Implementation/PDPAppSI.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/src/Altinn.Authorization.PEP/Implementation/PDPAppSI.cs
@@ -45,7 +45,7 @@ namespace Altinn.Common.PEP.Implementation
             }
             catch (Exception e)
             {
-                _logger.LogError("Unable to retrieve Xacml Json response. An error occured {message}", e.Message);
+                _logger.LogError("Unable to retrieve Xacml Json response. An error occured {Message}", e.Message);
             }
 
             return xacmlJsonResponse;


### PR DESCRIPTION
## Summary

Sweep PR for SonarCloud rule `csharpsquid:S6678` ("Use PascalCase for named placeholders"). 112 instances flagged across the AccessManagement (75) and Authorization (37) verticals plus the shared `Altinn.Authorization.PEP` package — every `{name}` placeholder in a logger template now starts with an uppercase letter.

The fix is mechanical. Args stay positional; only the placeholder names change. Three patterns covered:

| Pattern | Example before | Example after |
|---|---|---|
| Inline `_logger.Log*(...)` | `_logger.LogError("at path: {policyPath}", policyPath)` | `_logger.LogError("at path: {PolicyPath}", policyPath)` |
| Multi-line continuation template | `_logger.LogError(\n   "Writing failed: {policyPath}: {status}",\n   policyPath, httpResponse.Status)` | `_logger.LogError(\n   "Writing failed: {PolicyPath}: {Status}",\n   policyPath, httpResponse.Status)` |
| `[LoggerMessage(...)]` source-gen attributes | `[LoggerMessage(... Message = "got {statusCode}")]` | `[LoggerMessage(... Message = "got {StatusCode}")]` |

C# string interpolations (`$"{org}/{app}"`, `$"parties/{partyId}"`) are explicitly **not** touched — those are interpolation expressions, not Sonar placeholders, and renaming them would break compilation.

Severity for `S6678` in `.editorconfig` stays at `warning` per the convention established in #3074 and the tech-lead direction in #3077: long-term enforcement of individual Sonar rules belongs in the SonarCloud quality profile (server-side), not in client-side severity escalations.

## Files touched

30 files: 1 in the shared PEP package, 4 in Authorization (Program.cs, EventsQueueClient.cs, InstanceMetadataRepository.cs, plus 5 services + 1 repository), 20 in AccessManagement (PolicyAdministrationPoint.cs alone has 15 distinct placeholder renames; six integration clients, four hosted-service `[LoggerMessage]` files, two controllers).

## Heads-up: structured-log impact

Application Insights and Sonar log search index structured-log records by the placeholder name, so this rename changes the search key. Any ops dashboard or alert keyed on the old lowercase names (`policyPath`, `statusCode`, `responseContent`, `change`, `rule`, `coveredBy`, `offeredBy`, `from`, `to`, `role`, `count`, etc.) stops matching after this lands.

None of the touched logger calls are in production hot paths — they're error / warning messages on failure paths, plus a few startup info messages — but worth flagging if any critical alerts exist on the literal key names so they can be updated to OR over both during the deploy window.

## Test plan

- [x] `dotnet build` clean on both verticals (Authorization 0 errors / 4 NU1903, AccessManagement 0 errors / 38 same pre-existing surface as origin/main).
- [x] `dotnet test src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests` — 402 passed + 3 skipped (Docker-down baseline; integration tests skip cleanly).
- [x] Final cross-vertical grep: zero `_logger.Log*` or `[LoggerMessage]` lines with lowercase `{name}` placeholders remain in `src/apps/Altinn.Authorization/src/`, `src/apps/Altinn.AccessManagement/src/`, or `src/pkgs/Altinn.Authorization.PEP/src/`.
- [ ] CI Sonar scan after merge: `S6678` count goes 112 → 0.

Closes #3087.