### PR TITLE
chore: pin PEP/ABAC packages to net9.0;net10.0

### DIFF
--- a/.github/workflows/cd-pkgs.yml
+++ b/.github/workflows/cd-pkgs.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: |
-            8.0.x
+            9.0.x
             10.0.x
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/tpl-find-verticals.yml
+++ b/.github/workflows/tpl-find-verticals.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: |
-            8.0.x
+            9.0.x
             10.0.x
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: |
-            8.0.x
+            9.0.x
             10.0.x
 
       - name: Restore dotnet workloads

--- a/src/pkgs/Directory.Build.props
+++ b/src/pkgs/Directory.Build.props
@@ -8,7 +8,7 @@
         <CopyArtifactsAfterTargets>Pack</CopyArtifactsAfterTargets>
         <DefaultArtifactsFileMatch>*nupkg</DefaultArtifactsFileMatch>
         <BaseArtifactsPath Condition=" '$(BaseArtifactsPath)' == '' ">$(SolutionDir)artifacts\</BaseArtifactsPath>
-        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Realigns the published `Altinn.Authorization.PEP` and `Altinn.Authorization.ABAC` packages with the original spec in #2760: target `net9.0` and `net10.0`, drop `net8.0`.

The .NET 10 upgrade (#3066) flipped the multi-target from `net8.0;net9.0` to `net8.0;net10.0`, which both lost `net9.0` support (Apps still on .NET 9 cannot consume the packages) and kept `net8.0` around longer than needed.

## Changes

- `src/pkgs/Directory.Build.props` — `<TargetFrameworks>` becomes `net9.0;net10.0`.
- `.github/workflows/{tpl-vertical-ci,cd-pkgs,tpl-find-verticals}.yml` — `setup-dotnet` matrices install `9.0.x` and `10.0.x` (drop `8.0.x`).

## Test plan

- [x] Clean `dotnet build` of `Altinn.Authorization.PEP` produces `net9.0` and `net10.0` outputs (0 errors, 0 warnings); no `net8.0` directory.
- [x] Clean `dotnet build` of `Altinn.Authorization.ABAC` produces `net9.0` and `net10.0` outputs (0 errors, 0 warnings); no `net8.0` directory.
- [ ] CI green on this branch (build + test for both packages on the new SDK matrix).

Closes #3097.