### PR TITLE
bugfix: support systemusers as accessmanagers for resource delegation

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ConnectionsController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ConnectionsController.cs
@@ -477,7 +477,7 @@ public class ConnectionsController(
             resourceObj = await resourceService.GetResource(resource, cancellationToken);
             if (resourceObj is null)
             {
-                ProblemDetails problem = Core.Errors.Problems.InvalidResource.ToProblemDetails();
+                ProblemDetails problem = Problems.InvalidResource.ToProblemDetails();
                 problem.Extensions["resource"] = resource;
                 return problem.ToActionResult();
             }
@@ -522,7 +522,7 @@ public class ConnectionsController(
         var resourceObj = await resourceService.GetResource(resource, cancellationToken);
         if (resourceObj is null)
         {
-            ProblemDetails problem = Core.Errors.Problems.InvalidResource.ToProblemDetails();
+            ProblemDetails problem = Problems.InvalidResource.ToProblemDetails();
             problem.Extensions["resource"] = resource;
             return problem.ToActionResult();
         }
@@ -598,7 +598,7 @@ public class ConnectionsController(
         [FromBody] RightKeyListDto rightKeys,
         CancellationToken cancellationToken = default)
     {
-        var byId = AuthenticationHelper.GetPartyUuid(HttpContext);
+        var byId = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
         var fromEntity = await EntityService.GetEntity(party, cancellationToken);
         var toEntity = await EntityService.GetEntity(to, cancellationToken);
         var by = await EntityService.GetEntity(byId, cancellationToken);
@@ -607,7 +607,7 @@ public class ConnectionsController(
 
         if (result.IsProblem)
         {
-            if (result.Problem.Equals(Core.Errors.Problems.InvalidResource))
+            if (result.Problem.Equals(Problems.InvalidResource))
             {
                 ProblemDetails problem = result.Problem.ToProblemDetails();
                 problem.Extensions["resource"] = resource;
@@ -639,7 +639,7 @@ public class ConnectionsController(
         [FromBody] RightKeyListDto updateDto,
         CancellationToken cancellationToken = default)
     {
-        var byId = AuthenticationHelper.GetPartyUuid(HttpContext);
+        var byId = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
         var fromEntity = await EntityService.GetEntity(party, cancellationToken);
         var toEntity = await EntityService.GetEntity(to, cancellationToken);
         var byEntity = await EntityService.GetEntity(byId, cancellationToken);
@@ -649,7 +649,7 @@ public class ConnectionsController(
 
         if (result.IsProblem)
         {
-            if (result.Problem.Equals(Core.Errors.Problems.InvalidResource))
+            if (result.Problem.Equals(Problems.InvalidResource))
             {
                 ProblemDetails problem = result.Problem.ToProblemDetails();
                 problem.Extensions["resource"] = resource;
@@ -705,13 +705,13 @@ public class ConnectionsController(
         [FromQuery(Name = "resource")] string resource,
         CancellationToken cancellationToken = default)
     {
-        Guid authenticatedUserUuid = AuthenticationHelper.GetPartyUuid(HttpContext);
+        Guid authenticatedUserUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
         string languageCode = this.GetLanguageCode();
 
         var result = await ConnectionService.ResourceDelegationCheck(authenticatedUserUuid, party, resource, ConfigureConnections, languageCode, cancellationToken: cancellationToken);
         if (result.IsProblem)
         {
-            if (result.Problem.Equals(Core.Errors.Problems.InvalidResource))
+            if (result.Problem.Equals(Problems.InvalidResource))
             {
                 ProblemDetails problem = result.Problem.ToProblemDetails();
                 problem.Extensions["resource"] = resource;
@@ -762,7 +762,7 @@ public class ConnectionsController(
             resourceObj = await resourceService.GetResource(resource, cancellationToken);
             if (resourceObj is null)
             {
-                ProblemDetails problem = Core.Errors.Problems.InvalidResource.ToProblemDetails();
+                ProblemDetails problem = Problems.InvalidResource.ToProblemDetails();
                 problem.Extensions["resource"] = resource;
                 problem.Extensions["instance"] = instance;
                 return problem.ToActionResult();
@@ -818,7 +818,7 @@ public class ConnectionsController(
         var resourceObj = await resourceService.GetResource(resource, cancellationToken);
         if (resourceObj is null)
         {
-            ProblemDetails problem = Core.Errors.Problems.InvalidResource.ToProblemDetails();
+            ProblemDetails problem = Problems.InvalidResource.ToProblemDetails();
             problem.Extensions["resource"] = resource;
             problem.Extensions["instance"] = instance;
             return problem.ToActionResult();
@@ -957,7 +957,7 @@ public class ConnectionsController(
         }
 
         // Proceed with instance delegation
-        var byId = AuthenticationHelper.GetPartyUuid(HttpContext);
+        var byId = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
         var fromEntity = await EntityService.GetEntity(party, cancellationToken);
         var toEntity = await EntityService.GetEntity(targetEntityId, cancellationToken);
         var by = await EntityService.GetEntity(byId, cancellationToken);
@@ -970,7 +970,7 @@ public class ConnectionsController(
 
         if (result.IsProblem)
         {
-            if (result.Problem.Equals(Core.Errors.Problems.InvalidResource))
+            if (result.Problem.Equals(Problems.InvalidResource))
             {
                 ProblemDetails problem = result.Problem.ToProblemDetails();
                 problem.Extensions["resource"] = resource;
@@ -1010,7 +1010,7 @@ public class ConnectionsController(
             return validationErrors.ToActionResult();
         }
 
-        var byId = AuthenticationHelper.GetPartyUuid(HttpContext);
+        var byId = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
         var fromEntity = await EntityService.GetEntity(party, cancellationToken);
         var toEntity = await EntityService.GetEntity(to, cancellationToken);
         var byEntity = await EntityService.GetEntity(byId, cancellationToken);
@@ -1020,7 +1020,7 @@ public class ConnectionsController(
 
         if (result.IsProblem)
         {
-            if (result.Problem.Equals(Core.Errors.Problems.InvalidResource))
+            if (result.Problem.Equals(Problems.InvalidResource))
             {
                 ProblemDetails problem = result.Problem.ToProblemDetails();
                 problem.Extensions["resource"] = resource;
@@ -1090,13 +1090,13 @@ public class ConnectionsController(
             return validationErrors.ToActionResult();
         }
 
-        Guid authenticatedUserUuid = AuthenticationHelper.GetPartyUuid(HttpContext);
+        Guid authenticatedUserUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
         string languageCode = this.GetLanguageCode();
 
         var result = await ConnectionService.InstanceDelegationCheck(authenticatedUserUuid, party, resource, instance, ConfigureConnections, languageCode, cancellationToken);
         if (result.IsProblem)
         {
-            if (result.Problem.Equals(Core.Errors.Problems.InvalidResource))
+            if (result.Problem.Equals(Problems.InvalidResource))
             {
                 ProblemDetails problem = result.Problem.ToProblemDetails();
                 problem.Extensions["resource"] = resource;
@@ -1138,7 +1138,7 @@ public class ConnectionsController(
         var resourceObj = await resourceService.GetResource(resource, cancellationToken);
         if (resourceObj is null)
         {
-            ProblemDetails problem = Core.Errors.Problems.InvalidResource.ToProblemDetails();
+            ProblemDetails problem = Problems.InvalidResource.ToProblemDetails();
             problem.Extensions["resource"] = resource;
             problem.Extensions["instance"] = instance;
             return problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/DELETE_AsSysUsrAdmin_Connections_RemovePerson.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/DELETE_AsSysUsrAdmin_Connections_RemovePerson.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 delete {
-  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{party}}&from={{party}}&to={{toPersonUuid}}
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{party}}&from={{party}}&to={{toPersonUuid}}&cascade=true
   body: json
   auth: inherit
 }
@@ -14,6 +14,7 @@ params:query {
   party: {{party}}
   from: {{party}}
   to: {{toPersonUuid}}
+  cascade: true
 }
 
 script:pre-request {

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/DELETE_AsSysUsrAdmin_Connections_RemovePerson.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/DELETE_AsSysUsrAdmin_Connections_RemovePerson.bru
@@ -1,0 +1,53 @@
+meta {
+  name: DELETE_AsSysUsrAdmin_Connections_RemovePerson
+  type: http
+  seq: 6
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{party}}&from={{party}}&to={{toPersonUuid}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  from: {{party}}
+  to: {{toPersonUuid}}
+}
+
+script:pre-request {
+  const sharedtestdata = require(`./testdata/sharedtestdata.js`);
+  const testdata = require(`./test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  bru.setVar("requestName", "DELETE_AsSysUsrAdmin_Connections_RemovePerson");
+  
+  bru.setVar("party", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.partyUuid);
+  bru.setVar("toPersonUuid", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.personRightholderToAdd.partyUuid);
+  
+  var getTokenParameters = {
+    auth_systemUserId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.partyUuid,
+    auth_orgNo: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.orgno,
+    auth_clientId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.clientId,
+    auth_tokenType: sharedtestdata.authTokenType.systemUser,
+    auth_scopes: sharedtestdata.auth_scopes.enduserSystemToOthersWrite
+  }
+  
+  const testTokenGenerator = require(`./TestToolsTokenGenerator.js`);
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken", token);
+}
+
+tests {
+  const testdata = require(`./test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  test(bru.getVar("requestName"), function() {
+    const data = res.getBody();
+    
+    expect(res.status).to.equal(204);  
+  });
+}
+
+docs {
+  Lager connection til person
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/GET_AsSysUsrAdmin_AccPkg_DelegationCheck.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/GET_AsSysUsrAdmin_AccPkg_DelegationCheck.bru
@@ -1,0 +1,97 @@
+meta {
+  name: GET_AsSysUsrAdmin_AccPkg_DelegationCheck
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/accesspackages/delegationcheck?party={{party}}&packages={{package}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  packages: {{package}}
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+vars:pre-request {
+  party: 08cb10ee-4f3d-461a-8b11-a6604fdf2cc2
+  resource: ttd-test-enkeltjeneste-ressurs-at22
+}
+
+script:pre-request {
+  const sharedtestdata = require(`./testdata/sharedtestdata.js`);
+  const testdata = require(`./test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  bru.setVar("requestName", "GET_AsSysUsrAdmin_AccPkg_DelegationCheck");
+  
+  bru.setVar("party", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.partyUuid);
+  bru.setVar("package", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.hasPackage);
+  
+  var getTokenParameters = {
+    auth_systemUserId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.partyUuid,
+    auth_orgNo: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.orgno,
+    auth_clientId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.clientId,
+    auth_tokenType: sharedtestdata.authTokenType.systemUser,
+    auth_scopes: sharedtestdata.auth_scopes.enduserSystemToOthersWrite
+  }
+  
+  const testTokenGenerator = require(`./TestToolsTokenGenerator.js`);
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken", token);
+}
+
+script:post-response {
+  
+  
+}
+
+tests {
+  
+  test(bru.getVar("requestName"), function() {
+    const body = res.getBody();
+    const data = body.data;
+    
+    expect(res.status).to.equal(200);
+    assert.isNotEmpty(data, "Expected data in response body to NOT be empty array");
+  
+    const innbyggerAccessPackagePrefix = 'urn:altinn:accesspackage:innbygger-';
+    const vergemalAccessPackagePrefix = 'urn:altinn:accesspackage:vergemal-';
+  
+    // Find if innbygger or vergemål packages are returned
+    const offending = body.data
+      .map((item, idx) => ({
+        idx,
+        urn: item?.package?.urn
+      }))
+      .filter(x =>
+        typeof x.urn === 'string' && (
+          x.urn.startsWith(innbyggerAccessPackagePrefix) ||
+          x.urn.startsWith(vergemalAccessPackagePrefix)
+        )
+      );
+  
+    // Assert none found; include details if the assertion fails
+    expect(
+      offending,
+      `Response contains ${offending.length} illegal packages for organizations: ` + offending.map(o => `[${o.idx}] ${o.urn}`).join(', ')
+    ).to.be.empty;
+  
+    // ✅ Assert result values for specific packages
+    const resultByUrn = urn => data.find(p => p.package.urn === urn)?.result;
+  
+    expect(resultByUrn("urn:altinn:accesspackage:posttjenester")).to.be.true;
+    
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/GET_AsSysUsrAdmin_Resource_DelegationCheck.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/GET_AsSysUsrAdmin_Resource_DelegationCheck.bru
@@ -1,0 +1,88 @@
+meta {
+  name: GET_AsSysUsrAdmin_Resource_DelegationCheck
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources/delegationcheck?party={{party}}&resource={{resource}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  resource: {{resource}}
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+vars:pre-request {
+  party: 08cb10ee-4f3d-461a-8b11-a6604fdf2cc2
+  resource: ttd-test-enkeltjeneste-ressurs-at22
+}
+
+script:pre-request {
+  const sharedtestdata = require(`./testdata/sharedtestdata.js`);
+  const testdata = require(`./test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  bru.setVar("requestName", "GET_AsSysUsrAdmin_Resource_DelegationCheck");
+  
+  bru.setVar("party", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.partyUuid);
+  bru.setVar("resource", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.hasResource);
+  
+  var getTokenParameters = {
+    auth_systemUserId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.partyUuid,
+    auth_orgNo: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.orgno,
+    auth_clientId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.clientId,
+    auth_tokenType: sharedtestdata.authTokenType.systemUser,
+    auth_scopes: sharedtestdata.auth_scopes.enduserSystemToOthersWrite
+  }
+  
+  const testTokenGenerator = require(`./TestToolsTokenGenerator.js`);
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken", token);
+}
+
+script:post-response {
+  
+  
+}
+
+tests {
+  const testdata = require(`./test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  test(bru.getVar("requestName"), function() {
+  
+    const data = res.getBody();
+    const expectedActions = ["read", "write"];
+  
+    expect(data.rights).to.be.an("array");
+    expect(data.rights.length).to.equal(expectedActions.length);
+    
+    const actualActions = data.rights.map(r => r.right.action.value);
+  
+    expect(actualActions).to.have.members(expectedActions);
+  
+    data.rights.forEach(r => {
+      expect(r.result).to.equal(true);
+      expect(r.reasonCodes).to.include("DelegationAccess");
+  
+      // Key should exist
+      expect(r.right.key).to.exist;
+  
+      // Resource in right should match the same resource refId
+      expect(r.right.resource).to.be.an("array");
+      expect(r.right.resource[0]).to.have.property("value", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.hasResource);
+  
+    });
+  });
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/POST_AsSysUsrAdmin_AccPkg_ToPerson.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/POST_AsSysUsrAdmin_AccPkg_ToPerson.bru
@@ -1,0 +1,63 @@
+meta {
+  name: POST_AsSysUsrAdmin_AccPkg_ToPerson
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/accesspackages?party={{party}}&from={{party}}&to={{toPersonUuid}}&package={{package}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  from: {{party}}
+  to: {{toPersonUuid}}
+  package: {{package}}
+}
+
+headers {
+  Accept: application/json
+}
+
+script:pre-request {
+  const sharedtestdata = require(`./testdata/sharedtestdata.js`);
+  const testdata = require(`./test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  bru.setVar("requestName", "POST_AsSysUsrAdmin_AccPkg_ToPerson");
+  
+  bru.setVar("party", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.partyUuid);
+  bru.setVar("toPersonUuid", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.personRightholderToAdd.partyUuid);
+  bru.setVar("package", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.hasPackage);
+  
+  var getTokenParameters = {
+    auth_systemUserId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.partyUuid,
+    auth_orgNo: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.orgno,
+    auth_clientId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.clientId,
+    auth_tokenType: sharedtestdata.authTokenType.systemUser,
+    auth_scopes: sharedtestdata.auth_scopes.enduserSystemToOthersWrite
+  }
+  
+  const testTokenGenerator = require(`./TestToolsTokenGenerator.js`);
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken", token);
+}
+
+script:post-response {
+  const data = res.getBody();
+  const packageId = data.packageId;
+  bru.setEnvVar("packageId", packageId)
+}
+
+tests {
+  
+  test(bru.getVar("requestName"), function() {
+    const data = res.getBody();
+    
+    expect(res.status).to.equal(200);
+    assert.isOk(data, "Expected response body to return created assignment package");
+    
+    assert.equal(data.packageId, "a736c33b-c15a-43ac-85be-a684630e1e59"); //posttjenester
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/POST_AsSysUsrAdmin_Connections_AddPerson.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/POST_AsSysUsrAdmin_Connections_AddPerson.bru
@@ -1,0 +1,66 @@
+meta {
+  name: POST_AsSysUsrAdmin_Connections_AddPerson
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{party}}&from={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  from: {{party}}
+}
+
+body:json {
+   {
+    "personidentifier": "{{pid}}", // fnr or username
+    "lastName": "{{lastName}}"
+  }
+}
+
+script:pre-request {
+  const sharedtestdata = require(`./testdata/sharedtestdata.js`);
+  const testdata = require(`./test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  bru.setVar("requestName", "POST_AsSysUsrAdmin_Connections_AddPerson");
+  
+  bru.setVar("party", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.partyUuid);
+  bru.setVar("pid", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.personRightholderToAdd.pid);
+  bru.setVar("lastName", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.personRightholderToAdd.lastName);
+  
+  var getTokenParameters = {
+    auth_systemUserId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.partyUuid,
+    auth_orgNo: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.orgno,
+    auth_clientId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.clientId,
+    auth_tokenType: sharedtestdata.authTokenType.systemUser,
+    auth_scopes: sharedtestdata.auth_scopes.enduserSystemToOthersWrite
+  }
+  
+  const testTokenGenerator = require(`./TestToolsTokenGenerator.js`);
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken", token);
+}
+
+tests {
+  const testdata = require(`./test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  test(bru.getVar("requestName"), function() {
+    const data = res.getBody();
+    
+    expect(res.status).to.equal(200);
+    assert.isOk(data, "Expected response body to return created assignment");
+    
+    assert.equal(data.fromId, bru.getVar("party").toLowerCase());
+    assert.equal(data.toId, testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.personRightholderToAdd.partyUuid);
+    assert.equal(data.roleId, "42cae370-2dc1-4fdc-9c67-c2f4b0f0f829"); //Rettighetshaver
+    
+  });
+}
+
+docs {
+  Lager connection til person
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/POST_AsSysUsrAdmin_Resource_ToPerson.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/POST_AsSysUsrAdmin_Resource_ToPerson.bru
@@ -1,0 +1,69 @@
+meta {
+  name: POST_AsSysUsrAdmin_Resource_ToPerson
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources/rights?party={{party}}&from={{party}}&to={{toPersonUuid}}&resource={{resource}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  from: {{party}}
+  to: {{toPersonUuid}}
+  resource: {{resource}}
+}
+
+headers {
+  Accept: application/json
+}
+
+body:json {
+  {
+    "DirectRightKeys": [
+      "01dc6fefd5fb4b227cc3c3a2a54770552d8d70bbfd92904b64830605827c6ce7a7", 
+      "0106eba799a182fa816d64d80160f6571ead1e44ccf9cfb0377712e791e00d8e00"
+    ]
+  }
+}
+
+script:pre-request {
+  const sharedtestdata = require(`./testdata/sharedtestdata.js`);
+  const testdata = require(`./test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/${bru.getEnvVar("tokenEnv")}.js`);
+  
+  bru.setVar("requestName", "POST_AsSysUsrAdmin_Resource_ToPerson");
+  
+  bru.setVar("party", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.partyUuid);
+  bru.setVar("toPersonUuid", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.personRightholderToAdd.partyUuid);
+  bru.setVar("resource", testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.hasResource);
+  
+  var getTokenParameters = {
+    auth_systemUserId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.partyUuid,
+    auth_orgNo: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.orgno,
+    auth_clientId: testdata.REGN_ULASTELIG_RETTFERDIG_TIGER.systemuser_tilgangsstyrer.clientId,
+    auth_tokenType: sharedtestdata.authTokenType.systemUser,
+    auth_scopes: sharedtestdata.auth_scopes.enduserSystemToOthersWrite
+  }
+  
+  const testTokenGenerator = require(`./TestToolsTokenGenerator.js`);
+  const token = await testTokenGenerator.getToken(getTokenParameters);
+  bru.setVar("bearerToken", token);
+}
+
+script:post-response {
+  const data = res.getBody();
+  const packageId = data.packageId;
+  bru.setEnvVar("packageId", packageId)
+}
+
+tests {
+  
+  test(bru.getVar("requestName"), function() {
+    const data = res.getBody();
+    
+    expect(res.status).to.equal(201);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/POST_AsSysUsrAdmin_Resource_ToPerson.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/POST_AsSysUsrAdmin_Resource_ToPerson.bru
@@ -53,12 +53,6 @@ script:pre-request {
   bru.setVar("bearerToken", token);
 }
 
-script:post-response {
-  const data = res.getBody();
-  const packageId = data.packageId;
-  bru.setEnvVar("packageId", packageId)
-}
-
 tests {
   
   test(bru.getVar("requestName"), function() {

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: SystemUserAsAccessManager
+  seq: 11
+}
+
+auth {
+  mode: inherit
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/at22.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/at22.js
@@ -1,0 +1,396 @@
+module.exports = 
+{
+  "env": "at22",
+  "resources": {
+    "clientDelgResourceId": "devtest_gar_bruno_client_resource",
+    "directDelgResourceId": "devtest_gar_bruno_direct_resource",
+    "forretningsforer-eiendomResourceId": "devtest_gar_bruno_forretningsforer_eiendom",
+    "regnskapsforer": "devtest_gar_bruno_client_resource",
+    "appResourceId": "app_ttd_authz-bruno-testapp1",
+    "appInstanceDelegation": {
+            "resourceId": "app_ttd_authz-bruno-instancedelegation",
+            "org": "ttd",
+            "app":  "authz-bruno-instancedelegation"
+        }
+  },
+  "REGN_ULASTELIG_RETTFERDIG_TIGER": {
+    "name": "ULASTELIG RETTFERDIG TIGER AS",
+    "orgno": "314242726",
+    "partyId": 51235100,
+    "partyUuid": "066148fe-7077-4484-b7ea-44b5ede0014e",
+    "dagligleder": {
+      "name": "OPPRIKTIG KAMEL",
+      "pid": "30856499983",
+      "userId": 20013154,
+      "partyId": 51181765,
+      "partyUuid": "a5eb95db-97fc-4bd4-a6f6-b9214bc24549"
+    },
+    "client_USENSUELL_UVIRKSOM_TIGER": {
+      "name": "USENSUELL UVIRKSOM TIGER AS",
+      "orgno": "312714051",
+      "partyId": 51581690,
+      "partyUuid": "c12f8f37-391b-4651-be09-05665f5acdb6",
+      "dagligleder": {
+        "name": "PRATSOM BRUKSRETT",
+        "pid": "21835298350",
+        "userId": 20013153,
+        "partyId": 50183755,
+        "partyUuid": "4d2a7c10-e7c7-4685-8485-c211246db5d3"
+      },
+      "subunit": {
+        "name": "USENSUELL UVIRKSOM TIGER AS",
+        "orgno": "315556155",
+        "partyId": 51794395,
+        "partyUuid": "86ae6d6a-3545-4956-b395-c67ca0df4e51"
+      },
+      "directPackageToDelegate": "skatt-naering"
+    },
+    "client_ENK_HUMAN_TOPP_KATT_BIL": {
+      "name": "HUMAN TOPP KATT BIL",
+      "orgno": "310329495",
+      "partyId": 51340351,
+      "partyUuid": "ab07bec2-fcd0-4563-908a-d9f564724252",
+      "innehaver": {
+        "name": "EVENTYRLIG FALK",
+        "pid": "31886896576",
+        "userId": 20013167,
+        "partyId": 50175254,
+        "partyUuid": "00273506-3b4a-4e8e-a1f7-b7f28c4b411b"
+      },
+      "subunit": {
+        "name": "HUMAN TOPP KATT BIL",
+        "orgno": "315821525",
+        "partyId": 51818525,
+        "partyUuid": "ae9e37d4-0818-4c9f-9869-45e8049b64e0"
+      }
+    },
+    "client_WITHOUT_CLIENTDELEGATION": {
+      "name": "UNYTTIG MANGE TIGER AS",
+      "orgno": "313750531",
+      "partyId": 51653860,
+      "partyUuid": "0fcdee75-036a-47d9-ab40-5e55509a5b26"
+    },
+    "client_rightholderOrg1": {
+      "name": "TOPP FIRKANTET TIGER AS",
+      "orgno": "311127845",
+      "partyId": 51410913,
+      "partyUuid": "703c2e1e-d27c-40a1-b138-46b4f1a01b33",
+      "dagligleder": {
+        "name": "SAMTIDIG MATEMATIKER",
+        "pid": "07888397161",
+        "userId": 20013287,
+        "partyId": 50784075,
+        "partyUuid": "f75f209d-ce25-413e-b635-54897dc8400e"
+      },
+      "directPackageToDelegate": "motorvognavgift",
+      "directPackageToDelegate2": "skatt-naering",
+      "directPackageTilgangsstyrer": "tilgangsstyrer"
+    },
+    "client_rightholderOrg2": {
+      "name": "STOLT BETYDELIG TIGER AS",
+      "orgno": "313816915",
+      "partyId": 51658393,
+      "partyUuid": "ffa48a06-6a01-4fc7-ae5e-8aaff6c1a850",
+      "dagligleder": {
+        "name": "SKRAVLETE KAMERA",
+        "pid": "05838299719",
+        "userId": 20016888,
+        "partyId": 50922937,
+        "partyUuid": "11e6a957-5a74-4a10-b89f-c557ccca5b34"
+      },
+      "subunit": {
+        "name": "STOLT BETYDELIG TIGER AS",
+        "orgno": "315043336",
+        "partyId": 51747770,
+        "partyUuid": "1044638b-f6ad-4e6c-a341-11a6eac4d8b8",
+        "packageDelegatedToPerson": "skatt-naering",
+        "packageDelegatedToKeyRoleUnit": "kjop-og-salg-eiendom",
+        "roleDelegatedToPerson": "HVASK",
+        "roleDelegatedToKeyRoleUnit": "LOPER",
+        "resourceIdDelegatedToPerson": "devtest_gar_authparties-sub-to-person",
+        "resourceIdDelegatedToKeyRoleUnit": "devtest_gar_authparties-sub-to-org",
+        "instanceIdDelegatedToPerson": "9158bcbc-fca0-44d5-b049-93a78fce7a70",
+        "instanceRefDelegatedToPerson": "urn:altinn:instance-id:51747770/9158bcbc-fca0-44d5-b049-93a78fce7a70",
+        "instanceIdDelegatedToKeyRoleUnit": "a8084cad-202d-4435-be49-8c4bffd48b0c",
+        "instanceRefDelegatedToKeyRoleUnit": "urn:altinn:instance-id:51747770/a8084cad-202d-4435-be49-8c4bffd48b0c"
+      },
+      "directPackageToDelegate": "mobler-og-annen-industri",
+      "directPackageToDelegate2": "revisorattesterer",
+      "packageDelegatedToPerson": "lonn",
+      "roleDelegatedToPerson": "UTINN",
+      "roleDelegatedToKeyRoleUnit": "REGNA",
+      "resourceIdDelegatedToPerson": "devtest_gar_authparties-main-to-person",
+      "resourceIdDelegatedToKeyRoleUnit": "devtest_gar_authparties-main-to-org",
+      "appIdDelegatedToPerson": "app_ttd_authz-bruno-testapp1",
+      "appIdDelegatedToKeyRoleUnit": "app_ttd_authz-bruno-testapp2",
+      "instanceIdDelegatedToPerson": "4d52d719-b48d-474f-ba5c-022e5f2704b9",
+      "instanceRefDelegatedToPerson": "urn:altinn:instance-id:51658393/4d52d719-b48d-474f-ba5c-022e5f2704b9",
+      "instanceIdDelegatedToKeyRoleUnit": "f54e6f9c-f9cd-437e-9c75-8436252a2821",
+      "instanceRefDelegatedToKeyRoleUnit": "urn:altinn:instance-id:51658393/f54e6f9c-f9cd-437e-9c75-8436252a2821"
+    },
+    "client_ENK_DELETED_2025_11_27_InnehaverAccess": {
+      "name": "SJELDEN REN KATT KONJAKK",
+      "orgno": "313744019",
+      "partyId": 51653406,
+      "partyUuid": "1fbd06a3-3654-460b-8917-d9f4f9664625",
+      "innehaver": {
+        "name": "PRATSOM SKOLE",
+        "pid": "19846999968",
+        "userId": 20820830,
+        "partyId": 51175128,
+        "partyUuid": "ab0e4f41-4dbe-4198-bc69-6429cbfb6989"
+      },
+      "subunit": {
+        "name": "SJELDEN REN KATT KONJAKK",
+        "orgno": "314964055",
+        "partyId": 51740562,
+        "partyUuid": "ce662cb7-f781-4771-bbd3-2cbb291e523f"
+      }
+    },
+    "client_ENK_DELETED_2023_11_01_NoInnehaverAccess": {
+      "name": "OMSORGSFULL KUL KATT SKATOLL",
+      "orgno": "312282054",
+      "partyId": 51545196,
+      "partyUuid": "2c3b1064-2289-4217-b5de-41038ea86158",
+      "innehaver": {
+        "name": "SYMPATISK LINJE",
+        "pid": "24887299168",
+        "userId": 20946709,
+        "partyId": 50218861,
+        "partyUuid": "c5950a52-d4b4-454d-8cdf-a9c78bda6ff8"
+      },
+      "subunit": {
+        "name": "OMSORGSFULL KUL KATT SKATOLL",
+        "orgno": "315252946",
+        "partyId": 51766826,
+        "partyUuid": "893c7aae-e228-4e64-9643-38116d67eb39"
+      }
+    },
+    "a2_klientadministrator": {
+      "name": "RUSTEN AKVARELL",
+      "pid": "11860198721",
+      "userId": 20013151,
+      "partyId": 50395759,
+      "partyUuid": "5d4119c2-6a3a-4aec-ac72-7b78ad456d12"
+    },
+    "a2_hovedadministrator": {
+      "name": "MATEMATISK UNIVERSITET",
+      "pid": "03899798324",
+      "userId": 20013152,
+      "partyId": 50345170,
+      "partyUuid": "15977366-d191-4762-bb53-562461cab5c5"
+    },
+    "a2_tilgangsstyrer": {
+      "name": "GLEMSOM GREND",
+      "pid": "27920898721",
+      "userId": 20013157,
+      "partyId": 50382857,
+      "partyUuid": "f489878a-927f-4789-9dab-ff73c36c2f26"
+    },
+    "revisor": {
+      "name": "OVERFLADISK LANG TIGER AS",
+      "orgno": "310267511",
+      "partyId": 51235849,
+      "partyUuid": "037a33d1-af1c-4156-9506-86d63a09f6a6",
+      "directPackageToDelegate": "revisorattesterer"
+    },
+    "systemuser": {
+      "name": "Fiken",
+      "partyUuid": "aae74f4e-cae4-4237-a1da-c1b62a61fe4b",
+      "directPackageToDelegate": "urn:altinn:accesspackage:ansettelsesforhold",
+      "clientPackageToDelegate": "urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet",
+      "clientEnkPackageToDelegate": "urn:altinn:accesspackage:regnskapsforer-lonn",
+      "clientPackageForDelete": "urn:altinn:accesspackage:regnskapsforer-uten-signeringsrettighet"
+    },
+    "systemuser_tilgangsstyrer": {
+      "name": "314242726_bruno-systembruker-som-tilgangsstyrer",
+      "clientId": "76db1f73-9895-41c0-8f76-09e8ebaee6c9",
+      "partyUuid": "171bd27b-31d2-409b-89b7-b88cb5b6bae3",
+      "hasPackage": "posttjenester",
+      "hasResource": "authz_bruno_gar_resource1",
+      "personRightholderToAdd": {
+        "name": "UMUSIKALSK SEPTEMBER KARTLEGGING",
+        "lastName": "KARTLEGGING",
+        "pid": "21887997923",
+        "userId": 20549173,
+        "partyId": 51229900,
+        "partyUuid": "717d33eb-e3f6-4515-b0fa-530ddba6760e"
+      },
+    },
+    "subunit": {
+      "name": "ULASTELIG RETTFERDIG TIGER AS",
+      "orgno": "314613155",
+      "partyId": 51708660,
+      "partyUuid": "825d14bf-b3f3-4d68-ae33-0994febf8a43"
+    },
+    "employee_rightholderWithoutPackages": {
+      "name": "MOBIL LAMA",
+      "lastname": "LAMA",
+      "pid": "31858374521",
+      "userId": 20429745,
+      "partyId": 50427753,
+      "partyUuid": "582591cd-b618-4c6f-a0e2-b2c6fe70eb70"
+    },
+    "employee_rightholderWithPackages": {
+      "name": "STOR UTHOLDEN AUTORITET ANSIKTSKREM",
+      "lastname": "ANSIKTSKREM",
+      "pid": "27877695722",
+      "userId": 20962455,
+      "partyId": 51233907,
+      "partyUuid": "c8ded0aa-60b5-4007-9429-6acca2f88031",
+      "directPackageToDelegate": "revisorattesterer",
+      "directPackageTilgangsstyrer": "tilgangsstyrer"
+    },
+    "employee_instancedelegator": {
+      "name": "LYS MAMMA",
+      "lastname": "MAMMA",
+      "pid": "01818199690",
+      "userId": 20774140,
+      "partyId": 50363273,
+      "partyUuid": "a126547a-ae41-47c7-a63e-9d0f516ecd30",
+      "directPackageToDelegate": "post-til-virksomheten-med-taushetsbelagt-innhold",
+      "directPackageInstanceDelegator": "tilgangsstyring-enkeltinstanser",
+      "instanceThroughInstanceDelegation": "urn:altinn:instance-id:51235100/d64cdc13-8762-460c-9a9a-a727e3f8942e",
+      "instanceThroughPackageAccess": ""
+    },
+    "employee_agent_enk": {
+      "name": "KUL KJENNING",
+      "lastname": "KJENNING",
+      "pid": "20876795923",
+      "userId": 2421354,
+      "partyId": 50929567,
+      "partyUuid": "da6649e7-969e-48c4-8f31-3749f6612cf3"
+    }
+  },
+  "a2BrunoSIUser": {
+    "name": "A2BrunoSIUser",
+    "username": "a2brunosiuser",
+    "userId": 21226088,
+    "partyId": 51842409,
+    "partyUuid": "2c496351-cdc6-402a-b4f8-2b1145bb626e"
+  },
+  "a2BrunoECUser": {
+    "name": "bruno_ec_digdir",
+    "username": "bruno_ec_digdir",
+    "userId": 21226091,
+    "partyId": 50088610,
+    "partyUuid": "B2139D9E-811B-48BD-81A7-7EDD79A84D69"
+  },
+  "forretningsforerNonfigurativEmosjonellPuma": {
+    "name": "NONFIGURATIV EMOSJONELL PUMA",
+    "orgno": "313760243",
+    "partyId": 51317416,
+    "partyUuid": "a3846553-4f56-4dd3-addc-d2a79b663b51",
+    "dagligleder": {
+      "name": "SPETTETE DALSIDE",
+      "pid": "08817696563",
+      "userId": 21129089,
+      "partyId": 50639183,
+      "partyUuid": "ec30c235-d7f6-432b-b060-bdbbe9cdd8ec"
+    },
+    "subunit": {
+      "name": "NONFIGURATIV EMOSJONELL PUMA",
+      "orgno": "312145529",
+      "partyId": 51535215,
+      "partyUuid": "480c7f77-4ca2-4467-aff2-c358d8288f6e"
+    },
+    "esekClient": {
+      "name": "LETT SLEM LØVE SAMEIE",
+      "orgno": "313184390",
+      "partyId": 51614735,
+      "partyUuid": "1d53cb86-18e0-45d7-b777-8a06c3d55fc3",
+      "dagligleder": {
+        "name": "??",
+        "pid": "??",
+        "userId": 0,
+        "partyId": 0,
+        "partyUuid": "??"
+      },
+      "clientPackage": "forretningsforer-eiendom"
+    },
+    "nonBrlEsekClient": {
+      "name": "SKEPTISK LILLA HEST BORETTSLAG",
+      "orgno": "311115057",
+      "partyId": 51409777,
+      "partyUuid": "02f2e6c8-b67e-4ee7-b98d-8c6541eb0bfa",
+      "dagligleder": {
+        "name": "??",
+        "pid": "??",
+        "userId": 0,
+        "partyId": 0,
+        "partyUuid": "??"
+      }
+    }
+  },
+  "regnVennligProaktivTiger": {
+      "name": "VENNLIG PROAKTIV TIGER AS",
+      "orgno": "314063945",
+      "partyId": 51237765,
+      "partyUuid": "5bdfb2be-9453-4dbe-93a9-dae246c0dc52",
+      "dagligleder": {
+        "name": "STRENG INFORMASJON",
+        "pid": "13847599221",
+        "userId": 20557677,
+        "partyId": 50191020,
+        "partyUuid": "734ab63e-f516-4629-95f6-52c7ee7641ae"
+      },
+      "enkClient": {
+        "name": "FALSK UAVHENGIG KATT LERKETRE",
+        "orgno": "313079422",
+        "partyId": 51461290,
+        "partyUuid": "f87ad063-b922-4160-9c68-d4dea27e47c7",
+        "innehaver": {
+          "name": "PARODISK KANIN",
+          "pid": "30847798161",
+          "userId": 20756999,
+          "partyId": 50291135,
+          "partyUuid": "9d82394b-d77f-4947-b5c4-d89c24d01c92"
+        },
+      }
+    },
+  "regnskapsforerShowClientUnitsFalse": {
+    "name": "FROM TYPISK TIGER AS",
+    "orgno": "310592676",
+    "partyId": 51235598,
+    "partyUuid": "0031ace1-895b-4b56-9820-1be22119a6b7",
+    "dagligleder": {
+      "name": "VIS DØR",
+      "pid": "02827399623",
+      "userId": 20480629,
+      "partyId": 50930332,
+      "partyUuid": "64aceb43-3ed5-46a3-bed4-bd35e212e50f"
+    },
+    "subunit": {
+      "name": "GYLDEN KNUSLETE FJELLREV",
+      "orgno": "212334782",
+      "partyId": 51265690,
+      "partyUuid": "4133091e-31c7-41b6-b7cb-251c44ff37e4"
+    }
+  },
+  "rightholderThroughDelegationToSubunitAndKeyRole": {
+    "name": "LATTERMILD LYDIG KATT FLAGG",
+    "orgno": "210367802",
+    "partyId": 51239663,
+    "partyUuid": "c2af12db-4a05-4f10-aa9a-834c280d24cc",
+    "dagligleder": {
+      "name": "FLINK PUSEKATT",
+      "pid": "27917995783",
+      "userId": 20347188,
+      "partyId": 50283018,
+      "partyUuid": "46b30689-b48c-4c30-9861-50b8302b6cc5"
+    },
+    "subunit": {
+      "name": "LATTERMILD LYDIG KATT FLAGG",
+      "orgno": "315703492",
+      "partyId": 51807792,
+      "partyUuid": "adfe37c7-d5a2-41a8-a3db-7268e9ba5926"
+    }
+  },
+  "idportenEmailUser": {
+    "name": "am-bruno-automated-tests@mailinator.com",
+    "emailId": "am-bruno-automated-tests@mailinator.com",
+    "userId": 21228268,
+    "partyId": 51844582,
+    "partyUuid": "c356ff8f-fb44-4d21-9052-ac5376b7d7bf",
+  }
+};

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: testdata
+  seq: 7
+}
+
+auth {
+  mode: inherit
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/tt02.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/tt02.js
@@ -205,7 +205,7 @@ module.exports =
         "systemuser_tilgangsstyrer": {
             "name": "314242726_bruno-systembruker-som-tilgangsstyrer",
             "clientId": "76db1f73-9895-41c0-8f76-09e8ebaee6c9",  
-            "partyUuid": "", // ToDo: Create for TT02
+            "partyUuid": "7ba107f5-19ae-4342-b8c2-ced6501a0adb",
             "hasPackage": "urn:altinn:accesspackage:posttjenester",
             "hasResource": "urn:altinn:resource:authz_bruno_gar_resource1",
             "personRightholderToAdd": {

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/tt02.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Connections/SystemUserAsAccessManager/testdata/tt02.js
@@ -1,0 +1,394 @@
+module.exports = 
+{
+    "env": "tt02",
+    "resources": {
+        "clientDelgResourceId": "devtest_gar_bruno_client_resource",
+        "directDelgResourceId": "devtest_gar_bruno_direct_resource",
+        "forretningsforer-eiendomResourceId": "devtest_gar_bruno_forretningsforer_eiendom",
+        "regnskapsforer": "devtest_gar_bruno_client_resource",
+        "appResourceId": "app_ttd_authz-bruno-testapp1",
+        "appInstanceDelegation": {
+            "resourceId": "app_ttd_authz-bruno-instancedelegation",
+            "org": "ttd",
+            "app": "authz-bruno-instancedelegation"
+        }
+    },
+    "REGN_ULASTELIG_RETTFERDIG_TIGER": {
+        "name": "ULASTELIG RETTFERDIG TIGER AS",
+        "orgno": "314242726",
+        "partyId": 51448647,
+        "partyUuid": "a0c79e9c-dc4d-4a0e-8493-a76350c5b80c",
+        "dagligleder": {
+            "name": "OPPRIKTIG KAMEL",
+            "pid": "30856499983",
+            "userId": 1442919,
+            "partyId": 51429726,
+            "partyUuid": "b5be92ce-e3e1-4c0f-bd02-b9ad6d75f3fe"
+        },
+        "client_USENSUELL_UVIRKSOM_TIGER": {
+            "name": "USENSUELL UVIRKSOM TIGER AS",
+            "orgno": "312714051",
+            "partyId": 51795224,
+            "partyUuid": "fd4ade4c-4463-485c-a764-172d4bde3b33",
+            "dagligleder": {
+                "name": "PRATSOM BRUKSRETT",
+                "pid": "21835298350",
+                "userId": 1442920,
+                "partyId": 50680376,
+                "partyUuid": "66cc755e-0f5a-47c9-bc56-2233e758b5d5"
+            },
+            "subunit": {
+                "name": "USENSUELL UVIRKSOM TIGER AS",
+                "orgno": "315556155",
+                "partyId": 52007751,
+                "partyUuid": "0f08aee7-a6e9-4674-ba2d-517bd31e3941"
+            },
+            "directPackageToDelegate": "skatt-naering"
+        },
+        "client_ENK_HUMAN_TOPP_KATT_BIL": {
+            "name": "HUMAN TOPP KATT BIL",
+            "orgno": "310329495",
+            "partyId": 51553883,
+            "partyUuid": "c22bb8e6-f08d-48ea-bd62-423c51662458",
+            "innehaver": {
+                "name": "EVENTYRLIG FALK",
+                "pid": "31886896576",
+                "userId": 1442143,
+                "partyId": 51109591,
+                "partyUuid": "45e8ce49-a21a-4788-87e4-5dd48c78fa30"
+            },
+            "subunit": {
+                "name": "HUMAN TOPP KATT BIL",
+                "orgno": "315821525",
+                "partyId": 52031876,
+                "partyUuid": "15068436-f4bb-4c3c-8ce7-5f0d5c7beb71"
+            }
+        },
+        "client_WITHOUT_CLIENTDELEGATION": {
+            "name": "UNYTTIG MANGE TIGER AS",
+            "orgno": "313750531",
+            "partyId": 51867229,
+            "partyUuid": "b528fc72-ca98-4cc5-bb7e-d65988e023fe"
+        },
+        "client_rightholderOrg1": {
+            "name": "TOPP FIRKANTET TIGER AS",
+            "orgno": "311127845",
+            "partyId": 51624448,
+            "partyUuid": "d778f3f5-4f73-48b4-bec5-144ceec54953",
+            "dagligleder": {
+                "name": "SAMTIDIG MATEMATIKER",
+                "pid": "07888397161",
+                "userId": 1455073,
+                "partyId": 50906465,
+                "partyUuid": "d673d146-ed6f-4bb4-8037-f63696a683c1"
+            },
+            "directPackageToDelegate": "motorvognavgift",
+            "directPackageToDelegate2": "skatt-naering",
+            "directPackageTilgangsstyrer": "tilgangsstyrer"
+        },
+        "client_rightholderOrg2": {
+            "name": "STOLT BETYDELIG TIGER AS",
+            "orgno": "313816915",
+            "partyId": 51871764,
+            "partyUuid": "320e6ea2-5860-466e-a8a3-6a1e964096a4",
+            "dagligleder": {
+                "name": "SKRAVLETE KAMERA",
+                "pid": "05838299719",
+                "userId": 1450528,
+                "partyId": 51171325,
+                "partyUuid": "fb7a622c-4d16-41eb-ad9d-5024bfd8ebe5"
+            },
+            "subunit": {
+                "name": "STOLT BETYDELIG TIGER AS",
+                "orgno": "315043336",
+                "partyId": 51961130,
+                "partyUuid": "2230cded-a253-4b44-a01c-5d2f3125e038",
+                "packageDelegatedToPerson": "skatt-naering",
+                "packageDelegatedToKeyRoleUnit": "kjop-og-salg-eiendom",
+                "roleDelegatedToPerson": "HVASK",
+                "roleDelegatedToKeyRoleUnit": "LOPER",
+                "resourceIdDelegatedToPerson": "devtest_gar_authparties-sub-to-person",
+                "resourceIdDelegatedToKeyRoleUnit": "devtest_gar_authparties-sub-to-org",
+                "instanceIdDelegatedToPerson": "de5d0a27-3a5f-4c04-951e-70581c5b29d8",
+                "instanceRefDelegatedToPerson": "urn:altinn:instance-id:51961130/de5d0a27-3a5f-4c04-951e-70581c5b29d8",
+                "instanceIdDelegatedToKeyRoleUnit": "7d79836f-cee4-48ec-ad7e-caa198a1923d",
+                "instanceRefDelegatedToKeyRoleUnit": "urn:altinn:instance-id:51961130/7d79836f-cee4-48ec-ad7e-caa198a1923d"
+            },
+            "directPackageToDelegate": "mobler-og-annen-industri",
+            "directPackageToDelegate2": "revisorattesterer",
+            "packageDelegatedToPerson": "lonn",
+            "roleDelegatedToPerson": "UTINN",
+            "roleDelegatedToKeyRoleUnit": "REGNA",
+            "resourceIdDelegatedToPerson": "devtest_gar_authparties-main-to-person",
+            "resourceIdDelegatedToKeyRoleUnit": "devtest_gar_authparties-main-to-org",
+            "appIdDelegatedToPerson": "app_ttd_authz-bruno-testapp1",
+            "appIdDelegatedToKeyRoleUnit": "app_ttd_authz-bruno-testapp2",
+            "instanceIdDelegatedToPerson": "74638d4c-275f-4568-8040-af6979246694",
+            "instanceRefDelegatedToPerson": "urn:altinn:instance-id:51871764/74638d4c-275f-4568-8040-af6979246694",
+            "instanceIdDelegatedToKeyRoleUnit": "b9468899-35b9-4956-99ab-2dcb0cc065fb",
+            "instanceRefDelegatedToKeyRoleUnit": "urn:altinn:instance-id:51871764/b9468899-35b9-4956-99ab-2dcb0cc065fb"
+        },
+        "client_ENK_DELETED_2025_11_27_InnehaverAccess": {
+            "name": "SJELDEN REN KATT KONJAKK",
+            "orgno": "313744019",
+            "partyId": 51866777,
+            "partyUuid": "3dbea3e5-d16b-4d22-9638-9503aefc1215",
+            "innehaver": {
+                "name": "PRATSOM SKOLE",
+                "pid": "19846999968",
+                "userId": 2133481,
+                "partyId": 51423182,
+                "partyUuid": "9922cf65-eea3-4d1b-ac11-e390cf0229ee"
+            },
+            "subunit": {
+                "name": "SJELDEN REN KATT KONJAKK",
+                "orgno": "314964055",
+                "partyId": 51953923,
+                "partyUuid": "0f7a17ac-c37d-476e-b0d0-8e718bbcce41"
+            }
+        },
+        "client_ENK_DELETED_2023_11_01_NoInnehaverAccess": {
+            "name": "OMSORGSFULL KUL KATT SKATOLL",
+            "orgno": "312282054",
+            "partyId": 51758726,
+            "partyUuid": "8f74d6a1-146c-49ea-9d39-9a76dde61210",
+            "innehaver": {
+                "name": "SYMPATISK LINJE",
+                "pid": "24887299168",
+                "userId": 1781973,
+                "partyId": 50946032,
+                "partyUuid": "49c5cbd5-7a8f-4904-b575-c8d44bc116a6"
+            },
+            "subunit": {
+                "name": "OMSORGSFULL KUL KATT SKATOLL",
+                "orgno": "315252946",
+                "partyId": 51980185,
+                "partyUuid": "2454fd08-5726-43e9-81e3-9551d29868bf"
+            }
+        },
+        "a2_klientadministrator": {
+            "name": "RUSTEN AKVARELL",
+            "pid": "11860198721",
+            "userId": 1436247,
+            "partyId": 50778845,
+            "partyUuid": "0ffac65a-380f-4c9c-8831-5418a3e5e950"
+        },
+        "a2_hovedadministrator": {
+            "name": "MATEMATISK UNIVERSITET",
+            "pid": "03899798324",
+            "userId": 1442921,
+            "partyId": 50676220,
+            "partyUuid": "b8f2d185-9bfd-4787-a479-242acc4d1cea"
+        },
+        "a2_tilgangsstyrer": {
+            "name": "GLEMSOM GREND",
+            "pid": "27920898721",
+            "userId": 1442949,
+            "partyId": 50885475,
+            "partyUuid": "b77b311b-9f23-4664-be72-9e3dfae761a6"
+        },
+        "revisor": {
+            "name": "OVERFLADISK LANG TIGER AS",
+            "orgno": "310267511",
+            "partyId": 51449365,
+            "partyUuid": "03b14d35-4b8c-44cd-9c71-dc740d8585c2",
+            "directPackageToDelegate": "revisorattesterer"
+        },
+        "systemuser": {
+            "name": "TEST_SBS_KLIENT",
+            "partyUuid": "26c483dd-068f-497a-b8d2-39a6bd92ecc8",
+            "directPackageToDelegate": "urn:altinn:accesspackage:ansettelsesforhold",
+            "clientPackageToDelegate": "urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet",
+            "clientEnkPackageToDelegate": "urn:altinn:accesspackage:regnskapsforer-lonn",
+            "clientPackageForDelete": "urn:altinn:accesspackage:regnskapsforer-uten-signeringsrettighet"
+        },
+        "systemuser_tilgangsstyrer": {
+            "name": "314242726_bruno-systembruker-som-tilgangsstyrer",
+            "clientId": "76db1f73-9895-41c0-8f76-09e8ebaee6c9",  
+            "partyUuid": "", // ToDo: Create for TT02
+            "hasPackage": "urn:altinn:accesspackage:posttjenester",
+            "hasResource": "urn:altinn:resource:authz_bruno_gar_resource1",
+            "personRightholderToAdd": {
+              "name": "UMUSIKALSK SEPTEMBER KARTLEGGING",
+              "lastName": "KARTLEGGING",
+              "pid": "21887997923",
+              "userId": 2058907,
+              "partyId": 52250993,
+              "partyUuid": "88476c4d-365a-44e9-aab1-c92ddf10f0ff"
+            },
+        },
+        "subunit": {
+            "name": "ULASTELIG RETTFERDIG TIGER AS",
+            "orgno": "314613155",
+            "partyId": 51922024,
+            "partyUuid": "8756202f-69d3-4f93-991c-7a2a40c53c87"
+        },
+        "employee_rightholderWithoutPackages": {
+            "name": "MOBIL LAMA",
+            "lastname": "LAMA",
+            "pid": "31858374521",
+            "userId": 1902484,
+            "partyId": 50384219,
+            "partyUuid": "650cbe81-7fb7-4671-842e-350ab9cf57d1"
+        },
+        "employee_rightholderWithPackages": {
+            "name": "STOR UTHOLDEN AUTORITET ANSIKTSKREM",
+            "lastname": "ANSIKTSKREM",
+            "pid": "27877695722",
+            "userId": 1791828,
+            "partyId": 53148036,
+            "partyUuid": "4c03fda4-d742-4616-9d06-719939d6d70e",
+            "directPackageToDelegate": "revisorattesterer",
+            "directPackageTilgangsstyrer": "tilgangsstyrer"
+        },
+        "employee_instancedelegator": {
+          "name": "LYS MAMMA",
+          "lastname": "MAMMA",
+          "pid": "01818199690",
+          "userId": 1567159,
+          "partyId": 50561881,
+          "partyUuid": "190d6c80-6476-4b7f-9cf6-6aa08620562c",
+          "directPackageToDelegate": "post-til-virksomheten-med-taushetsbelagt-innhold",
+          "directPackageInstanceDelegator": "tilgangsstyring-enkeltinstanser"
+        },
+        "employee_agent_enk": {
+          "name": "KUL KJENNING",
+          "lastname": "KJENNING",
+          "pid": "20876795923",
+          "userId": 21111470,
+          "partyId": 50795962,
+          "partyUuid": "e87a43c1-0e3d-4783-90f1-dfbd1c5c6170"
+        }
+    },
+    "a2BrunoSIUser": {
+        "name": "A2BrunoSIUser",
+        "username": "a2brunosiuser",
+        "userId": 2672541,
+        "partyId": 53429341,
+        "partyUuid": "d9eed4e0-69e5-47da-8b7e-16713af25c67"
+    },
+    "a2BrunoECUser": {
+        "name": "bruno_ec_digdir",
+        "username": "bruno_ec_digdir",
+        "userId": 2672640,
+        "partyId": 50167512,
+        "partyUuid": "0B88A017-0683-46F9-8771-7FB0EC4EA424"
+    },
+    "forretningsforerNonfigurativEmosjonellPuma": {
+        "name": "NONFIGURATIV EMOSJONELL PUMA",
+        "orgno": "313760243",
+        "partyId": 51530933,
+        "partyUuid": "039807e3-dbe7-411d-adb5-e0f690978a5c",
+        "dagligleder": {
+            "name": "SPETTETE DALSIDE",
+            "pid": "08817696563",
+            "userId": 163200,
+            "partyId": 50637525,
+            "partyUuid": "e022d039-6da8-401b-9250-ef7d5c37ea03"
+        },
+        "subunit": {
+            "name": "NONFIGURATIV EMOSJONELL PUMA",
+            "orgno": "312145529",
+            "partyId": 51748748,
+            "partyUuid": "94f8cbc3-2197-4f92-99aa-6f4059601f3f"
+        },
+        "esekClient": {
+            "name": "LETT SLEM LØVE SAMEIE",
+            "orgno": "313184390",
+            "partyId": 51828102,
+            "partyUuid": "ac3b6fc1-0126-4a2b-8b6f-61db143c5aa1",
+            "dagligleder": {
+                "name": "??",
+                "pid": "??",
+                "userId": 0,
+                "partyId": 0,
+                "partyUuid": "??"
+            },
+            "clientPackage": "forretningsforer-eiendom"
+        },
+        "nonBrlEsekClient": {
+            "name": "SKEPTISK LILLA HEST BORETTSLAG",
+            "orgno": "311115057",
+            "partyId": 51623312,
+            "partyUuid": "8b8ae7e6-6982-408e-b9bc-9f800081512c",
+            "dagligleder": {
+                "name": "??",
+                "pid": "??",
+                "userId": 0,
+                "partyId": 0,
+                "partyUuid": "??"
+            }
+        }
+    },
+    "regnVennligProaktivTiger": {
+      "name": "VENNLIG PROAKTIV TIGER AS",
+      "orgno": "314063945",
+      "partyId": 51451282,
+      "partyUuid": "00832e9b-7100-4e6c-8d7d-d21fb19d0aee",
+      "dagligleder": {
+        "name": "STRENG INFORMASJON",
+        "pid": "13847599221",
+        "userId": 1711398,
+        "partyId": 50670747,
+        "partyUuid": "39b418de-32db-457c-931e-1fd04148d225"
+      },
+      "enkClient": {
+        "name": "FALSK UAVHENGIG KATT LERKETRE",
+        "orgno": "313079422",
+        "partyId": 51674823,
+        "partyUuid": "00a9ab9b-42cf-4121-9086-8b423b0d644f",
+        "innehaver": {
+          "name": "PARODISK KANIN",
+          "pid": "30847798161",
+          "userId": 2203099,
+          "partyId": 51025583,
+          "partyUuid": "a8dbe5a4-55d9-418b-9a9f-3179b9f48a6f"
+        },
+      }
+    },
+    "regnskapsforerShowClientUnitsFalse": {
+        "name": "FROM TYPISK TIGER AS",
+        "orgno": "310592676",
+        "partyId": 51449134,
+        "partyUuid": "e272e780-660b-41e2-b448-70ff9adc669f",
+        "dagligleder": {
+            "name": "VIS DØR",
+            "pid": "02827399623",
+            "userId": 2305845,
+            "partyId": 51181727,
+            "partyUuid": "c02ea7af-c76f-4447-b1bf-9abed2c3bcb1"
+        },
+        "subunit": {
+            "name": "GYLDEN KNUSLETE FJELLREV",
+            "orgno": "212334782",
+            "partyId": 51479239,
+            "partyUuid": "5d0ec048-5cc4-435e-9056-9246189c039a"
+        }
+    },
+    "rightholderThroughDelegationToSubunitAndKeyRole": {
+      "name": "LATTERMILD LYDIG KATT FLAGG",
+      "orgno": "210367802",
+      "partyId": 51453202,
+      "partyUuid": "83145e4d-e84a-4eb3-b892-8697a9163c4c",
+      "dagligleder": {
+        "name": "FLINK PUSEKATT",
+        "pid": "27917995783",
+        "userId": 2245661,
+        "partyId": 50625169,
+        "partyUuid": "b28588ca-6f4f-4f4d-8b0b-7217423bec77"
+      },
+      "subunit": {
+        "name": "LATTERMILD LYDIG KATT FLAGG",
+        "orgno": "315703492",
+        "partyId": 52021146,
+        "partyUuid": "04f806fc-c763-4f93-97c7-ffa3b842acb4"
+      }
+    },
+    "idportenEmailUser": {
+      "name": "am-bruno-automated-tests@mailinator.com",
+      "emailId": "am-bruno-automated-tests@mailinator.com",
+      "userId": 2680437,
+      "partyId": 53440923,
+      "partyUuid": "a28806e7-5e11-4ffa-be5a-56c47dcedf98",
+    }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Switched getting authenticated user from AuthenticationHelper.GetPartyUuid which only supports authenticated person claim to AuthenticationHelper.GetAuthenticatedPartyUuid which support both
- Added bruno tests

## Related Issue(s)
- #3175

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
