### PR TITLE
Added search for multiple words in metadata api

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
@@ -37,10 +37,11 @@ public class PackagesController : ControllerBase
     /// <param name="searchInResources">Søk i ressurs verdier</param>
     /// <param name="typeName">Package for type (e.g. Organization, Person)</param>
     /// <param name="simpleSearch">Use new simple search</param>
+    /// <param name="strict">All tokens in term must match in some degree</param>
     /// <returns>Liste over søkeresultater.</returns>
     [Route("search")]
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<SearchObject<PackageDto>>>> Search([FromQuery] string term, [FromQuery] List<string> resourceProviderCode = null, [FromQuery] bool searchInResources = false, [FromQuery] string? typeName = null, [FromQuery] bool simpleSearch = true)
+    public async Task<ActionResult<IEnumerable<SearchObject<PackageDto>>>> Search([FromQuery] string term, [FromQuery] List<string> resourceProviderCode = null, [FromQuery] bool searchInResources = false, [FromQuery] string? typeName = null, [FromQuery] bool simpleSearch = true, [FromQuery] bool strict = false)
     {
         Guid? typeId = null;
         if (!string.IsNullOrEmpty(typeName))
@@ -56,6 +57,7 @@ public class PackagesController : ControllerBase
         var res = simpleSearch
             ? await packageService.SimpleSearch(
                 term: term,
+                strict: strict,
                 resourceProviderCodes: resourceProviderCode,
                 searchInResources: searchInResources,
                 typeId: typeId,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Metadata/Controllers/PackagesController.cs
@@ -61,8 +61,7 @@ public class PackagesController : ControllerBase
                 resourceProviderCodes: resourceProviderCode,
                 searchInResources: searchInResources,
                 typeId: typeId,
-                languageCode: this.GetLanguageCode(),
-                allowPartialTranslation: this.AllowPartialTranslation()
+                translation: new TranslationOptions(this.GetLanguageCode(), this.AllowPartialTranslation())
                 )
             : await packageService.FuzzySearch(
                 term: term,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
@@ -2,7 +2,6 @@
 using Altinn.AccessMgmt.PersistenceEF.Models;
 using Altinn.Authorization.Api.Contracts.AccessManagement;
 using Altinn.Authorization.Api.Contracts.AccessManagement.Request;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Altinn.AccessMgmt.Core.Services.Contracts;
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
@@ -33,11 +33,10 @@ public interface IPackageService
     /// <param name="resourceProviderCodes">Resource.Provider.Code (brreg, digdir, skatt)</param>
     /// <param name="searchInResources">Indicate if term should filter on resource values</param>
     /// <param name="typeId">Filter for entityType</param>
-    /// <param name="languageCode">Languagecode</param>
-    /// <param name="allowPartialTranslation">Allow partial translation</param>
+    /// <param name="translation">Language and partial-translation fallback options. Defaults to "nob" with partial fallback enabled when null.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>A list of search results containing packages that match the term.</returns>
-    Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, bool strict = false, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default);
+    Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, bool strict = false, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, TranslationOptions translation = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the hierarchical structure of area groups.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IPackageService.cs
@@ -2,6 +2,7 @@
 using Altinn.AccessMgmt.PersistenceEF.Models;
 using Altinn.Authorization.Api.Contracts.AccessManagement;
 using Altinn.Authorization.Api.Contracts.AccessManagement.Request;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Altinn.AccessMgmt.Core.Services.Contracts;
 
@@ -28,6 +29,7 @@ public interface IPackageService
     /// Searches for packages based on a search term.
     /// </summary>
     /// <param name="term">The search term to filter packages.</param>
+    /// <param name="strict">All terms must match in some degree</param>
     /// <param name="resourceProviderCodes">Resource.Provider.Code (brreg, digdir, skatt)</param>
     /// <param name="searchInResources">Indicate if term should filter on resource values</param>
     /// <param name="typeId">Filter for entityType</param>
@@ -35,7 +37,7 @@ public interface IPackageService
     /// <param name="allowPartialTranslation">Allow partial translation</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>A list of search results containing packages that match the term.</returns>
-    Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default);
+    Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, bool strict = false, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the hierarchical structure of area groups.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -43,96 +43,84 @@ public class PackageService : IPackageService
     ];
 
     private static SearchObject<PackageDto> ScorePackage(
-    PackageDto package,
-    string[] tokens,
-    bool searchInResources)
+        PackageDto package,
+        string[] tokens,
+        bool searchInResources)
     {
-        var totalScore = 0;
         var fields = new List<SearchField>();
 
-        // Phrase bonus when there's more than one token
         if (tokens.Length > 1)
         {
-            var phrase = string.Join(' ', tokens);
-            foreach (var rule in PackageRules)
-            {
-                var value = rule.Field(package);
-                if (rule.Match(value, phrase))
-                {
-                    totalScore += rule.Points * 2;
-                    fields.Add(new SearchField
-                    {
-                        Field = rule.FieldName + ".phrase",
-                        Value = value,
-                        Score = rule.Points * 2,
-                    });
-                }
-            }
+            fields.AddRange(ScorePhrase(package, string.Join(' ', tokens)));
         }
 
-        // Per-token scoring
-        foreach (var rule in PackageRules)
-        {
-            var value = rule.Field(package);
-            foreach (var token in tokens)
-            {
-                if (rule.Match(value, token))
-                {
-                    totalScore += rule.Points;
-                    fields.Add(new SearchField
-                    {
-                        Field = rule.FieldName,
-                        Value = value,
-                        Score = rule.Points,
-                    });
-                }
-            }
-        }
+        fields.AddRange(ScoreTokens(package, tokens));
 
         if (searchInResources)
         {
-            foreach (var resource in package.Resources)
-            {
-                foreach (var token in tokens)
-                {
-                    if (resource.Name.Contains(token, Ic))
-                    {
-                        totalScore += 2;
-                        fields.Add(new SearchField
-                        {
-                            Field = "resources.name",
-                            Value = resource.Name,
-                            Score = 2,
-                        });
-                    }
-                }
-            }
+            fields.AddRange(ScoreResources(package.Resources, tokens));
         }
 
         return new SearchObject<PackageDto>
         {
             Object = package,
-            Score = totalScore,
+            Score = fields.Sum(f => f.Score),
             Fields = fields,
         };
     }
 
+    private static IEnumerable<SearchField> ScorePhrase(PackageDto package, string phrase) =>
+        PackageRules
+            .Select(rule => (rule, value: rule.Field(package)))
+            .Where(t => t.rule.Match(t.value, phrase))
+            .Select(t => new SearchField
+            {
+                Field = t.rule.FieldName + ".phrase",
+                Value = t.value,
+                Score = t.rule.Points * 2,
+            });
+
+    private static IEnumerable<SearchField> ScoreTokens(PackageDto package, string[] tokens) =>
+        PackageRules.SelectMany(rule =>
+        {
+            var value = rule.Field(package);
+            return tokens
+                .Where(token => rule.Match(value, token))
+                .Select(_ => new SearchField
+                {
+                    Field = rule.FieldName,
+                    Value = value,
+                    Score = rule.Points,
+                });
+        });
+
+    private static IEnumerable<SearchField> ScoreResources(IEnumerable<ResourceDto> resources, string[] tokens) =>
+        resources.SelectMany(resource => tokens
+            .Where(token => resource.Name.Contains(token, Ic))
+            .Select(_ => new SearchField
+            {
+                Field = "resources.name",
+                Value = resource.Name,
+                Score = 2,
+            }));
+
     public async Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(
-    string term,
-    bool strict = false,
-    List<string> resourceProviderCodes = null,
-    bool searchInResources = false,
-    Guid? typeId = null,
-    string languageCode = "nob",
-    bool allowPartialTranslation = true,
-    CancellationToken ct = default)
+        string term,
+        bool strict = false,
+        List<string> resourceProviderCodes = null,
+        bool searchInResources = false,
+        Guid? typeId = null,
+        TranslationOptions translation = null,
+        CancellationToken cancellationToken = default)
     {
+        translation ??= new TranslationOptions();
+
         var data = await GetSearchData(
             resourceProviderCodes: resourceProviderCodes,
             typeId: typeId,
-            languageCode: languageCode,
-            allowPartialTranslation: allowPartialTranslation,
-            cancellationToken: ct);
+            languageCode: translation.LanguageCode,
+            allowPartialTranslation: translation.AllowPartial,
+            cancellationToken: cancellationToken);
 
         if (string.IsNullOrWhiteSpace(term))
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -44,38 +44,68 @@ public class PackageService : IPackageService
 
     private static SearchObject<PackageDto> ScorePackage(
     PackageDto package,
-    string term,
+    string[] tokens,
     bool searchInResources)
     {
         var totalScore = 0;
         var fields = new List<SearchField>();
 
+        // Phrase bonus when there's more than one token
+        if (tokens.Length > 1)
+        {
+            var phrase = string.Join(' ', tokens);
+            foreach (var rule in PackageRules)
+            {
+                var value = rule.Field(package);
+                if (rule.Match(value, phrase))
+                {
+                    totalScore += rule.Points * 2;
+                    fields.Add(new SearchField
+                    {
+                        Field = rule.FieldName + ".phrase",
+                        Value = value,
+                        Score = rule.Points * 2,
+                    });
+                }
+            }
+        }
+
+        // Per-token scoring
         foreach (var rule in PackageRules)
         {
             var value = rule.Field(package);
-            if (rule.Match(value, term))
+            foreach (var token in tokens)
             {
-                totalScore += rule.Points;
-                fields.Add(new SearchField
+                if (rule.Match(value, token))
                 {
-                    Field = rule.FieldName,
-                    Value = value,
-                    Score = rule.Points,
-                });
+                    totalScore += rule.Points;
+                    fields.Add(new SearchField
+                    {
+                        Field = rule.FieldName,
+                        Value = value,
+                        Score = rule.Points,
+                    });
+                }
             }
         }
 
         if (searchInResources)
         {
-            foreach (var resource in package.Resources.Where(t => t.Name.Contains(term, Ic)))
+            foreach (var resource in package.Resources)
             {
-                totalScore += 2;
-                fields.Add(new SearchField
+                foreach (var token in tokens)
                 {
-                    Field = "resources.name",
-                    Value = resource.Name,
-                    Score = 2,
-                });
+                    if (resource.Name.Contains(token, Ic))
+                    {
+                        totalScore += 2;
+                        fields.Add(new SearchField
+                        {
+                            Field = "resources.name",
+                            Value = resource.Name,
+                            Score = 2,
+                        });
+                    }
+                }
             }
         }
 
@@ -87,24 +117,41 @@ public class PackageService : IPackageService
         };
     }
 
-    public async Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(string term, List<string> resourceProviderCodes = null, bool searchInResources = false, Guid? typeId = null, string languageCode = "nob", bool allowPartialTranslation = true, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<SearchObject<PackageDto>>> SimpleSearch(
+    string term,
+    bool strict = false,
+    List<string> resourceProviderCodes = null,
+    bool searchInResources = false,
+    Guid? typeId = null,
+    string languageCode = "nob",
+    bool allowPartialTranslation = true,
+    CancellationToken ct = default)
     {
         var data = await GetSearchData(
-        resourceProviderCodes: resourceProviderCodes,
-        typeId: typeId,
-        languageCode: languageCode,
-        allowPartialTranslation: allowPartialTranslation,
-        cancellationToken: cancellationToken
-        );
+            resourceProviderCodes: resourceProviderCodes,
+            typeId: typeId,
+            languageCode: languageCode,
+            allowPartialTranslation: allowPartialTranslation,
+            cancellationToken: ct);
 
-        if (string.IsNullOrEmpty(term))
+        if (string.IsNullOrWhiteSpace(term))
         {
-            return data.Select(t => new SearchObject<PackageDto>() { Object = t, Score = 0, Fields = [] });
+            return data.Select(t => new SearchObject<PackageDto> { Object = t, Score = 0, Fields = [] });
         }
 
-        return data
-            .Select(p => ScorePackage(p, term, searchInResources))
-            .Where(s => s.Score > 0)
+        var tokens = term.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var scored = data
+            .Select(p => ScorePackage(p, tokens, searchInResources))
+            .Where(s => s.Score > 0);
+
+        if (strict && tokens.Length > 1)
+        {
+            scored = scored.Where(s => tokens.All(tok =>
+                s.Fields.Any(f => f.Value.Contains(tok, Ic))));
+        }
+
+        return scored
             .OrderByDescending(s => s.Score)
             .ToList();
     }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/TranslationOptions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Models/TranslationOptions.cs
@@ -1,0 +1,9 @@
+namespace Altinn.AccessMgmt.Core.Utils.Models;
+
+/// <summary>
+/// Bundles the per-request language preference and the partial-translation fallback flag
+/// so that service operations can pass them as a single argument.
+/// </summary>
+/// <param name="LanguageCode">ISO 639-2 language code (e.g. "nob").</param>
+/// <param name="AllowPartial">If true, missing translations fall back to the source language instead of returning null.</param>
+public sealed record TranslationOptions(string LanguageCode = "nob", bool AllowPartial = true);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs
@@ -251,6 +251,99 @@ public class PackagesControllerIntegrationTests : IClassFixture<PostgresFixture>
         }
     }
 
+    // ── Multi-token SimpleSearch — phrase bonus, per-token scoring, strict filter ──
+    //
+    // The SimpleSearch scorer tokenizes on whitespace and applies two scoring
+    // passes: a phrase pass (only when tokens.Length > 1) and a per-token pass.
+    // The `strict` flag additionally requires every token to appear in at least
+    // one matched field's value. Single-token tests above never exercise the
+    // tokens.Length > 1 branches, so these tests target those code paths
+    // directly and guard against regressions in the multi-word search added
+    // to support phrase queries.
+    [Fact]
+    public async Task SimpleSearch_MultiTokenPhraseMatch_AddsPhraseBonusField()
+    {
+        // "Kunst og" is a strict prefix of the seeded package name "Kunst og
+        // underholdning", so the name.prefix rule fires on the full phrase
+        // and contributes a ".phrase" field to the result. A regression that
+        // dropped the phrase pass would still rank the package via per-token
+        // matches, but no `name.prefix.phrase` field would appear.
+        var result = await CreateController().Search("Kunst og");
+
+        var hits = AssertOkEnumerable(result).ToList();
+        Assert.NotEmpty(hits);
+
+        var kunst = hits.FirstOrDefault(h => h.Object.Name == PackageKunstName);
+        Assert.NotNull(kunst);
+        Assert.Contains(kunst.Fields, f => f.Field.EndsWith(".phrase"));
+    }
+
+    [Fact]
+    public async Task SimpleSearch_MultiTokenNoPhraseMatch_NoPhraseFieldButPackageStillScored()
+    {
+        // "Kunst underholdning" (tokens in unnatural order) does NOT appear
+        // verbatim in any field, so the phrase pass produces zero hits while
+        // the per-token pass still scores both tokens against the package
+        // name. Guards against a regression that conflates phrase-presence
+        // with token-presence and overcredits the package.
+        var result = await CreateController().Search("Kunst underholdning");
+
+        var hits = AssertOkEnumerable(result).ToList();
+        var kunst = hits.FirstOrDefault(h => h.Object.Name == PackageKunstName);
+        Assert.NotNull(kunst);
+        Assert.DoesNotContain(kunst.Fields, f => f.Field.EndsWith(".phrase"));
+        Assert.True(kunst.Score > 0);
+    }
+
+    [Fact]
+    public async Task SimpleSearch_StrictTrue_ExcludesPackagesMissingAToken()
+    {
+        // Without strict, "Kunst og underholdning" matches "Kunst" and is
+        // returned even though the second token matches nothing. With strict
+        // and tokens.Length > 1, every token must appear in some matched
+        // field's value, so the package is filtered out. Regression target:
+        // strict flag silently ignored, or the All/Any predicate inverted.
+        const string nonExistentToken = "zzz_no_field_contains_this_xyzzy";
+
+        var withoutStrict = await CreateController().Search($"Kunst {nonExistentToken}");
+        var withoutHits = AssertOkEnumerable(withoutStrict).ToList();
+        Assert.Contains(withoutHits, h => h.Object.Name == PackageKunstName);
+
+        // Every other potential hit also lacks the non-existent token, so the
+        // strict filter wipes the whole result set → NoContent.
+        var withStrict = await CreateController().Search($"Kunst {nonExistentToken}", strict: true);
+        Assert.IsType<NoContentResult>(withStrict.Result);
+    }
+
+    [Fact]
+    public async Task SimpleSearch_StrictTrue_KeepsPackagesWhereAllTokensMatch()
+    {
+        // Both "Kunst" and "underholdning" appear in the package name
+        // "Kunst og underholdning", so strict-mode must keep this package.
+        // Pairs with the exclusion test above to pin the strict predicate
+        // direction (All-of, not Any-of).
+        var result = await CreateController().Search("Kunst underholdning", strict: true);
+
+        var hits = AssertOkEnumerable(result).ToList();
+        Assert.Contains(hits, h => h.Object.Name == PackageKunstName);
+    }
+
+    [Fact]
+    public async Task SimpleSearch_WhitespaceOnlyTerm_ReturnsAllPackagesWithScoreZero()
+    {
+        // The empty/whitespace short-circuit returns every package with
+        // Score=0 and empty Fields — the controller does not treat this as
+        // NoContent. Regression target: a switch from IsNullOrWhiteSpace
+        // back to IsNullOrEmpty would let "   " fall through to tokenization
+        // and return an empty result instead of the listing behavior.
+        var result = await CreateController().Search("   ");
+
+        var hits = AssertOkEnumerable(result).ToList();
+        Assert.NotEmpty(hits);
+        Assert.All(hits, h => Assert.Equal(0, h.Score));
+        Assert.All(hits, h => Assert.Empty(h.Fields));
+    }
+
     [Fact]
     public async Task FuzzySearch_StillReachableViaSimpleSearchFalse()
     {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
@@ -45,7 +45,7 @@ public class PackagesControllerTest
     public async Task Search_DefaultIsSimpleSearch_RoutesToSimpleSearchAndNotFuzzy()
     {
         var serviceMock = new Mock<IPackageService>(MockBehavior.Strict);
-        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<SearchObject<PackageDto>>
             {
                 new() { Object = new PackageDto { Id = Guid.NewGuid(), Name = "Tax" }, Score = 100 },
@@ -61,7 +61,7 @@ public class PackagesControllerTest
 
         // Strict mock would have thrown if FuzzySearch had been invoked.
         serviceMock.Verify(
-            s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -96,7 +96,7 @@ public class PackagesControllerTest
         bool? capturedAllowPartial = null;
 
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Callback<string, List<string>, bool, Guid?, string, bool, CancellationToken>(
                 (_, _, _, _, lang, allowPartial, _) =>
                 {
@@ -146,7 +146,7 @@ public class PackagesControllerTest
         // silently ignore the type filter and return cross-type results.
         Guid? capturedTypeId = null;
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Callback<string, List<string>, bool, Guid?, string, bool, CancellationToken>(
                 (_, _, _, id, _, _, _) => capturedTypeId = id)
             .ReturnsAsync(new List<SearchObject<PackageDto>>
@@ -168,7 +168,7 @@ public class PackagesControllerTest
     {
         // Default (simpleSearch=true) hits SimpleSearch — empty maps to NoContent.
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<SearchObject<PackageDto>>());
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
@@ -182,7 +182,7 @@ public class PackagesControllerTest
     public async Task Search_DefaultPath_WhenServiceReturnsNull_Returns204NoContent()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<SearchObject<PackageDto>>)null);
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
@@ -45,7 +45,7 @@ public class PackagesControllerTest
     public async Task Search_DefaultIsSimpleSearch_RoutesToSimpleSearchAndNotFuzzy()
     {
         var serviceMock = new Mock<IPackageService>(MockBehavior.Strict);
-        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<TranslationOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<SearchObject<PackageDto>>
             {
                 new() { Object = new PackageDto { Id = Guid.NewGuid(), Name = "Tax" }, Score = 100 },
@@ -61,7 +61,7 @@ public class PackagesControllerTest
 
         // Strict mock would have thrown if FuzzySearch had been invoked.
         serviceMock.Verify(
-            s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<TranslationOptions>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -96,12 +96,12 @@ public class PackagesControllerTest
         bool? capturedAllowPartial = null;
 
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-            .Callback<string, bool, List<string>, bool, Guid?, string, bool, CancellationToken>(
-                (_, _, _, _, _, lang, allowPartial, _) =>
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<TranslationOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, bool, List<string>, bool, Guid?, TranslationOptions, CancellationToken>(
+                (_, _, _, _, _, translation, _) =>
                 {
-                    capturedLanguageCode = lang;
-                    capturedAllowPartial = allowPartial;
+                    capturedLanguageCode = translation.LanguageCode;
+                    capturedAllowPartial = translation.AllowPartial;
                 })
             .ReturnsAsync(new List<SearchObject<PackageDto>>
             {
@@ -146,9 +146,9 @@ public class PackagesControllerTest
         // silently ignore the type filter and return cross-type results.
         Guid? capturedTypeId = null;
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-            .Callback<string, bool, List<string>, bool, Guid?, string, bool, CancellationToken>(
-                (_, _, _, _, id, _, _, _) => capturedTypeId = id)
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<TranslationOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, bool, List<string>, bool, Guid?, TranslationOptions, CancellationToken>(
+                (_, _, _, _, id, _, _) => capturedTypeId = id)
             .ReturnsAsync(new List<SearchObject<PackageDto>>
             {
                 new() { Object = new PackageDto { Id = Guid.NewGuid() }, Score = 1 },
@@ -168,7 +168,7 @@ public class PackagesControllerTest
     {
         // Default (simpleSearch=true) hits SimpleSearch — empty maps to NoContent.
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<TranslationOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<SearchObject<PackageDto>>());
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);
@@ -182,7 +182,7 @@ public class PackagesControllerTest
     public async Task Search_DefaultPath_WhenServiceReturnsNull_Returns204NoContent()
     {
         var serviceMock = new Mock<IPackageService>();
-        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<TranslationOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<SearchObject<PackageDto>>)null);
 
         var controller = CreateController(serviceMock.Object, PassThroughTranslation().Object);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
@@ -97,8 +97,8 @@ public class PackagesControllerTest
 
         var serviceMock = new Mock<IPackageService>();
         serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-            .Callback<string, List<string>, bool, Guid?, string, bool, CancellationToken>(
-                (_, _, _, _, lang, allowPartial, _) =>
+            .Callback<string, bool, List<string>, bool, Guid?, string, bool, CancellationToken>(
+                (_, _, _, _, _, lang, allowPartial, _) =>
                 {
                     capturedLanguageCode = lang;
                     capturedAllowPartial = allowPartial;
@@ -147,8 +147,8 @@ public class PackagesControllerTest
         Guid? capturedTypeId = null;
         var serviceMock = new Mock<IPackageService>();
         serviceMock.Setup(s => s.SimpleSearch(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<List<string>>(), It.IsAny<bool>(), It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-            .Callback<string, List<string>, bool, Guid?, string, bool, CancellationToken>(
-                (_, _, _, id, _, _, _) => capturedTypeId = id)
+            .Callback<string, bool, List<string>, bool, Guid?, string, bool, CancellationToken>(
+                (_, _, _, _, id, _, _, _) => capturedTypeId = id)
             .ReturnsAsync(new List<SearchObject<PackageDto>>
             {
                 new() { Object = new PackageDto { Id = Guid.NewGuid() }, Score = 1 },


### PR DESCRIPTION
## Description
Utvidet søk i metadata api til å ta hensyn til flere ord i søkestrengen. La også inn et nytt flagg`strict` som krever at begge ordene gir treff i et element for å returnere resultat.

## Issue
- #3242 