### PR TITLE
chore: clear S112 throw-new-Exception in hosted services + targeted EF code

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
@@ -149,7 +149,7 @@ namespace Altinn.AccessManagement.Integration.Clients
             ConsentTemplate consentTemplate = templates.FirstOrDefault(t => t.Id.Equals(templateId, StringComparison.OrdinalIgnoreCase));
             if (consentTemplate == null)
             {
-                throw new Exception($"Consent template with id {templateId} and version {version} not found.");
+                throw new KeyNotFoundException($"Consent template with id {templateId} and version {version} not found.");
             }
 
             return consentTemplate;
@@ -209,7 +209,7 @@ namespace Altinn.AccessManagement.Integration.Clients
             }
             catch (Exception ex)
             {
-                throw new Exception($"Something went wrong when retrieving consent templates", ex);
+                throw new InvalidOperationException("Something went wrong when retrieving consent templates", ex);
             }
         }
     }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/DelegationMetadataEF.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/DelegationMetadataEF.cs
@@ -301,7 +301,7 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
 
         if (from == null)
         {
-            throw new Exception($"OfferedBy not found with partyId '{offeredByPartyId}'");
+            throw new KeyNotFoundException($"OfferedBy not found with partyId '{offeredByPartyId}'");
         }
 
         var result = await DbContext.AssignmentResources.AsNoTracking()
@@ -671,7 +671,7 @@ public class DelegationMetadataEF(IAuditAccessor AuditAccessor, AppDbContext DbC
 
                     await DbContext.SaveChangesAsync(cancellationToken);
 
-                    throw new Exception("Assignment or resource not found for given policy");
+                    throw new KeyNotFoundException("Assignment or resource not found for given policy");
                 }
 
                 var assignmentInstance = await DbContext.AssignmentInstances.FirstOrDefaultAsync(t => t.AssignmentId == assignment.Id && t.ResourceId == resource.Id && t.InstanceId == policy.Rules.InstanceId, cancellationToken);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AllAltinnRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AllAltinnRoleSyncService.cs
@@ -63,7 +63,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                 if (!page.IsSuccessful)
                 {
                     Log.ResponseError(_logger, page.StatusCode);
-                    throw new Exception("Stream page is not successful");
+                    throw new InvalidOperationException("Stream page is not successful");
                 }
 
                 var batchName = batchId.ToString().ToLower().Replace("-", string.Empty);
@@ -84,7 +84,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                         var assignment = await ConvertRoleDelegationModelToAssignment(appDbContext, item, batchId.ToString(), cancellationToken);
                         if (assignment.Assignment == null)
                         {
-                            throw new Exception("Failed to convert RoleModel to Assignment");
+                            throw new InvalidOperationException("Failed to convert RoleModel to Assignment");
                         }
 
                         currentOptions = assignment.Options;
@@ -148,7 +148,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Failed to ingest and/or merge Assignment and EntityLookup batch {0} to db", batchName);
-                        throw new Exception(string.Format("Failed to ingest and/or merge Assignment and EntityLookup batch {0} to db", batchName), ex);
+                        throw new InvalidOperationException($"Failed to ingest and/or merge Assignment and EntityLookup batch {batchName} to db", ex);
                     }
                     finally
                     {
@@ -182,7 +182,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
             }
             catch (Exception ex)
             {
-                throw new Exception(string.Format("Failed to convert model to Assignment. From:{0} To:{1} Role:{2}", model.FromPartyUuid, model.ToUserPartyUuid, model.RoleTypeCode), ex);
+                throw new InvalidOperationException($"Failed to convert model to Assignment. From:{model.FromPartyUuid} To:{model.ToUserPartyUuid} Role:{model.RoleTypeCode}", ex);
             }
         }
 
@@ -202,7 +202,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
 
             if (role == null)
             {
-                throw new Exception(string.Format("Unable to get role '{0}'", roleIdentifier));
+                throw new InvalidOperationException($"Unable to get role '{roleIdentifier}'");
             }
 
             Roles.Add(roleIdentifier, role);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AllAltinnRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AllAltinnRoleSyncService.cs
@@ -147,8 +147,8 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Failed to ingest and/or merge Assignment and EntityLookup batch {0} to db", batchName);
-                        throw new InvalidOperationException($"Failed to ingest and/or merge Assignment and EntityLookup batch {batchName} to db", ex);
+                        _logger.LogError(ex, "Failed to ingest and/or merge Assignment batch {0} to db", batchName);
+                        throw new InvalidOperationException($"Failed to ingest and/or merge Assignment batch {batchName} to db", ex);
                     }
                     finally
                     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnAdminRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnAdminRoleSyncService.cs
@@ -52,7 +52,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                 if (!page.IsSuccessful)
                 {
                     Log.ResponseError(_logger, page.StatusCode);
-                    throw new Exception("Stream page is not successful");
+                    throw new InvalidOperationException("Stream page is not successful");
                 }
 
                 Guid batchId = Guid.CreateVersion7();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnBankruptcyEstateRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnBankruptcyEstateRoleSyncService.cs
@@ -48,7 +48,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                 if (!page.IsSuccessful)
                 {
                     Log.ResponseError(_logger, page.StatusCode);
-                    throw new Exception("Stream page is not successful");
+                    throw new InvalidOperationException("Stream page is not successful");
                 }
 
                 Guid batchId = Guid.CreateVersion7();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnClientRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/AltinnClientRoleSyncService.cs
@@ -53,7 +53,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                 if (!page.IsSuccessful)
                 {
                     Log.ResponseError(_logger, page.StatusCode);
-                    throw new Exception("Stream page is not successful");
+                    throw new InvalidOperationException("Stream page is not successful");
                 }
 
                 Guid batchId = Guid.CreateVersion7();
@@ -130,7 +130,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
             var request = new ImportClientDelegationRequestDto()
             {
                 ClientId = delegationModel.FromPartyUuid,
-                AgentId = delegationModel.ToUserPartyUuid ?? throw new Exception($"'delegationModel.ToUserPartyUuid' does not have value"),
+                AgentId = delegationModel.ToUserPartyUuid ?? throw new InvalidOperationException("'delegationModel.ToUserPartyUuid' does not have value"),
                 AgentRole = "agent",
                 RolePackages = [],
                 Facilitator = facilitatorPartyId,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/PartySyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/PartySyncService.cs
@@ -65,7 +65,7 @@ public class PartySyncService : BaseSyncService, IPartySyncService
             if (page.IsProblem)
             {
                 Log.ResponseError(_logger, page.StatusCode);
-                throw new Exception("Stream page is not successful");
+                throw new InvalidOperationException("Stream page is not successful");
             }
 
             _logger.LogInformation("Starting proccessing party page ({0}-{1})", page.Content.Stats.PageStart, page.Content.Stats.PageEnd);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/PrivateTaxAffairRoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/PrivateTaxAffairRoleSyncService.cs
@@ -52,7 +52,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                 if (!page.IsSuccessful)
                 {
                     Log.ResponseError(_logger, page.StatusCode);
-                    throw new Exception("Stream page is not successful");
+                    throw new InvalidOperationException("Stream page is not successful");
                 }
 
                 Guid batchId = Guid.CreateVersion7();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/ResourceSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/ResourceSyncService.cs
@@ -202,7 +202,7 @@ public partial class ResourceSyncService : IResourceSyncService
         var role = await dbContext.Roles
             .AsNoTracking()
             .Where(r => EF.Functions.ILike(r.LegacyUrn, updatedResource.SubjectUrn) || EF.Functions.ILike(r.Urn, updatedResource.SubjectUrn))
-            .SingleOrDefaultAsync(cancellationToken) ?? throw new Exception(string.Format("Role not found '{0}'", subjectUrnPart));
+            .SingleOrDefaultAsync(cancellationToken) ?? throw new KeyNotFoundException($"Role not found '{subjectUrnPart}'");
 
         var roleResource = await dbContext.RoleResources.FirstOrDefaultAsync(t => t.RoleId == role.Id && t.ResourceId == resource.Id, cancellationToken);
         if (roleResource == null)
@@ -276,7 +276,7 @@ public partial class ResourceSyncService : IResourceSyncService
             return null;
         }
 
-        var resourceType = await GetOrCreateResourceType(dbContext, model, cancellationToken) ?? throw new Exception("Unable to get or create resourcetype");
+        var resourceType = await GetOrCreateResourceType(dbContext, model, cancellationToken) ?? throw new InvalidOperationException("Unable to get or create resourcetype");
         return new Resource()
         {
             Name = model.Title?.Nb ?? model.Identifier,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/RoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/RoleSyncService.cs
@@ -57,7 +57,7 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
             if (page.IsProblem)
             {
                 Log.ResponseError(_logger, page.StatusCode);
-                throw new Exception("Stream page is not successful");
+                throw new InvalidOperationException("Stream page is not successful");
             }
 
             _logger.LogInformation("Starting proccessing party page ({0}-{1})", page.Content.Stats.PageStart, page.Content.Stats.PageEnd);
@@ -184,7 +184,7 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to ingest and/or merge Assignment and EntityLookup batch {0} to db", batchId.ToString());
-            throw new Exception(string.Format("Failed to ingest and/or merge Assignment and EntityLookup batch {0} to db", batchId.ToString()), ex);
+            throw new InvalidOperationException($"Failed to ingest and/or merge Assignment and EntityLookup batch {batchId} to db", ex);
         }
     }
 
@@ -241,6 +241,6 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
             };
         }
 
-        throw new Exception(string.Format("Failed to convert model to Assignment. From:{0} To:{1} Role:{2}", model.FromParty, model.ToParty, model.RoleIdentifier));
+        throw new InvalidOperationException($"Failed to convert model to Assignment. From:{model.FromParty} To:{model.ToParty} Role:{model.RoleIdentifier}");
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/RoleSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/RoleSyncService.cs
@@ -183,8 +183,8 @@ public class RoleSyncService : BaseSyncService, IRoleSyncService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to ingest and/or merge Assignment and EntityLookup batch {0} to db", batchId.ToString());
-            throw new InvalidOperationException($"Failed to ingest and/or merge Assignment and EntityLookup batch {batchId} to db", ex);
+            _logger.LogError(ex, "Failed to ingest and/or merge Assignment batch {0} to db", batchId.ToString());
+            throw new InvalidOperationException($"Failed to ingest and/or merge Assignment batch {batchId} to db", ex);
         }
     }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleAppRightSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleAppRightSyncService.cs
@@ -54,7 +54,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                 if (!page.IsSuccessful)
                 {
                     Log.ResponseError(_logger, page.StatusCode);
-                    throw new Exception("Stream page is not successful");
+                    throw new InvalidOperationException("Stream page is not successful");
                 }
 
                 Guid batchId = Guid.CreateVersion7();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleInstanceRightSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleInstanceRightSyncService.cs
@@ -54,7 +54,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                 if (!page.IsSuccessful)
                 {
                     Log.ResponseError(_logger, page.StatusCode);
-                    throw new Exception("Stream page is not successful");
+                    throw new InvalidOperationException("Stream page is not successful");
                 }
 
                 Guid batchId = Guid.CreateVersion7();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleResourceRegistryRightSyncService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/HostedServices/Services/SingleResourceRegistryRightSyncService.cs
@@ -54,7 +54,7 @@ namespace Altinn.AccessMgmt.Core.HostedServices.Services
                 if (!page.IsSuccessful)
                 {
                     Log.ResponseError(_logger, page.StatusCode);
-                    throw new Exception("Stream page is not successful");
+                    throw new InvalidOperationException("Stream page is not successful");
                 }
 
                 Guid batchId = Guid.CreateVersion7();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/IngestService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/IngestService.cs
@@ -31,7 +31,7 @@ public class IngestService : IIngestService
     {
         if (ingestId.Equals(Guid.Empty))
         {
-            throw new Exception(string.Format("Ingest id '{0}' not valid", ingestId.ToString()));
+            throw new ArgumentException($"Ingest id '{ingestId}' not valid", nameof(ingestId));
         }
 
         var table = GetTableName<T>(DbContext.Model);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -152,7 +152,7 @@ public class ConnectionQuery(AppDbContext db)
                 }
                 catch (Exception ex)
                 {
-                    throw new Exception("Failed to include packages", ex);
+                    throw new InvalidOperationException("Failed to include packages", ex);
                 }
             }
 
@@ -165,7 +165,7 @@ public class ConnectionQuery(AppDbContext db)
             }
             catch (Exception ex)
             {
-                throw new Exception("Failed to include resources", ex);
+                throw new InvalidOperationException("Failed to include resources", ex);
             }
 
             try
@@ -177,7 +177,7 @@ public class ConnectionQuery(AppDbContext db)
             }
             catch (Exception ex)
             {
-                throw new Exception("Failed to include instances", ex);
+                throw new InvalidOperationException("Failed to include instances", ex);
             }
 
             if (filter.EnrichEntities || filter.ExcludeDeleted)
@@ -196,7 +196,7 @@ public class ConnectionQuery(AppDbContext db)
         }
         catch (Exception ex)
         {
-            throw new Exception($"Failed to get connections with filter: {JsonSerializer.Serialize(filter)}", ex);
+            throw new InvalidOperationException($"Failed to get connections with filter: {JsonSerializer.Serialize(filter)}", ex);
         }
     }
 


### PR DESCRIPTION
## Summary

Sweep a focused subset of the SonarCloud `csharpsquid:S112` (`'System.Exception' should not be thrown by user code`) findings in the AccessManagement vertical — ~22 sites across the hosted-service sync layer, `IngestService`, `ConnectionQuery`, `DelegationMetadataEF`, and `ResourceRegistryClient`.

Each throw moves to the semantically appropriate type:
- **`InvalidOperationException`** for upstream-stream failures (`Stream page is not successful` × 10), EF-query wrap throws (`ConnectionQuery` × 4), and ingest/convert failures (with inner exception preserved where one existed).
- **`KeyNotFoundException`** for missing-entity lookups (missing role, missing OfferedBy, missing consent template, missing assignment-or-resource).
- **`ArgumentException`** for parameter validation (`IngestTempData` rejecting `Guid.Empty`).

Scope deliberately excludes the legacy `Altinn.AccessMgmt.Persistence/Services/*` and `Altinn.AccessMgmt.Persistence.Core/*` (being replaced by their PersistenceEF / AccessMgmt.Core counterparts), `MockDataService` (dev seed), and the larger per-class clusters in `Altinn.AccessMgmt.Core/Services/DelegationService.cs` and `AssignmentService.cs` — those will follow as separate Tasks.

While touching each throw, four `string.Format("...{0}...", x)` calls are folded to interpolated strings.

No behaviour change beyond exception type; existing upstream `catch (Exception ex)` blocks remain catch-all.

## Test plan
- [x] `dotnet build src/apps/Altinn.AccessManagement` — 0 errors
- [x] `AccessMgmt.Tests` (`ConnectionQueryTests` + `RequestServiceTests` + broader run): 534 / 534 pass
- [ ] SonarCloud diff: `csharpsquid:S112` clean on the touched files; no new findings introduced on the converted throws

Closes #3163