### PR TITLE
chore: clear S112 throw-new-Exception in AccessMgmt.Core Delegation/AssignmentService

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AssignmentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AssignmentService.cs
@@ -653,13 +653,13 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         // Check if user has AccessManager (Tilgangsstyrer) role
         if (await HasRole(assignment.Id, user.Id, RoleConstants.AccessManager, cancellationToken))
         {
-            throw new UnauthorizedAccessException("User does not have permission to add resource to assignment");
+            throw new UnauthorizedAccessException("User does not have permission to remove package from assignment");
         }
 
         // Check if user has access to the package
         if (await HasPackage(assignment.Id, user.Id, package.Id, cancellationToken))
         {
-            throw new UnauthorizedAccessException($"User '{user.Name}' does not have resource '{package.Name}' for '{assignment.FromId}'");
+            throw new UnauthorizedAccessException($"User '{user.Name}' does not have package '{package.Name}' for '{assignment.FromId}'");
         }
 
         var obj = await db.AssignmentPackages.SingleAsync(t => t.AssignmentId == assignment.Id && t.PackageId == package.Id, cancellationToken);
@@ -680,7 +680,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         // Check if user has AccessManager (Tilgangsstyrer) role
         if (await HasRole(assignment.Id, user.Id, RoleConstants.AccessManager, cancellationToken))
         {
-            throw new UnauthorizedAccessException("User does not have permission to add resource to assignment");
+            throw new UnauthorizedAccessException("User does not have permission to remove resource from assignment");
         }
 
         // Check if user has access to the resource
@@ -707,7 +707,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         // Check if user has AccessManager (Tilgangsstyrer) role
         if (await HasRole(assignment.Id, user.Id, RoleConstants.AccessManager, cancellationToken))
         {
-            throw new UnauthorizedAccessException("User does not have permission to add resource to assignment");
+            throw new UnauthorizedAccessException("User does not have permission to remove instance from assignment");
         }
 
         // Check if user has access to the resource
@@ -1001,7 +1001,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
             return assignment;
         }
 
-        var role = await db.Roles.AsNoTracking().SingleAsync(t => t.Id == roleId, cancellationToken);
+        var role = await db.Roles.AsNoTracking().SingleOrDefaultAsync(t => t.Id == roleId, cancellationToken);
         if (role == null)
         {
             throw new KeyNotFoundException($"Role '{roleId}' not found");

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AssignmentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AssignmentService.cs
@@ -400,7 +400,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
 
         if (!await HasPackage(assignment.FromId, userId, package.Id, cancellationToken))
         {
-            throw new Exception(string.Format("User '{0}' does not have package '{1}'", user.Name, package.Name));
+            throw new UnauthorizedAccessException($"User '{user.Name}' does not have package '{package.Name}'");
         }
 
         await db.AssignmentPackages.AddAsync(
@@ -431,13 +431,13 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         // Check if user has AccessManager (Tilgangsstyrer) role
         if (await HasRole(assignment.Id, user.Id, RoleConstants.AccessManager, cancellationToken))
         {
-            throw new Exception("User does not have permission to add resource to assignment");
+            throw new UnauthorizedAccessException("User does not have permission to add resource to assignment");
         }
 
         // Check if user has access to the resource
         if (await HasResource(assignment.Id, user.Id, resource.Id, cancellationToken))
         {
-            throw new Exception(string.Format("User '{0}' does not have resource '{1}' for '{2}'", user.Name, resource.Name, assignment.FromId));
+            throw new UnauthorizedAccessException($"User '{user.Name}' does not have resource '{resource.Name}' for '{assignment.FromId}'");
         }
 
         db.AssignmentResources.Add(new AssignmentResource()
@@ -464,13 +464,13 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         // Check if user has AccessManager (Tilgangsstyrer) role
         if (await HasRole(assignment.Id, user.Id, RoleConstants.AccessManager, cancellationToken))
         {
-            throw new Exception("User does not have permission to add resource to assignment");
+            throw new UnauthorizedAccessException("User does not have permission to add resource to assignment");
         }
 
         // Check if user has access to the resource
         if (await HasResource(assignment.Id, user.Id, resource.Id, cancellationToken))
         {
-            throw new Exception(string.Format("User '{0}' does not have resource '{1}' for '{2}'", user.Name, resource.Name, assignment.FromId));
+            throw new UnauthorizedAccessException($"User '{user.Name}' does not have resource '{resource.Name}' for '{assignment.FromId}'");
         }
 
         db.AssignmentInstances.Add(new AssignmentInstance()
@@ -498,13 +498,13 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         // Check if user has AccessManager (Tilgangsstyrer) role
         if (await HasRole(assignment.Id, user.Id, RoleConstants.AccessManager, cancellationToken))
         {
-            throw new Exception("User does not have permission to add resource to assignment");
+            throw new UnauthorizedAccessException("User does not have permission to add resource to assignment");
         }
 
         // Check if user has access to the resource
         if (await HasResource(assignment.Id, user.Id, resource.Id, cancellationToken))
         {
-            throw new Exception(string.Format("User '{0}' does not have resource '{1}' for '{2}'", user.Name, resource.Name, assignment.FromId));
+            throw new UnauthorizedAccessException($"User '{user.Name}' does not have resource '{resource.Name}' for '{assignment.FromId}'");
         }
 
         var res = await db.AssignmentResources.AsTracking().FirstOrDefaultAsync(t => t.AssignmentId == assignmentId && t.ResourceId == resource.Id, cancellationToken);
@@ -574,13 +574,13 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         // Check if user has AccessManager (Tilgangsstyrer) role
         if (await HasRole(assignment.Id, user.Id, RoleConstants.AccessManager, cancellationToken))
         {
-            throw new Exception("User does not have permission to add resource to assignment");
+            throw new UnauthorizedAccessException("User does not have permission to add resource to assignment");
         }
 
         // Check if user has access to the resource
         if (await HasResource(assignment.Id, user.Id, resource.Id, cancellationToken))
         {
-            throw new Exception(string.Format("User '{0}' does not have resource '{1}' for '{2}'", user.Name, resource.Name, assignment.FromId));
+            throw new UnauthorizedAccessException($"User '{user.Name}' does not have resource '{resource.Name}' for '{assignment.FromId}'");
         }
 
         var res = await db.AssignmentInstances.AsTracking().FirstOrDefaultAsync(t => t.AssignmentId == assignmentId && t.ResourceId == resource.Id && t.InstanceId == instanceId, cancellationToken);
@@ -653,13 +653,13 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         // Check if user has AccessManager (Tilgangsstyrer) role
         if (await HasRole(assignment.Id, user.Id, RoleConstants.AccessManager, cancellationToken))
         {
-            throw new Exception("User does not have permission to add resource to assignment");
+            throw new UnauthorizedAccessException("User does not have permission to add resource to assignment");
         }
 
         // Check if user has access to the package
         if (await HasPackage(assignment.Id, user.Id, package.Id, cancellationToken))
         {
-            throw new Exception(string.Format("User '{0}' does not have resource '{1}' for '{2}'", user.Name, package.Name, assignment.FromId));
+            throw new UnauthorizedAccessException($"User '{user.Name}' does not have resource '{package.Name}' for '{assignment.FromId}'");
         }
 
         var obj = await db.AssignmentPackages.SingleAsync(t => t.AssignmentId == assignment.Id && t.PackageId == package.Id, cancellationToken);
@@ -680,13 +680,13 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         // Check if user has AccessManager (Tilgangsstyrer) role
         if (await HasRole(assignment.Id, user.Id, RoleConstants.AccessManager, cancellationToken))
         {
-            throw new Exception("User does not have permission to add resource to assignment");
+            throw new UnauthorizedAccessException("User does not have permission to add resource to assignment");
         }
 
         // Check if user has access to the resource
         if (await HasResource(assignment.Id, user.Id, resource.Id, cancellationToken))
         {
-            throw new Exception(string.Format("User '{0}' does not have resource '{1}' for '{2}'", user.Name, resource.Name, assignment.FromId));
+            throw new UnauthorizedAccessException($"User '{user.Name}' does not have resource '{resource.Name}' for '{assignment.FromId}'");
         }
 
         var obj = await db.AssignmentResources.SingleAsync(t => t.AssignmentId == assignment.Id && t.ResourceId == resource.Id, cancellationToken);
@@ -707,13 +707,13 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         // Check if user has AccessManager (Tilgangsstyrer) role
         if (await HasRole(assignment.Id, user.Id, RoleConstants.AccessManager, cancellationToken))
         {
-            throw new Exception("User does not have permission to add resource to assignment");
+            throw new UnauthorizedAccessException("User does not have permission to add resource to assignment");
         }
 
         // Check if user has access to the resource
         if (await HasResource(assignment.Id, user.Id, resource.Id, cancellationToken))
         {
-            throw new Exception(string.Format("User '{0}' does not have resource '{1}' for '{2}'", user.Name, resource.Name, assignment.FromId));
+            throw new UnauthorizedAccessException($"User '{user.Name}' does not have resource '{resource.Name}' for '{assignment.FromId}'");
         }
 
         var obj = await db.AssignmentInstances.SingleAsync(t => t.AssignmentId == assignment.Id && t.ResourceId == resource.Id && t.InstanceId == instanceId, cancellationToken);
@@ -986,7 +986,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         var roleResult = await db.Roles.AsNoTracking().Where(t => t.Code == roleCode).ToListAsync(cancellationToken);
         if (roleResult == null || !roleResult.Any())
         {
-            throw new Exception(string.Format("Role '{0}' not found", roleCode));
+            throw new KeyNotFoundException($"Role '{roleCode}' not found");
         }
 
         return await GetOrCreateAssignment(fromEntityId, toEntityId, roleResult.First().Id, cancellationToken: cancellationToken);
@@ -1004,7 +1004,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
         var role = await db.Roles.AsNoTracking().SingleAsync(t => t.Id == roleId, cancellationToken);
         if (role == null)
         {
-            throw new Exception(string.Format("Role '{0}' not found", roleId));
+            throw new KeyNotFoundException($"Role '{roleId}' not found");
         }
 
         /*
@@ -1166,7 +1166,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
 
         if (resource is null)
         {
-            throw new Exception(string.Format("Resource '{0}' not found", resourceName));
+            throw new KeyNotFoundException($"Resource '{resourceName}' not found");
         }
 
         var maskinportenResourceType = await db.ResourceTypes
@@ -1225,7 +1225,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
 
         if (resource is null)
         {
-            throw new Exception(string.Format("Resource '{0}' not found", resourceName));
+            throw new KeyNotFoundException($"Resource '{resourceName}' not found");
         }
 
         var resourceType = await db.ResourceTypes
@@ -1669,7 +1669,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
 
         if (resource is null)
         {
-            throw new Exception(string.Format("Resource '{0}' not found", resourceName));
+            throw new KeyNotFoundException($"Resource '{resourceName}' not found");
         }
 
         var resourceType = await db.ResourceTypes
@@ -1802,7 +1802,7 @@ public class AssignmentService(AppDbContext db, ConnectionQuery connectionQuery,
 
         if (resource is null)
         {
-            throw new Exception(string.Format("Resource '{0}' not found", resourceName));
+            throw new KeyNotFoundException($"Resource '{resourceName}' not found");
         }
 
         var maskinportenResourceType = await db.ResourceTypes

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
@@ -319,7 +319,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
         foreach (var rp in rolepacks)
         {
             // Find ClientPartyId Role
-            var clientRole = (await roleService.GetByCode(rp.Key)).First() ?? throw new KeyNotFoundException($"Role not found '{rp.Key}'");
+            var clientRole = (await roleService.GetByCode(rp.Key)).FirstOrDefault() ?? throw new KeyNotFoundException($"Role not found '{rp.Key}'");
 
             // Find ClientAssignment
             var clientAssignment = await assignmentService.GetAssignment(client.Id, facilitator.Id, clientRole.Id, cancellationToken) ?? throw new KeyNotFoundException($"Could not find client assignment '{client.Name}' - {clientRole.Code} - {facilitator.Name}");
@@ -404,7 +404,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
         foreach (var rp in rolepacks)
         {
             // Find ClientPartyId Role
-            var clientRole = (await roleService.GetByCode(rp.Key)).First() ?? throw new KeyNotFoundException($"Role not found '{rp.Key}'");
+            var clientRole = (await roleService.GetByCode(rp.Key)).FirstOrDefault() ?? throw new KeyNotFoundException($"Role not found '{rp.Key}'");
 
             // Find ClientAssignment
             var clientAssignment = await assignmentService.GetAssignment(client.Id, facilitator.Id, clientRole.Id, cancellationToken) ?? throw new KeyNotFoundException($"Could not find client assignment '{client.Name}' - {clientRole.Code} - {facilitator.Name}");

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
@@ -50,7 +50,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
 
         if (result == 0)
         {
-            throw new Exception("Failed to create delegation");
+            throw new InvalidOperationException("Failed to create delegation");
         }
 
         return await db.Delegations.AsNoTracking().SingleAsync(t => t.Id == delegation.Id, cancellationToken);
@@ -85,7 +85,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
 
         if (assignmentPackages.Count(t => t.AssignmentPackageId == packageId) == 0 && rolePackages.Count(t => t.Id == packageId) == 0)
         {
-            throw new Exception($"The source assignment does not have the package '{package.Name}'");
+            throw new InvalidOperationException($"The source assignment does not have the package '{package.Name}'");
         }
 
         db.DelegationPackages.Add(new DelegationPackage()
@@ -128,7 +128,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
             && roleResources.Count(t => t.Id == resourceId) == 0
             )
         {
-            throw new Exception($"The source assignment does not have the resource '{resource.Name}'");
+            throw new InvalidOperationException($"The source assignment does not have the resource '{resource.Name}'");
         }
 
         await db.DelegationResources.AddAsync(
@@ -148,10 +148,10 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
     public async Task<IEnumerable<CreateDelegationResponseDto>> CreateClientDelegation(CreateSystemDelegationRequestDto request, Guid facilitatorPartyId, CancellationToken cancellationToken)
     {
         // Find Facilitator
-        var facilitator = await entityService.GetEntity(facilitatorPartyId, cancellationToken) ?? throw new Exception(string.Format("Party not found '{0}' for facilitator", facilitatorPartyId));
+        var facilitator = await entityService.GetEntity(facilitatorPartyId, cancellationToken) ?? throw new KeyNotFoundException($"Party not found '{facilitatorPartyId}' for facilitator");
 
         // Find Client
-        var client = await entityService.GetEntity(request.ClientId, cancellationToken) ?? throw new Exception(string.Format("Party not found '{0}' for client", request.ClientId));
+        var client = await entityService.GetEntity(request.ClientId, cancellationToken) ?? throw new KeyNotFoundException($"Party not found '{request.ClientId}' for client");
 
         // Create Delegation and DelegationPackage(s)
         var delegations = await CreateClientDelegations(request, client, facilitator, cancellationToken);
@@ -164,13 +164,13 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
     public async Task<int> RevokeImportedClientDelegation(ImportClientDelegationRequestDto request, AuditValues audit, bool onlyRemoveA2Packages = true, CancellationToken cancellationToken = default)
     {
         // Find Client
-        var client = await entityService.GetEntity(request.ClientId, cancellationToken) ?? throw new Exception(string.Format("Party not found '{0}' for client", request.ClientId));
+        var client = await entityService.GetEntity(request.ClientId, cancellationToken) ?? throw new KeyNotFoundException($"Party not found '{request.ClientId}' for client");
 
         Entity facilitator = null;
         if (request.Facilitator.HasValue)
         {
             // Find Facilitator
-            facilitator = await entityService.GetEntity(request.Facilitator.Value, cancellationToken) ?? throw new Exception(string.Format("Party not found '{0}' for facilitator", request.Facilitator.Value));
+            facilitator = await entityService.GetEntity(request.Facilitator.Value, cancellationToken) ?? throw new KeyNotFoundException($"Party not found '{request.Facilitator.Value}' for facilitator");
 
             // Delete Delegation
             return await RevokeImportedClientDelegations(request, client, facilitator, audit, onlyRemoveA2Packages, cancellationToken);
@@ -197,7 +197,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
         int packagesRevoked = 0;
 
         // Find Agent Role
-        var agentRole = await db.Roles.AsNoTracking().FirstOrDefaultAsync(t => string.Equals(t.Code.ToLower(), request.AgentRole.ToLower()), cancellationToken) ?? throw new Exception(string.Format("Role not found '{0}'", request.AgentRole));
+        var agentRole = await db.Roles.AsNoTracking().FirstOrDefaultAsync(t => string.Equals(t.Code.ToLower(), request.AgentRole.ToLower()), cancellationToken) ?? throw new KeyNotFoundException($"Role not found '{request.AgentRole}'");
 
         // Verify Delegation Packages
         Dictionary<string, List<PackageDto>> rolepacks = await VerifyDelegationPackages(request);
@@ -220,7 +220,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
 
             var clientPackages = await assignmentService.GetPackagesForAssignment(clientAssignment.Id);
 
-            var agent = await entityService.GetEntity(request.AgentId, cancellationToken) ?? throw new Exception(string.Format("Could not find party '{0}'", request.AgentId));
+            var agent = await entityService.GetEntity(request.AgentId, cancellationToken) ?? throw new KeyNotFoundException($"Could not find party '{request.AgentId}'");
             var agentAssignment = await assignmentService.GetAssignment(facilitator.Id, agent.Id, agentRole.Id, cancellationToken);
             if (agentAssignment == null)
             {
@@ -293,10 +293,10 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
     public async Task<IEnumerable<CreateDelegationResponseDto>> ImportClientDelegation(ImportClientDelegationRequestDto request, AuditValues audit, CancellationToken cancellationToken)
     {
         // Find Facilitator
-        var facilitator = await entityService.GetEntity(request.Facilitator.Value, cancellationToken) ?? throw new Exception(string.Format("Party not found '{0}' for facilitator", request.Facilitator.Value));
+        var facilitator = await entityService.GetEntity(request.Facilitator.Value, cancellationToken) ?? throw new KeyNotFoundException($"Party not found '{request.Facilitator.Value}' for facilitator");
 
         // Find Client
-        var client = await entityService.GetEntity(request.ClientId, cancellationToken) ?? throw new Exception(string.Format("Party not found '{0}' for client", request.ClientId));
+        var client = await entityService.GetEntity(request.ClientId, cancellationToken) ?? throw new KeyNotFoundException($"Party not found '{request.ClientId}' for client");
 
         // Create Delegation and DelegationPackage(s)
         var delegations = await ImportClientDelegations(request, client, facilitator, audit, cancellationToken);
@@ -310,7 +310,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
         var result = new List<Delegation>();
 
         // Find Agent Role
-        var agentRole = await db.Roles.AsNoTracking().FirstOrDefaultAsync(t => t.Code == request.AgentRole, cancellationToken) ?? throw new Exception(string.Format("Role not found '{0}'", request.AgentRole));
+        var agentRole = await db.Roles.AsNoTracking().FirstOrDefaultAsync(t => t.Code == request.AgentRole, cancellationToken) ?? throw new KeyNotFoundException($"Role not found '{request.AgentRole}'");
 
         // Verify Delegation Packages
         Dictionary<string, List<PackageDto>> rolepacks = await VerifyDelegationPackages(request);
@@ -319,10 +319,10 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
         foreach (var rp in rolepacks)
         {
             // Find ClientPartyId Role
-            var clientRole = (await roleService.GetByCode(rp.Key)).First() ?? throw new Exception(string.Format("Role not found '{0}'", rp.Key));
+            var clientRole = (await roleService.GetByCode(rp.Key)).First() ?? throw new KeyNotFoundException($"Role not found '{rp.Key}'");
 
             // Find ClientAssignment
-            var clientAssignment = await assignmentService.GetAssignment(client.Id, facilitator.Id, clientRole.Id, cancellationToken) ?? throw new Exception(string.Format("Could not find client assignment '{0}' - {1} - {2}", client.Name, clientRole.Code, facilitator.Name));
+            var clientAssignment = await assignmentService.GetAssignment(client.Id, facilitator.Id, clientRole.Id, cancellationToken) ?? throw new KeyNotFoundException($"Could not find client assignment '{client.Name}' - {clientRole.Code} - {facilitator.Name}");
             var clientPackages = await assignmentService.GetPackagesForAssignment(clientAssignment.Id);
 
             Delegation delegation = null;
@@ -332,7 +332,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
                 var clientPackage = clientPackages.FirstOrDefault(t => t.PackageId == package.Id);
                 if (clientPackage == null)
                 {
-                    throw new Exception(string.Format("Party does not have the package '{0}'", package.Urn));
+                    throw new InvalidOperationException($"Party does not have the package '{package.Urn}'");
                 }
 
                 if (delegation == null)
@@ -340,14 +340,14 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
                     if (agentAssignment == null)
                     {
                         // Find Agent Entity
-                        var agent = await entityService.GetEntity(request.AgentId, cancellationToken) ?? throw new Exception(string.Format("Could not find party '{0}'", request.AgentId));
+                        var agent = await entityService.GetEntity(request.AgentId, cancellationToken) ?? throw new KeyNotFoundException($"Could not find party '{request.AgentId}'");
 
                         // Find or Create Agent Assignment
-                        agentAssignment = await GetOrCreateAssignment(facilitator, agent, agentRole, audit, cancellationToken) ?? throw new Exception(string.Format("Could not find or create assignment '{0}' - {1} - {2}", facilitator.Name, agentRole.Code, agent.Name));
+                        agentAssignment = await GetOrCreateAssignment(facilitator, agent, agentRole, audit, cancellationToken) ?? throw new InvalidOperationException($"Could not find or create assignment '{facilitator.Name}' - {agentRole.Code} - {agent.Name}");
                     }
 
                     // Find or Create Delegation
-                    delegation = await GetOrCreateDelegation(clientAssignment, agentAssignment, facilitator, audit, cancellationToken) ?? throw new Exception(string.Format("Could not find or create delegation '{0}' - {1} - {2}", client.Name, facilitator.Name, agentAssignment.Id));
+                    delegation = await GetOrCreateDelegation(clientAssignment, agentAssignment, facilitator, audit, cancellationToken) ?? throw new InvalidOperationException($"Could not find or create delegation '{client.Name}' - {facilitator.Name} - {agentAssignment.Id}");
                 }
 
                 // Find AssignmentPackageId or RolePackageId
@@ -358,7 +358,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
                 var delegationPackage = await GetOrCreateDelegationPackage(delegation.Id, package.Id, assignmentPackageId, rolePackageId, audit, cancellationToken);
                 if (delegationPackage == null)
                 {
-                    throw new Exception("Unable to add package to delegation");
+                    throw new InvalidOperationException("Unable to add package to delegation");
                 }
             }
 
@@ -395,7 +395,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
         var result = new List<Delegation>();
 
         // Find Agent Role
-        var agentRole = await db.Roles.AsNoTracking().FirstOrDefaultAsync(t => t.Code == request.AgentRole, cancellationToken) ?? throw new Exception(string.Format("Role not found '{0}'", request.AgentRole));
+        var agentRole = await db.Roles.AsNoTracking().FirstOrDefaultAsync(t => t.Code == request.AgentRole, cancellationToken) ?? throw new KeyNotFoundException($"Role not found '{request.AgentRole}'");
 
         // Verify Delegation Packages
         Dictionary<string, List<PackageDto>> rolepacks = await VerifyDelegationPackages(request);
@@ -404,10 +404,10 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
         foreach (var rp in rolepacks)
         {
             // Find ClientPartyId Role
-            var clientRole = (await roleService.GetByCode(rp.Key)).First() ?? throw new Exception(string.Format("Role not found '{0}'", rp.Key));
+            var clientRole = (await roleService.GetByCode(rp.Key)).First() ?? throw new KeyNotFoundException($"Role not found '{rp.Key}'");
 
             // Find ClientAssignment
-            var clientAssignment = await assignmentService.GetAssignment(client.Id, facilitator.Id, clientRole.Id, cancellationToken) ?? throw new Exception(string.Format("Could not find client assignment '{0}' - {1} - {2}", client.Name, clientRole.Code, facilitator.Name));
+            var clientAssignment = await assignmentService.GetAssignment(client.Id, facilitator.Id, clientRole.Id, cancellationToken) ?? throw new KeyNotFoundException($"Could not find client assignment '{client.Name}' - {clientRole.Code} - {facilitator.Name}");
             var clientPackages = await assignmentService.GetPackagesForAssignment(clientAssignment.Id);
 
             Delegation delegation = null;
@@ -419,7 +419,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
                 var clientPackage = clientPackages.FirstOrDefault(t => t.PackageId == package.Id);
                 if (clientPackage == null)
                 {
-                    throw new Exception(string.Format("Party does not have the package '{0}'", package.Urn));
+                    throw new InvalidOperationException($"Party does not have the package '{package.Urn}'");
                 }
 
                 if (delegation == null)
@@ -427,20 +427,20 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
                     if (agentAssignment == null)
                     {
                         // Find or Create Agent Entity
-                        var agent = await entityService.GetOrCreateEntity(request.AgentId, request.AgentName, request.AgentId.ToString(), EntityTypeConstants.SystemUser.Entity.Name, EntityVariantConstants.AgentSystem.Entity.Name, cancellationToken) ?? throw new Exception(string.Format("Could not find or create party '{0}' for agent", request.AgentId));
+                        var agent = await entityService.GetOrCreateEntity(request.AgentId, request.AgentName, request.AgentId.ToString(), EntityTypeConstants.SystemUser.Entity.Name, EntityVariantConstants.AgentSystem.Entity.Name, cancellationToken) ?? throw new InvalidOperationException($"Could not find or create party '{request.AgentId}' for agent");
 
                         // Handle existing agent entity found with different type or variant
                         if (agent.TypeId != EntityTypeConstants.SystemUser.Id || agent.VariantId != EntityVariantConstants.AgentSystem.Id)
                         {
-                            throw new Exception(string.Format("An entity with id '{0}' already exists and is not a valid agent SystemUser", request.AgentId));
+                            throw new InvalidOperationException($"An entity with id '{request.AgentId}' already exists and is not a valid agent SystemUser");
                         }
 
                         // Find or Create Agent Assignment
-                        agentAssignment = await GetOrCreateAssignment(facilitator, agent, agentRole) ?? throw new Exception(string.Format("Could not find or create assignment '{0}' - {1} - {2}", facilitator.Name, agentRole.Code, agent.Name));
+                        agentAssignment = await GetOrCreateAssignment(facilitator, agent, agentRole) ?? throw new InvalidOperationException($"Could not find or create assignment '{facilitator.Name}' - {agentRole.Code} - {agent.Name}");
                     }
 
                     // Find or Create Delegation
-                    delegation = await GetOrCreateDelegation(clientAssignment, agentAssignment, facilitator) ?? throw new Exception(string.Format("Could not find or create delegation '{0}' - {1} - {2}", client.Name, facilitator.Name, agentAssignment.Id));
+                    delegation = await GetOrCreateDelegation(clientAssignment, agentAssignment, facilitator) ?? throw new InvalidOperationException($"Could not find or create delegation '{client.Name}' - {facilitator.Name} - {agentAssignment.Id}");
                 }
 
                 // Find AssignmentPackageId or RolePackageId
@@ -451,7 +451,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
                 var delegationPackage = await GetOrCreateDelegationPackage(delegation.Id, package.Id, assignmentPackageId, rolePackageId);
                 if (delegationPackage == null)
                 {
-                    throw new Exception("Unable to add package to delegation");
+                    throw new InvalidOperationException("Unable to add package to delegation");
                 }
             }
 
@@ -472,7 +472,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
                 var package = await packageService.GetPackageByUrnValue(packageUrn);
                 if (package == null)
                 {
-                    throw new Exception(string.Format("Package not found '{0}'", packageUrn));
+                    throw new KeyNotFoundException($"Package not found '{packageUrn}'");
                 }
 
                 rolepacks[role].Add(package);
@@ -493,7 +493,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
                 var package = await packageService.GetPackageByUrnValue(packageUrn);
                 if (package == null)
                 {
-                    throw new Exception(string.Format("Package not found '{0}'", packageUrn));
+                    throw new KeyNotFoundException($"Package not found '{packageUrn}'");
                 }
 
                 rolepacks[role].Add(package);
@@ -605,7 +605,7 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
             // Get system from token
             if (roleProvider.Code != "sys-altinn3")
             {
-                throw new Exception(string.Format("You cannot create assignment with the role '{0}' ({1})", role.Name, role.Code));
+                throw new InvalidOperationException($"You cannot create assignment with the role '{role.Name}' ({role.Code})");
             }
 
             return await assignmentService.GetOrCreateAssignment(from.Id, to.Id, role.Id, audit, cancellationToken);


### PR DESCRIPTION
## Summary

Continuation of the S112 (`csharpsquid:S112` — `'System.Exception' should not be thrown by user code`) sweep started in #3172. Targets the two largest new-code clusters in the AccessManagement vertical: `AccessMgmt.Core/Services/DelegationService.cs` (31 sites) + `AssignmentService.cs` (21 sites).

Each throw moves to the semantically appropriate type — per-call judgment, not mechanical:
- **`KeyNotFoundException`** for missing-entity lookups (`?? throw new Exception("Party not found ...")`, `"Role not found ..."`, `"Package not found ..."`, `"Resource '<name>' not found"`, `"Could not find party ..."`, `"Could not find client assignment ..."`).
- **`UnauthorizedAccessException`** for `HasRole` / `HasPackage` / `HasResource` permission guards (matches the convention #3101 already introduced in `AssignmentService.AddPackageAssignment`).
- **`InvalidOperationException`** for invariant violations (`"Failed to create delegation"`, `"Party does not have the package '...'"`, `"Could not find or create assignment ..."`, `"Could not find or create delegation ..."`, `"Unable to add package to delegation"`, `"An entity with id '...' already exists and is not a valid agent SystemUser"`, `"You cannot create assignment with the role '...'"`).

Folds the touched `string.Format("...{0}...", x)` calls to interpolated strings.

**Pre-existing security gap (#3111) explicitly NOT touched here:** three sites in `AssignmentService.AddAssignmentResource` / `AddAssignmentInstance` / `UpsertAssignmentResource` have an inverted `HasRole` Tilgangsstyrer check AND pass `assignment.Id` where the helper expects a party id. Two bugs cancel out today (the check effectively no-ops). The exception type is swapped to `UnauthorizedAccessException` to match the surrounding pattern, but the conditional logic stays as the existing bug — #3111 fixes that in its own scoped Task.

No behaviour change beyond exception type; upstream `catch (Exception ex)` blocks remain catch-all.

## Test plan
- [x] `dotnet build src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core` — 0 errors
- [x] `AccessMgmt.Tests` (`DelegationServiceTests` + `AssignmentServiceTests` + `ConnectionQueryTests`): 521 / 521 pass
- [ ] SonarCloud diff: `csharpsquid:S112` clean on the touched files; no new findings introduced on the converted throws

Closes #3173
