### PR TITLE
bugfix: fix use of connection query filters in AuthorizedPartiesServiceEfOld

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEfOld.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEfOld.cs
@@ -485,7 +485,7 @@ public class AuthorizedPartiesServiceEfOld(
         bool resourceFilterSpecified = filter.ProviderCode != null || filter.AnyOfResourceIds?.Count() > 0;
         if (!resourceFilterSpecified || filter.PackageFilter?.Count > 0)
         {
-            connections = await repoService.GetConnectionsFromOthers(toId, filters: filter, ct: cancellationToken);
+            connections = await repoService.GetConnectionsFromOthersOld(toId, filters: filter, ct: cancellationToken);
         }
 
         // Get App, Resource and Instance delegations
@@ -842,24 +842,6 @@ public class AuthorizedPartiesServiceEfOld(
                 foreach (var roleCode in roleCodes)
                 {
                     filter.RoleFilter[roleCode] = roleCode;
-                }
-
-                // Find all Roles for the PackageResources found above, as we need to include roles giving access via packages as well.
-                List<RolePackage> rolePackages = await repoService.GetRolePackages(packageIds: filter.PackageFilter.Keys, ct: cancellationToken);
-                foreach (var group in rolePackages.GroupBy(rp => rp.PackageId))
-                {
-                    foreach (var role in group.Select(rp => rp.Role))
-                    {
-                        if (!filter.RoleFilter.ContainsKey(role.Code))
-                        {
-                            filter.RoleFilter[role.Code] = role.Code;
-                        }
-
-                        if (role.LegacyCode != null && !filter.RoleFilter.ContainsKey(role.LegacyCode))
-                        {
-                            filter.RoleFilter[role.LegacyCode] = role.LegacyCode;
-                        }
-                    }
                 }
 
                 cachedFilters.ResourceFilter = filter.ResourceFilter;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
@@ -119,8 +119,35 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
             IncludeMainUnitConnections = true,
             IncludeDelegation = true,
             IncludePackages = filters?.IncludeAccessPackages == true || filters?.PackageFilter?.Keys?.Count > 0,
-            IncludeResources = AuthorizedPartiesSettings.UsingConnectionQueryOnly ? filters?.IncludeResources == true || filters?.ResourceFilter?.Keys?.Count > 0 : false,
-            IncludeInstances = AuthorizedPartiesSettings.UsingConnectionQueryOnly ? filters?.IncludeInstances == true || filters?.ResourceFilter?.Keys?.Count > 0 : false,
+            IncludeResources = filters?.IncludeResources == true || filters?.ResourceFilter?.Keys?.Count > 0,
+            IncludeInstances = filters?.IncludeInstances == true || filters?.ResourceFilter?.Keys?.Count > 0,
+            EnrichPackageResources = false,
+            ExcludeDeleted = false
+        },
+        ConnectionQueryDirection.FromOthers,
+        useNewQuery: true,
+        ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthersOld(
+        Guid toId,
+        AuthorizedPartiesFilters filters = null,
+        CancellationToken ct = default)
+    {
+        return await connectionQuery.GetConnectionsAsync(
+        new ConnectionQueryFilter()
+        {
+            ToIds = [toId],
+            FromIds = filters?.PartyFilter?.Keys.ToList(),
+            PackageIds = filters?.PackageFilter?.Keys.ToList(),
+            EnrichEntities = false,
+            IncludeSubConnections = true,
+            IncludeKeyRole = filters?.IncludePartiesViaKeyRoles == AuthorizedPartiesIncludeFilter.True ? true : false,
+            IncludeMainUnitConnections = true,
+            IncludeDelegation = true,
+            IncludePackages = filters?.IncludeAccessPackages == true || filters?.PackageFilter?.Keys?.Count > 0,
+            IncludeResources = false,
             EnrichPackageResources = false,
             ExcludeDeleted = false
         },

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IAuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IAuthorizedPartyRepoServiceEf.cs
@@ -94,13 +94,13 @@ public interface IAuthorizedPartyRepoServiceEf
     Task<IEnumerable<Assignment>> GetKeyRoleAssignments(Guid toId, CancellationToken ct = default);
 
     /// <summary>
-    /// Get list of packages the to party has access to, on behalf of the from party. New use of the ConnectionQuery to get all connections, including package permissions, in one query for the new AuthorizedPartiesServiceEf implementation.
+    /// Get all connections the to party has any access to in one query, for usage in the new AuthorizedPartiesServiceEf implementation.
     /// </summary>
     /// <returns>Enumerable of package permissions</returns>
     Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthers(Guid toId, AuthorizedPartiesFilters filters = null, CancellationToken ct = default);
 
     /// <summary>
-    /// Get list of packages the to party has access to, on behalf of the from party. Implementation of the ConnectionQuery for the AuthorizedPartiesServiceEfOld implementation.
+    /// Get all connections the to party has any access packages for, for usage in the AuthorizedPartiesServiceEfOld implementation.
     /// </summary>
     /// <returns>Enumerable of package permissions</returns>
     Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthersOld(Guid toId, AuthorizedPartiesFilters filters = null, CancellationToken ct = default);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IAuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IAuthorizedPartyRepoServiceEf.cs
@@ -94,10 +94,16 @@ public interface IAuthorizedPartyRepoServiceEf
     Task<IEnumerable<Assignment>> GetKeyRoleAssignments(Guid toId, CancellationToken ct = default);
 
     /// <summary>
-    /// Get list of packages the to party has access to, on behalf of the from party
+    /// Get list of packages the to party has access to, on behalf of the from party. New use of the ConnectionQuery to get all connections, including package permissions, in one query for the new AuthorizedPartiesServiceEf implementation.
     /// </summary>
     /// <returns>Enumerable of package permissions</returns>
     Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthers(Guid toId, AuthorizedPartiesFilters filters = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get list of packages the to party has access to, on behalf of the from party. Implementation of the ConnectionQuery for the AuthorizedPartiesServiceEfOld implementation.
+    /// </summary>
+    /// <returns>Enumerable of package permissions</returns>
+    Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthersOld(Guid toId, AuthorizedPartiesFilters filters = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get list of packages the to party has access to, on behalf of the from party


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Filter was changed for the new ConnectionQuery only usage in AuthorizedPartiesServiceEf while forgetting it's still in use from AuthorizedPartiesServiceEfOld :facepalm:
- Also fixed rolefilter issue found during testing of the new implementation:
  - RolePackage roles should not be included in roleFilter

## Related Issue(s)
- #3096

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
