### PR TITLE
chore: apply S2325 static modifier to private helpers in AccessMgmt.Core + PersistenceEF

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Health/HealthTelemetryFilter.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Health/HealthTelemetryFilter.cs
@@ -32,7 +32,7 @@ namespace Altinn.AccessManagement.Health
             Next.Process(item);
         }
 
-        private bool ExcludeItemTelemetry(ITelemetry item)
+        private static bool ExcludeItemTelemetry(ITelemetry item)
         {
             RequestTelemetry request = item as RequestTelemetry;
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Audit/AuditMiddleware.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Audit/AuditMiddleware.cs
@@ -115,7 +115,7 @@ public class AuditMiddleware : IMiddleware
         return TraceId(context);
     }
 
-    private async Task<Entity> GetEntityFromConsumerClaim(AppDbContext db, HttpContext context, ConsentPartyUrn party)
+    private static async Task<Entity> GetEntityFromConsumerClaim(AppDbContext db, HttpContext context, ConsentPartyUrn party)
     {
         if (party.IsOrganizationId(out var organizationIdentifier))
         {
@@ -128,7 +128,7 @@ public class AuditMiddleware : IMiddleware
     /// <summary>
     /// Find the special system user claim and return it as standard claim if available
     /// </summary>
-    private Claim? GetSystemUserClaim(IEnumerable<Claim>? claims)
+    private static Claim? GetSystemUserClaim(IEnumerable<Claim>? claims)
     {
         Claim? authorizationDetails = claims?.FirstOrDefault(c => c.Type.Equals("authorization_details"));
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -366,7 +366,7 @@ public class AuthorizedPartiesServiceEf(
         );
     }
 
-    private List<AuthorizedParty> MergeAuthorizePartyLists(IEnumerable<AuthorizedParty> a2AuthorizedParties, Dictionary<Guid, Entity> allA2Parties, IEnumerable<AuthorizedParty> a3AuthorizedParties, Dictionary<Guid, AuthorizedParty> allParties)
+    private static List<AuthorizedParty> MergeAuthorizePartyLists(IEnumerable<AuthorizedParty> a2AuthorizedParties, Dictionary<Guid, Entity> allA2Parties, IEnumerable<AuthorizedParty> a3AuthorizedParties, Dictionary<Guid, AuthorizedParty> allParties)
     {
         List<AuthorizedParty> result = a3AuthorizedParties.ToList();
 
@@ -509,7 +509,7 @@ public class AuthorizedPartiesServiceEf(
         return Tuple.Create(allPartiesDict, authorizedParties.AsEnumerable());
     }
 
-    private void EnrichWithPartiesWithAccessInfo(Dictionary<Guid, AuthorizedParty> parties, List<ConnectionQueryExtendedRecord> connections, AuthorizedPartiesFilters filters)
+    private static void EnrichWithPartiesWithAccessInfo(Dictionary<Guid, AuthorizedParty> parties, List<ConnectionQueryExtendedRecord> connections, AuthorizedPartiesFilters filters)
     {
         if (!filters.IncludeRoles && !filters.IncludeAccessPackages && !filters.IncludeResources && !filters.IncludeInstances)
         {
@@ -655,7 +655,7 @@ public class AuthorizedPartiesServiceEf(
         return filtered;
     }
 
-    private List<AuthorizedParty> GetFilteredA2Parties(IEnumerable<AuthorizedParty> parties, AuthorizedPartiesFilters filters)
+    private static List<AuthorizedParty> GetFilteredA2Parties(IEnumerable<AuthorizedParty> parties, AuthorizedPartiesFilters filters)
     {
         bool filterParties = filters.PartyFilter?.Count > 0;
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEfOld.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEfOld.cs
@@ -412,7 +412,7 @@ public class AuthorizedPartiesServiceEfOld(
         ).ToList();
     }
 
-    private IEnumerable<AuthorizedParty> MergeAuthorizePartyLists(IEnumerable<AuthorizedParty> a2AuthorizedParties, Dictionary<Guid, Entity> allA2Parties, IEnumerable<AuthorizedParty> a3AuthorizedParties, Dictionary<Guid, AuthorizedParty> allParties, AuthorizedPartiesFilters filters)
+    private static IEnumerable<AuthorizedParty> MergeAuthorizePartyLists(IEnumerable<AuthorizedParty> a2AuthorizedParties, Dictionary<Guid, Entity> allA2Parties, IEnumerable<AuthorizedParty> a3AuthorizedParties, Dictionary<Guid, AuthorizedParty> allParties, AuthorizedPartiesFilters filters)
     {
         List<AuthorizedParty> result = a3AuthorizedParties.ToList();
 
@@ -640,7 +640,7 @@ public class AuthorizedPartiesServiceEfOld(
         }
     }
 
-    private async Task EnrichWithResourceAndInstanceParties(Dictionary<Guid, AuthorizedParty> parties, List<DelegationChange> resourceDelegations, AuthorizedPartiesFilters filters)
+    private static async Task EnrichWithResourceAndInstanceParties(Dictionary<Guid, AuthorizedParty> parties, List<DelegationChange> resourceDelegations, AuthorizedPartiesFilters filters)
     {
         if (!filters.IncludeResources && !filters.IncludeInstances)
         {
@@ -681,7 +681,7 @@ public class AuthorizedPartiesServiceEfOld(
         }
     }
 
-    private List<AuthorizedParty> GetFilteredA2Parties(IEnumerable<AuthorizedParty> parties, AuthorizedPartiesFilters filters)
+    private static List<AuthorizedParty> GetFilteredA2Parties(IEnumerable<AuthorizedParty> parties, AuthorizedPartiesFilters filters)
     {
         bool filterParties = filters.PartyFilter?.Count > 0;
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
@@ -820,7 +820,7 @@ public partial class ConnectionService(
     private static ValidationProblemInstance ValidateWriteOpInput(Entity from, Entity to, ConnectionOptions options) =>
         ConnectionWriteValidation.ValidateWriteOpInput(from, to, options);
 
-    private ProblemInstance ValidateReadOpInput(Guid? fromId, Entity? from, Guid? toId, Entity? to, ConnectionOptions options)
+    private static ProblemInstance ValidateReadOpInput(Guid? fromId, Entity? from, Guid? toId, Entity? to, ConnectionOptions options)
     {
         if (from is { })
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Contexts/AppDbContext.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Contexts/AppDbContext.cs
@@ -154,7 +154,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.HasAnnotation(AuditExtensions.AnnotationName, AuditEFConfiguration.Version);
     }
 
-    private void ApplyViewConfiguration(ModelBuilder modelBuilder)
+    private static void ApplyViewConfiguration(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration<Connection>(new ConnectionConfiguration());
 
@@ -168,7 +168,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         */
     }
 
-    private void ApplyAuditConfiguration(ModelBuilder modelBuilder)
+    private static void ApplyAuditConfiguration(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration<AuditArea>(new AuditAreaConfiguration());
         modelBuilder.ApplyConfiguration<AuditAreaGroup>(new AuditAreaGroupConfiguration());
@@ -201,7 +201,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.ApplyConfiguration<AuditRequestAssignmentResource>(new AuditRequestAssignmentResourceConfiguration());
     }
 
-    private void ApplyConfiguration(ModelBuilder modelBuilder)
+    private static void ApplyConfiguration(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration<TranslationEntry>(new TranslationEntryConfiguration());
 
@@ -335,7 +335,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         }
     }
 
-    private void ValidateAuditValues(AuditValues audit)
+    private static void ValidateAuditValues(AuditValues audit)
     {
         if (audit == null || audit.ChangedBy == Guid.Empty || audit.ChangedBySystem == Guid.Empty || string.IsNullOrWhiteSpace(audit.OperationId))
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/AuditValues.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/AuditValues.cs
@@ -64,7 +64,7 @@ public class ReadOnlyInterceptor : SaveChangesInterceptor
         return base.SavingChangesAsync(eventData, result, cancellationToken);
     }
 
-    private void ThrowIfHasChanges(DbContext? context)
+    private static void ThrowIfHasChanges(DbContext? context)
     {
         if (context == null)
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/CustomMigrationsSqlGenerator.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/CustomMigrationsSqlGenerator.cs
@@ -292,7 +292,7 @@ public class CustomMigrationsSqlGenerator : NpgsqlMigrationsSqlGenerator
             .ToList();
     }
 
-    private string GenerateAuditInsertFunctionAndTrigger(string schema, string name, List<string> columns)
+    private static string GenerateAuditInsertFunctionAndTrigger(string schema, string name, List<string> columns)
     {
         var sb = new StringBuilder();
 
@@ -323,7 +323,7 @@ public class CustomMigrationsSqlGenerator : NpgsqlMigrationsSqlGenerator
         return sb.ToString();
     }
 
-    private string GenerateAuditUpdateFunctionAndTrigger(string schema, string name, List<string> columns)
+    private static string GenerateAuditUpdateFunctionAndTrigger(string schema, string name, List<string> columns)
     {
         var sb = new StringBuilder();
 
@@ -351,7 +351,7 @@ public class CustomMigrationsSqlGenerator : NpgsqlMigrationsSqlGenerator
         return sb.ToString();
     }
 
-    private string GenerateAuditDeleteFunctionAndTrigger(string schema, string name, List<string> columns)
+    private static string GenerateAuditDeleteFunctionAndTrigger(string schema, string name, List<string> columns)
     {
         var sb = new StringBuilder();
 
@@ -383,7 +383,7 @@ public class CustomMigrationsSqlGenerator : NpgsqlMigrationsSqlGenerator
         return sb.ToString();
     }
 
-    private string GenerateGrants(string schema, string table)
+    private static string GenerateGrants(string schema, string table)
     {
         var sb = new StringBuilder();
         sb.AppendLine($"GRANT SELECT, INSERT, UPDATE, DELETE, TRIGGER, REFERENCES ON TABLE {schema}.{table} TO platform_authorization;");


### PR DESCRIPTION
## Summary

Sweep `csharpsquid:S2325` (`Methods and properties that don't access instance data should be static`) findings in a focused, non-overlapping subset of the AccessManagement vertical. 19 private helper methods gain the `static` modifier:

- `HealthTelemetryFilter.ExcludeItemTelemetry`
- `AuditMiddleware.GetEntityFromConsumerClaim`, `GetSystemUserClaim`
- `AuthorizedPartiesServiceEf` × 3 helpers (`MergeAuthorizePartyLists`, `EnrichWithPartiesWithAccessInfo`, `GetFilteredA2Parties`)
- `AuthorizedPartiesServiceEfOld` × 3 helpers (same names, old variant)
- `ConnectionService.ValidateReadOpInput`
- `AppDbContext` × 4 helpers (`ApplyViewConfiguration`, `ApplyAuditConfiguration`, `ApplyConfiguration`, `ValidateAuditValues`)
- `AuditValues.ThrowIfHasChanges`
- `CustomMigrationsSqlGenerator` × 4 helpers (the trigger/grant generators)

All sites are `private` — no API surface impact, no override / interface implementation considerations. Method bodies unchanged.

Scope excludes:
- Files in flight on PR #3172 (hosted services, `IngestService`, `DelegationMetadataEF`) to avoid merge conflicts.
- Legacy `Altinn.AccessMgmt.Persistence/*` and `Altinn.AccessMgmt.Persistence.Core/*` (deferred per the deprecation arc).
- `Altinn.Authorization.ABAC` (published NuGet — breaking API).
- `Altinn.Authorization` vertical's `ContextHandler.cs` (separate Task).

## Test plan
- [x] `dotnet build src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement` — 0 errors
- [x] Full `AccessMgmt.Tests` suite: 1337 / 1337 pass
- [ ] SonarCloud diff: `csharpsquid:S2325` clean on the touched files; no new findings introduced

Closes #3177
