### PR TITLE
test: stabilise remaining timing-based ConsentMigration tests

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs
@@ -107,8 +107,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             .Setup(x => x.IsEnabledAsync(AccessMgmtFeatureFlags.HostedServicesConsentMigration))
             .ReturnsAsync(true);
 
+        using var leaseAttempted = new SemaphoreSlim(0, int.MaxValue);
         _leaseServiceMock
             .Setup(x => x.TryAcquireNonBlocking("access_management_consent_migration", It.IsAny<CancellationToken>()))
+            .Callback(() => leaseAttempted.Release())
             .ReturnsAsync((ILease)null);
 
         var service = CreateService();
@@ -117,11 +119,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10, TestContext.Current.CancellationToken);
-
-        // Advance by EmptyFeedDelayMs + max jitter (2000ms)
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.EmptyFeedDelayMs + 2000));
-        await Task.Delay(10, TestContext.Current.CancellationToken);
+        // First iteration runs immediately on service start.
+        Assert.True(
+            await leaseAttempted.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "Lease attempt did not fire within 2s");
 
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
@@ -147,8 +148,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             .Setup(x => x.TryAcquireNonBlocking("access_management_consent_migration", It.IsAny<CancellationToken>()))
             .ReturnsAsync(_leaseMock.Object);
 
+        using var batchProcessed = new SemaphoreSlim(0, int.MaxValue);
         _syncServiceMock
             .Setup(x => x.ProcessBatch(It.IsAny<CancellationToken>()))
+            .Callback(() => batchProcessed.Release())
             .ReturnsAsync(5);
 
         var service = CreateService();
@@ -157,9 +160,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10, TestContext.Current.CancellationToken);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10, TestContext.Current.CancellationToken);
+        // First iteration runs immediately on service start.
+        Assert.True(
+            await batchProcessed.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "ProcessBatch did not fire within 2s");
 
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
@@ -185,8 +189,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             .Setup(x => x.TryAcquireNonBlocking("access_management_consent_migration", It.IsAny<CancellationToken>()))
             .ReturnsAsync(_leaseMock.Object);
 
+        using var batchProcessed = new SemaphoreSlim(0, int.MaxValue);
         _syncServiceMock
             .Setup(x => x.ProcessBatch(It.IsAny<CancellationToken>()))
+            .Callback(() => batchProcessed.Release())
             .ReturnsAsync(0); // Empty batch
 
         var service = CreateService();
@@ -195,9 +201,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10, TestContext.Current.CancellationToken);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.EmptyFeedDelayMs));
-        await Task.Delay(10, TestContext.Current.CancellationToken);
+        // First iteration runs immediately on service start.
+        Assert.True(
+            await batchProcessed.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "ProcessBatch did not fire within 2s");
 
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
@@ -220,8 +227,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             .Setup(x => x.TryAcquireNonBlocking("access_management_consent_migration", It.IsAny<CancellationToken>()))
             .ReturnsAsync(_leaseMock.Object);
 
+        using var batchProcessed = new SemaphoreSlim(0, int.MaxValue);
         _syncServiceMock
             .Setup(x => x.ProcessBatch(It.IsAny<CancellationToken>()))
+            .Callback(() => batchProcessed.Release())
             .ReturnsAsync(5); // Non-empty batch
 
         var service = CreateService();
@@ -230,9 +239,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10, TestContext.Current.CancellationToken);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10, TestContext.Current.CancellationToken);
+        // First iteration runs immediately on service start.
+        Assert.True(
+            await batchProcessed.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "ProcessBatch did not fire within 2s");
 
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
@@ -256,10 +266,12 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             .Setup(x => x.TryAcquireNonBlocking("access_management_consent_migration", It.IsAny<CancellationToken>()))
             .ReturnsAsync(_leaseMock.Object);
 
+        using var batchProcessed = new SemaphoreSlim(0, int.MaxValue);
         _syncServiceMock
             .Setup(x => x.ProcessBatch(It.IsAny<CancellationToken>()))
             .Returns(() =>
             {
+                batchProcessed.Release();
                 callCount++;
                 if (callCount == 1)
                 {
@@ -275,16 +287,30 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10, TestContext.Current.CancellationToken);
-        _timeProvider.Advance(TimeSpan.FromMinutes(1)); // Error delay
-        await Task.Delay(10, TestContext.Current.CancellationToken);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10, TestContext.Current.CancellationToken);
+        // First call fires immediately on service start (throws).
+        Assert.True(
+            await batchProcessed.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "First ProcessBatch did not fire within 2s");
+
+        // Pump time forward until the second call fires. After the exception, the
+        // SUT's catch block delays by 1 minute (error delay) before the next iteration.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        var secondCallFired = false;
+        while (DateTime.UtcNow < deadline)
+        {
+            _timeProvider.Advance(TimeSpan.FromMinutes(1));
+            if (await batchProcessed.WaitAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken))
+            {
+                secondCallFired = true;
+                break;
+            }
+        }
 
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
         // Assert - Service continues after exception
+        Assert.True(secondCallFired, "Second ProcessBatch did not fire within 2s after error delay");
         _syncServiceMock.Verify(
             x => x.ProcessBatch(It.IsAny<CancellationToken>()),
             Times.AtLeast(2));
@@ -332,8 +358,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             .Setup(x => x.TryAcquireNonBlocking("access_management_consent_migration", It.IsAny<CancellationToken>()))
             .ReturnsAsync(_leaseMock.Object);
 
+        using var batchProcessed = new SemaphoreSlim(0, int.MaxValue);
         _syncServiceMock
             .Setup(x => x.ProcessBatch(It.IsAny<CancellationToken>()))
+            .Callback(() => batchProcessed.Release())
             .ReturnsAsync(5);
 
         var service = CreateService();
@@ -342,9 +370,12 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10, TestContext.Current.CancellationToken);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10, TestContext.Current.CancellationToken);
+        // First iteration runs immediately on service start; the lease's DisposeAsync
+        // fires when control returns past the `await using var lease = ...` block
+        // after ProcessBatch returns.
+        Assert.True(
+            await batchProcessed.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "ProcessBatch did not fire within 2s");
 
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
@@ -477,8 +508,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             .Setup(x => x.IsEnabledAsync(AccessMgmtFeatureFlags.HostedServicesConsentMigration))
             .ReturnsAsync(true);
 
+        using var leaseAttempted = new SemaphoreSlim(0, int.MaxValue);
         _leaseServiceMock
             .Setup(x => x.TryAcquireNonBlocking(expectedLeaseName, It.IsAny<CancellationToken>()))
+            .Callback(() => leaseAttempted.Release())
             .ReturnsAsync(_leaseMock.Object);
 
         _syncServiceMock
@@ -491,9 +524,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10, TestContext.Current.CancellationToken);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.NormalDelayMs));
-        await Task.Delay(10, TestContext.Current.CancellationToken);
+        // First iteration runs immediately on service start.
+        Assert.True(
+            await leaseAttempted.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "Lease attempt did not fire within 2s");
 
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
@@ -597,8 +631,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             .Setup(x => x.IsEnabledAsync(AccessMgmtFeatureFlags.HostedServicesConsentMigration))
             .ReturnsAsync(true);
 
+        using var leaseAttempted = new SemaphoreSlim(0, int.MaxValue);
         _leaseServiceMock
             .Setup(x => x.TryAcquireNonBlocking("access_management_consent_migration", It.IsAny<CancellationToken>()))
+            .Callback(() => leaseAttempted.Release())
             .ReturnsAsync((ILease)null);
 
         var service = CreateService();
@@ -607,12 +643,10 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        await Task.Delay(10, TestContext.Current.CancellationToken);
-
-        // The jitter adds 1000-2000ms to the EmptyFeedDelayMs
-        // So we need to advance by at least EmptyFeedDelayMs + 1000ms to guarantee triggering
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(_settings.EmptyFeedDelayMs + 1000));
-        await Task.Delay(10, TestContext.Current.CancellationToken);
+        // First iteration runs immediately on service start.
+        Assert.True(
+            await leaseAttempted.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "Lease attempt did not fire within 2s");
 
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs
@@ -206,13 +206,32 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             await batchProcessed.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
             "ProcessBatch did not fire within 2s");
 
+        // After an empty batch the SUT should wait EmptyFeedDelayMs (200ms) — not NormalDelayMs
+        // (100ms). Pump advances until the second iteration fires; the test asserts the second
+        // iteration only fires once we've advanced past EmptyFeedDelayMs.
+        var totalAdvanced = 0;
+        var secondFired = false;
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (DateTime.UtcNow < deadline && !secondFired)
+        {
+            // Advance in small (50ms) increments to detect the exact threshold.
+            _timeProvider.Advance(TimeSpan.FromMilliseconds(50));
+            totalAdvanced += 50;
+            if (await batchProcessed.WaitAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken))
+            {
+                secondFired = true;
+            }
+        }
+
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
-        // Assert
+        // Assert: second iteration fired AND only after at least EmptyFeedDelayMs was advanced.
+        Assert.True(secondFired, "Second ProcessBatch did not fire within 2s");
+        Assert.True(totalAdvanced >= _settings.EmptyFeedDelayMs, $"SUT used a delay shorter than EmptyFeedDelayMs ({_settings.EmptyFeedDelayMs}ms): second iteration fired after only {totalAdvanced}ms");
         _syncServiceMock.Verify(
             x => x.ProcessBatch(It.IsAny<CancellationToken>()),
-            Times.AtLeastOnce);
+            Times.AtLeast(2));
     }
 
     [Fact]
@@ -244,13 +263,33 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             await batchProcessed.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
             "ProcessBatch did not fire within 2s");
 
+        // After a non-empty batch the SUT should wait NormalDelayMs (100ms) — strictly less than
+        // EmptyFeedDelayMs (200ms). Pump advances in small increments; verify the second iteration
+        // fires before we've advanced past EmptyFeedDelayMs (otherwise the SUT picked the wrong
+        // delay branch).
+        var totalAdvanced = 0;
+        var secondFired = false;
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (DateTime.UtcNow < deadline && !secondFired)
+        {
+            _timeProvider.Advance(TimeSpan.FromMilliseconds(50));
+            totalAdvanced += 50;
+            if (await batchProcessed.WaitAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken))
+            {
+                secondFired = true;
+            }
+        }
+
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
-        // Assert
+        // Assert: second iteration fired AND fired before EmptyFeedDelayMs would have elapsed
+        // (proving the SUT used NormalDelayMs not EmptyFeedDelayMs).
+        Assert.True(secondFired, "Second ProcessBatch did not fire within 2s");
+        Assert.True(totalAdvanced < _settings.EmptyFeedDelayMs, $"SUT appears to have used EmptyFeedDelayMs ({_settings.EmptyFeedDelayMs}ms) instead of NormalDelayMs ({_settings.NormalDelayMs}ms): second iteration only fired after {totalAdvanced}ms");
         _syncServiceMock.Verify(
             x => x.ProcessBatch(It.IsAny<CancellationToken>()),
-            Times.AtLeastOnce);
+            Times.AtLeast(2));
     }
 
     [Fact]
@@ -364,21 +403,33 @@ public class ConsentMigrationHostedServiceTests : IDisposable
             .Callback(() => batchProcessed.Release())
             .ReturnsAsync(5);
 
+        using var leaseDisposed = new SemaphoreSlim(0, int.MaxValue);
+        _leaseMock
+            .Setup(x => x.DisposeAsync())
+            .Callback(() => leaseDisposed.Release())
+            .Returns(ValueTask.CompletedTask);
+
         var service = CreateService();
         using var testCts = new CancellationTokenSource();
 
         // Act
         var serviceTask = service.StartAsync(testCts.Token);
 
-        // First iteration runs immediately on service start; the lease's DisposeAsync
-        // fires when control returns past the `await using var lease = ...` block
-        // after ProcessBatch returns.
+        // Wait until ProcessBatch has run (proves the lease was acquired and we're in the
+        // post-batch _timeProvider.Delay await). Then cancel — the `await using var lease`
+        // block disposes the lease as cancellation unwinds.
         Assert.True(
             await batchProcessed.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
             "ProcessBatch did not fire within 2s");
 
         testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
+
+        // Wait for DisposeAsync to actually fire. The previous version verified immediately
+        // after WhenAny(serviceTask, ...) which returns as soon as StartAsync's task completes
+        // (StartAsync != ExecuteAsync), so the dispose hadn't run yet on slow CI.
+        Assert.True(
+            await leaseDisposed.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "DisposeAsync did not fire within 2s of cancellation");
 
         // Assert
         _leaseMock.Verify(x => x.DisposeAsync(), Times.AtLeastOnce);
@@ -646,15 +697,41 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         // First iteration runs immediately on service start.
         Assert.True(
             await leaseAttempted.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
-            "Lease attempt did not fire within 2s");
+            "First lease attempt did not fire within 2s");
+
+        // When the lease is unavailable, the SUT delays by EmptyFeedDelayMs + RandomJitter
+        // (1000–1999ms). Pump time in small increments until the second attempt fires; the
+        // assertion below checks the cumulative advance was well above EmptyFeedDelayMs alone —
+        // i.e. the SUT added jitter on top of the base delay. (Pumping in small increments also
+        // tolerates the race where the SUT hasn't yet registered its timer when we start
+        // advancing; a single big Advance can otherwise no-op against an unregistered timer.)
+        var totalAdvanced = 0;
+        var secondFired = false;
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline && !secondFired)
+        {
+            _timeProvider.Advance(TimeSpan.FromMilliseconds(50));
+            totalAdvanced += 50;
+            if (await leaseAttempted.WaitAsync(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken))
+            {
+                secondFired = true;
+            }
+        }
 
         testCts.Cancel();
         await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
 
-        // Assert - Verify lease was attempted (jitter doesn't prevent retry)
+        // Assert: second attempt fired, AND only after a delay much larger than EmptyFeedDelayMs
+        // alone — proving the SUT added RandomJitter (1000–1999ms) on top. Without jitter the
+        // second attempt would fire at totalAdvanced ≈ EmptyFeedDelayMs (200ms, plus tiny race
+        // lag); with jitter it fires at 1200–2200ms.
+        Assert.True(secondFired, "Second lease attempt did not fire within 5s");
+        Assert.True(
+            totalAdvanced > _settings.EmptyFeedDelayMs + 500,
+            $"SUT did not apply jitter: second lease attempt fired after {totalAdvanced}ms, which is too close to EmptyFeedDelayMs ({_settings.EmptyFeedDelayMs}ms) alone — expected at least EmptyFeedDelayMs + ~1000ms of jitter");
         _leaseServiceMock.Verify(
             x => x.TryAcquireNonBlocking("access_management_consent_migration", It.IsAny<CancellationToken>()),
-            Times.AtLeastOnce);
+            Times.AtLeast(2));
     }
 
     private ConsentMigrationHostedService CreateService()


### PR DESCRIPTION
## Summary

Stabilises the remaining seven racy timing-based tests in [`ConsentMigrationHostedServiceTests`](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs). Same `FakeTimeProvider.Advance + Task.Delay(10)` anti-pattern that produced flakes in:

- `ExecuteAsync_MultipleIterations_AcquiresLeaseEachTime` — fixed in #3101
- `ExecuteAsync_LeaseUnavailable_RetriesWithCorrectDelay` — fixed in #3150

Both flaked on CI even though their SUT wasn't touched by the surrounding PRs. The remaining seven sibling tests share the same risky pattern; this PR addresses them proactively.

## Fix shape

The SUT (`ConsentMigrationHostedService.ExecuteAsync`) registers its next-iteration timer only after `ProcessBatch` (or the lease-unavailable delay) returns. `FakeTimeProvider.Advance(t)` only fires timers that exist at the call site, so a fixed `Task.Delay(10)` between `Advance` calls is racy — the SUT may not have reached its next `await _timeProvider.Delay(...)` when the test advances.

Two sub-patterns mirror #3101 / #3150:

- **Single-iteration tests** (6 of 7): drop the `Advance + Task.Delay(10)` ceremony entirely. The SUT's first iteration runs immediately on service start with no preceding `_timeProvider.Delay`, so a `SemaphoreSlim` released in the relevant mock callback (`TryAcquireNonBlocking` / `ProcessBatch`) plus a single `WaitAsync(2s)` is enough. The assertion fires deterministically.
- **Multi-iteration test** (`ProcessBatchThrowsException_ContinuesProcessing`): same loop shape as #3101 / #3150 — semaphore + bounded `Advance + WaitAsync` poll until the second call fires.

Tests fixed:

| Test | Iterations expected | Fix |
|---|---|---|
| `LeaseUnavailable_SkipsProcessing` | 1 | semaphore + first-wait |
| `LeaseAcquired_ProcessesBatch` | 1 | semaphore + first-wait |
| `EmptyBatch_UsesEmptyFeedDelay` | 1 | semaphore + first-wait |
| `NonEmptyBatch_UsesNormalDelay` | 1 | semaphore + first-wait |
| `LeaseDisposedAfterProcessing` | 1 | semaphore + first-wait |
| `UsesCorrectLeaseName` | 1 | semaphore + first-wait |
| `LeaseUnavailable_AppliesJitter` | 1 | semaphore + first-wait |
| `ProcessBatchThrowsException_ContinuesProcessing` | 2 (1m error delay between) | semaphore + Advance/WaitAsync loop |

## Out of scope

- `MultipleIterations_AcquiresLeaseEachTime` — already fixed in #3101 (merged).
- `LeaseUnavailable_RetriesWithCorrectDelay` — fix in flight on #3150 (open). Leaving alone to avoid merge conflict; #3150 will land it.
- `Times.Never` tests (`FeatureDisabled_SkipsProcessing`, `FeatureDisabled_UsesFeatureDisabledDelay`) — fail-safe under the race. Short timing only means we don't observe spurious calls, which makes the assertion still pass.
- Tests without timing interaction or already using deterministic signals: `StartAsync_StartsSuccessfully`, `StopAsync_StopsSuccessfully`, `CancellationRequested_StopsProcessing`, `OperationCanceledException_RethrowsWhenCancellationRequested` (uses `TaskCompletionSource`).

The SUT (`ConsentMigrationHostedService`) is unchanged.

Closes #3151

## Test plan

- [x] Build succeeds
- [x] Stress test: 50 consecutive class-level runs of the full 16-test class, all pass
- [ ] CI green on this PR
