### PR TITLE
fix(deps): pin Azure.Security.KeyVault.Certificates back to 4.8.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Azure.ResourceManager.PostgreSql" Version="1.3.1" />
     <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.24.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -34,8 +34,8 @@
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.3" />
     <PackageVersion Include="Azure.ResourceManager.PostgreSql" Version="1.3.1" />
     <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.11.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.24.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />


### PR DESCRIPTION
## Summary

- Reverts `Azure.Security.KeyVault.Certificates` from 4.11.0 (set in [#3115](https://github.com/Altinn/altinn-authorization-tmp/pull/3115)) back to **4.8.0**.
- Leaves `Azure.Security.KeyVault.Secrets` at **4.11.0**.

PR #3115 bumped both in lockstep, but the two Azure SDK packages drifted out of sync upstream: `Secrets 4.11.0` is published on nuget.org, but `Certificates 4.11.0` is not — the latest published version of Certificates is `4.8.0` stable (`4.9.0-beta.1` preview). Every NuGet restore on main since #3115 merged hit `NU1102: Unable to find package Azure.Security.KeyVault.Certificates with version (>= 4.11.0)`.

The asymmetric pin matters: `Altinn.Authorization.Cli` depends transitively on `Azure.Security.KeyVault.Secrets >= 4.11.0` through `Altinn.Authorization.ServiceDefaults.HttpClient.MaskinPorten 5.4.0` (added in #3115). Forcing Secrets back to 4.8.0 triggers `NU1605` (package downgrade) on the Cli sln — confirmed in the first CI run on this PR. Keeping Secrets at 4.11.0 satisfies that transitive while the Certificates revert clears the original NU1102.

Once Microsoft ships Certificates 4.11.0, Renovate / dependabot can re-do the bump cleanly.

Closes #3143

## Test plan

- [x] `dotnet restore --force --no-cache` succeeds on `Altinn.AccessManagement.sln`, `Altinn.Authorization.sln`, and `Altinn.Authorization.Cli.sln` locally
- [x] `dotnet build` succeeds on all three (0 errors)
- [ ] CI green on this PR
