### PR TITLE
Change the latestchanges api to events api and add filters, list oldest first

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
@@ -144,7 +144,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
         /// <param name="continuationToken">Opaque cursor token returned in the <c>nextLink</c> of a previous response. Pass this to retrieve the next page of results.</param>
         /// <param name="createdAfter">Optional. Filters events created at or after this timestamp.</param>
         /// <param name="createdBefore">Optional. Filters events created before this timestamp.</param>
-        /// <param name="eventTypes">Optional. Filters results to one or more specific event types. Can be specified multiple times, e.g. <c>eventType=approved&amp;eventType=revoked</c>.</param>
+        /// <param name="eventTypes">Optional. Filters results to one or more specific event types. Can be specified multiple times, e.g. <c>eventType=accepted&amp;eventType=revoked</c>.</param>
         /// <param name="consentRequestId">Optional. Filters results to events belonging to a specific consent request.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         [Authorize(Policy = AuthzConstants.POLICY_CONSENTREQUEST_READ)]

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
@@ -1,10 +1,8 @@
-﻿using System.Net.Mime;
-using System.Security.Claims;
-using System.Text;
-using Altinn.AccessManagement.Api.Enterprise.Extensions;
+﻿using Altinn.AccessManagement.Api.Enterprise.Extensions;
 using Altinn.AccessManagement.Api.Enterprise.Utils;
 using Altinn.AccessManagement.Core.Configuration;
 using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessManagement.Core.Errors;
 using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.Consent;
 using Altinn.AccessManagement.Core.Services.Interfaces;
@@ -17,6 +15,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using System.Net.Mime;
+using System.Security.Claims;
+using System.Text;
 
 namespace Altinn.AccessManagement.Api.Enterprise.Controllers
 {
@@ -33,6 +34,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
 
         private const string CreateRouteName = "enterprisecreateconsentrequest";
         private const string GetRouteName = "enterprisegetconsentrequest";
+        private const string ROUTE_CONSENTEVENTS = "enterprise/consentrequests/events";
 
         /// <summary>
         /// Endpoint to create a consent request for
@@ -156,14 +158,15 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetConsentEvents(
             [FromQuery(Name = "continuationToken")] string? continuationToken = null,
-            [FromQuery(Name = "createdAfter")] DateTime? createdAfter = null,
-            [FromQuery(Name = "createdBefore")] DateTime? createdBefore = null,
+            [FromQuery(Name = "createdAfter")] DateTimeOffset? createdAfter = null,
+            [FromQuery(Name = "createdBefore")] DateTimeOffset? createdBefore = null,
             [FromQuery(Name = "eventTypes")] string[]? eventTypes = null,
             [FromQuery(Name = "consentRequestId")] Guid? consentRequestId = null, 
             CancellationToken cancellationToken = default)
         {
             int pageSize = _consentSettings.CurrentValue.EventsPageSize;
-            int safetyLagSeconds = _consentSettings.CurrentValue.EventsSafetyLagSeconds;
+            int safetyLagSeconds = 0;//_consentSettings.CurrentValue.EventsSafetyLagSeconds;
+            Guid? continueFrom = null;
             Core.Models.Consent.ConsentPartyUrn? authenticatedParty = OrgUtil.GetAuthenticatedParty(User);
 
             if (authenticatedParty == null)
@@ -171,12 +174,61 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
                 return Unauthorized();
             }
 
+            ValidationErrorBuilder errors = default;
+
+            if (createdAfter.HasValue && createdBefore.HasValue && createdAfter >= createdBefore)
+            {
+                errors.Add(ValidationErrors.InvalidDateRange, $"/{nameof(createdAfter)}");
+            }
+
+            if (eventTypes is { Length: > 0 })
+            {
+                var validEventTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "rejected", "accepted", "revoked", "deleted", "used"
+                };
+
+                foreach (string eventType in eventTypes)
+                {
+                    if (!validEventTypes.Contains(eventType))
+                    {
+                        errors.Add(ValidationErrors.InvalidEventType, $"/{nameof(eventTypes)}");
+                        break;
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(continuationToken))
+            {
+                try
+                {
+                    byte[] bytes = Convert.FromBase64String(continuationToken);                    
+                    if (bytes.Length != 16)
+                    {
+                        errors.Add(ValidationErrors.InvalidContinuationToken, $"/{nameof(continuationToken)}");
+                    }
+                    else
+                    {
+                        continueFrom = new Guid(bytes);
+                    }                    
+                }
+                catch (FormatException)
+                {
+                    errors.Add(ValidationErrors.InvalidContinuationToken, $"/{nameof(continuationToken)}");
+                }
+            }
+
+            if (errors.TryBuild(out var errorResult))
+            {
+                return errorResult.ToActionResult();
+            }
+
             ConsentEventsQuery query = new ConsentEventsQuery(
                 ConsentRequestId: consentRequestId,
                 EventTypes: eventTypes,
-                CreatedAfter: createdAfter.HasValue ? DateTime.SpecifyKind(createdAfter.Value, DateTimeKind.Utc) : null,
-                CreatedBefore: createdBefore.HasValue ? DateTime.SpecifyKind(createdBefore.Value, DateTimeKind.Utc) : null,
-                ContinuationToken: continuationToken);
+                CreatedAfter: createdAfter.HasValue ? createdAfter.Value.UtcDateTime : (DateTime?)null,
+                CreatedBefore: createdBefore.HasValue ? createdBefore.Value.UtcDateTime : (DateTime?)null,
+                ContinueFrom: continueFrom);
 
             Result<List<ConsentStatusChange>> result = await _consentService.GetConsentEventsForParty(authenticatedParty, query, safetyLagSeconds, pageSize, cancellationToken);
 
@@ -204,7 +256,8 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
                     .Append($"continuationToken={Uri.EscapeDataString(nextToken)}")
                     .ToList();
 
-                nextLink = $"{Request.Scheme}://{Request.Host}{Request.Path}?{string.Join("&", queryParams)}";
+                nextLink = Url.ActionLink(action: nameof(GetConsentEvents));
+                nextLink = $"{nextLink}?{string.Join("&", queryParams)}";
             }
 
             // Return paginated result

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
@@ -134,10 +134,17 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
         }
 
         /// <summary>
-        /// Get a list of consents that had recent status changes for the authenticated enterprise.
-        /// Returns consents ordered by the latest status change occurred for a consent request(newest first).
-        /// Uses cursor-based pagination.
+        /// Get a list of consent events for the authenticated enterprise.
+        /// Results are ordered oldest first (ascending by event ID). When paginating, the oldest events are returned first and the newest last.
+        /// Only events created more than 5 minutes ago are returned, to ensure consistency and avoid returning events that are still being processed.
+        /// Uses cursor-based pagination via the <c>continuationToken</c> parameter. If a <c>nextLink</c> is present in the response, follow it to retrieve the next page.
         /// </summary>
+        /// <param name="continuationToken">Opaque cursor token returned in the <c>nextLink</c> of a previous response. Pass this to retrieve the next page of results.</param>
+        /// <param name="createdAfter">Optional. Filters events created at or after this timestamp.</param>
+        /// <param name="createdBefore">Optional. Filters events created before this timestamp.</param>
+        /// <param name="eventTypes">Optional. Filters results to one or more specific event types. Can be specified multiple times, e.g. <c>eventTypes=approved&amp;eventTypes=revoked</c>.</param>
+        /// <param name="consentRequestId">Optional. Filters results to events belonging to a specific consent request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         [Authorize(Policy = AuthzConstants.POLICY_CONSENTREQUEST_READ)]
         [HttpGet]
         [Route("consentrequests/events")]
@@ -147,7 +154,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
         [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
-        public async Task<IActionResult> GetConsentStatusChanges(
+        public async Task<IActionResult> GetConsentEvents(
             [FromQuery(Name = "continuationToken")] string? continuationToken = null,
             [FromQuery(Name = "createdAfter")] DateTime? createdAfter = null,
             [FromQuery(Name = "createdBefore")] DateTime? createdBefore = null,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
@@ -165,7 +165,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
             CancellationToken cancellationToken = default)
         {
             int pageSize = _consentSettings.CurrentValue.EventsPageSize;
-            int safetyLagSeconds = 0;//_consentSettings.CurrentValue.EventsSafetyLagSeconds;
+
             Guid? continueFrom = null;
             Core.Models.Consent.ConsentPartyUrn? authenticatedParty = OrgUtil.GetAuthenticatedParty(User);
 
@@ -230,7 +230,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
                 CreatedBefore: createdBefore.HasValue ? createdBefore.Value.UtcDateTime : (DateTime?)null,
                 ContinueFrom: continueFrom);
 
-            Result<List<ConsentStatusChange>> result = await _consentService.GetConsentEventsForParty(authenticatedParty, query, safetyLagSeconds, pageSize, cancellationToken);
+            Result<List<ConsentStatusChange>> result = await _consentService.GetConsentEventsForParty(authenticatedParty, query, pageSize, cancellationToken);
 
             if (result.IsProblem)
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
@@ -140,7 +140,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
         /// </summary>
         [Authorize(Policy = AuthzConstants.POLICY_CONSENTREQUEST_READ)]
         [HttpGet]
-        [Route("consentrequests/latestchanges")]
+        [Route("consentrequests/events")]
         [Produces(MediaTypeNames.Application.Json)]
         [ProducesResponseType(typeof(PaginatedResult<ConsentStatusChangeDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -149,9 +149,14 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetConsentStatusChanges(
             [FromQuery] string? continuationToken = null,
+            [FromQuery] DateTime? createdAfter = null,
+            [FromQuery] DateTime? createdBefore = null,
+            [FromQuery] string[]? eventTypes = null,
+            [FromQuery] Guid? consentRequestId = null, 
             CancellationToken cancellationToken = default)
         {
-            int pageSize = _consentSettings.CurrentValue.LatestChangesPageSize;
+            int pageSize = _consentSettings.CurrentValue.EventsPageSize;
+            int safetyLagSeconds = _consentSettings.CurrentValue.EventsSafetyLagSeconds;
             Core.Models.Consent.ConsentPartyUrn? authenticatedParty = OrgUtil.GetAuthenticatedParty(User);
 
             if (authenticatedParty == null)
@@ -159,7 +164,14 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
                 return Unauthorized();
             }
 
-            Result<List<ConsentStatusChange>> result = await _consentService.GetConsentStatusChangesForParty(authenticatedParty, continuationToken, pageSize, cancellationToken);
+            ConsentEventsQuery query = new ConsentEventsQuery(
+                ConsentRequestId: consentRequestId,
+                EventTypes: eventTypes,
+                CreatedAfter: createdAfter.HasValue ? DateTime.SpecifyKind(createdAfter.Value, DateTimeKind.Utc) : null,
+                CreatedBefore: createdBefore.HasValue ? DateTime.SpecifyKind(createdBefore.Value, DateTimeKind.Utc) : null,
+                ContinuationToken: continuationToken);
+
+            Result<List<ConsentStatusChange>> result = await _consentService.GetConsentEventsForParty(authenticatedParty, query, safetyLagSeconds, pageSize, cancellationToken);
 
             if (result.IsProblem)
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
@@ -34,7 +34,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
 
         private const string CreateRouteName = "enterprisecreateconsentrequest";
         private const string GetRouteName = "enterprisegetconsentrequest";
-        private const string ROUTE_CONSENTEVENTS = "enterprise/consentrequests/events";
+        private const string ROUTE_CONSENTEVENTS = "consentrequests/events";
 
         /// <summary>
         /// Endpoint to create a consent request for
@@ -144,12 +144,12 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
         /// <param name="continuationToken">Opaque cursor token returned in the <c>nextLink</c> of a previous response. Pass this to retrieve the next page of results.</param>
         /// <param name="createdAfter">Optional. Filters events created at or after this timestamp.</param>
         /// <param name="createdBefore">Optional. Filters events created before this timestamp.</param>
-        /// <param name="eventTypes">Optional. Filters results to one or more specific event types. Can be specified multiple times, e.g. <c>eventTypes=approved&amp;eventTypes=revoked</c>.</param>
+        /// <param name="eventTypes">Optional. Filters results to one or more specific event types. Can be specified multiple times, e.g. <c>eventType=approved&amp;eventType=revoked</c>.</param>
         /// <param name="consentRequestId">Optional. Filters results to events belonging to a specific consent request.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         [Authorize(Policy = AuthzConstants.POLICY_CONSENTREQUEST_READ)]
         [HttpGet]
-        [Route("consentrequests/events")]
+        [Route("consentrequests/events", Name = ROUTE_CONSENTEVENTS)]
         [Produces(MediaTypeNames.Application.Json)]
         [ProducesResponseType(typeof(PaginatedResult<ConsentStatusChangeDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
@@ -160,7 +160,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
             [FromQuery(Name = "continuationToken")] string? continuationToken = null,
             [FromQuery(Name = "createdAfter")] DateTimeOffset? createdAfter = null,
             [FromQuery(Name = "createdBefore")] DateTimeOffset? createdBefore = null,
-            [FromQuery(Name = "eventTypes")] string[]? eventTypes = null,
+            [FromQuery(Name = "eventType")] string[]? eventTypes = null,
             [FromQuery(Name = "consentRequestId")] Guid? consentRequestId = null, 
             CancellationToken cancellationToken = default)
         {
@@ -178,7 +178,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
 
             if (createdAfter.HasValue && createdBefore.HasValue && createdAfter >= createdBefore)
             {
-                errors.Add(ValidationErrors.InvalidDateRange, $"/{nameof(createdAfter)}");
+                errors.Add(ValidationErrors.InvalidDateRange, "$QUERY/createdAfter");
             }
 
             if (eventTypes is { Length: > 0 })
@@ -192,7 +192,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
                 {
                     if (!validEventTypes.Contains(eventType))
                     {
-                        errors.Add(ValidationErrors.InvalidEventType, $"/{nameof(eventTypes)}");
+                        errors.Add(ValidationErrors.InvalidEventType, "$QUERY/eventType");
                         break;
                     }
                 }
@@ -205,7 +205,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
                     byte[] bytes = Convert.FromBase64String(continuationToken);                    
                     if (bytes.Length != 16)
                     {
-                        errors.Add(ValidationErrors.InvalidContinuationToken, $"/{nameof(continuationToken)}");
+                        errors.Add(ValidationErrors.InvalidContinuationToken, "$QUERY/continuationToken");
                     }
                     else
                     {
@@ -214,7 +214,7 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
                 }
                 catch (FormatException)
                 {
-                    errors.Add(ValidationErrors.InvalidContinuationToken, $"/{nameof(continuationToken)}");
+                    errors.Add(ValidationErrors.InvalidContinuationToken, "$QUERY/continuationToken");
                 }
             }
 
@@ -249,15 +249,32 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
                 Guid consentEventId = changes.Last().ConsentEventId;
                 string nextToken = Convert.ToBase64String(consentEventId.ToByteArray());
 
-                // Rebuild query string with all existing parameters, replacing/adding continuationToken
-                var queryParams = Request.Query
-                    .Where(kv => !kv.Key.Equals("continuationToken", StringComparison.OrdinalIgnoreCase))
-                    .SelectMany(kv => kv.Value.Select(v => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(v ?? string.Empty)}"))
-                    .Append($"continuationToken={Uri.EscapeDataString(nextToken)}")
-                    .ToList();
+                var routeValues = new RouteValueDictionary
+                {
+                    { "continuationToken", nextToken }
+                };
 
-                nextLink = Url.ActionLink(action: nameof(GetConsentEvents));
-                nextLink = $"{nextLink}?{string.Join("&", queryParams)}";
+                if (Request.Query.ContainsKey("consentRequestId"))
+                {
+                    routeValues["consentRequestId"] = query.ConsentRequestId?.ToString();
+                }
+
+                if (Request.Query.ContainsKey("createdAfter"))
+                {
+                    routeValues["createdAfter"] = query.CreatedAfter?.ToString("O");
+                }
+
+                if (Request.Query.ContainsKey("createdBefore"))
+                {
+                    routeValues["createdBefore"] = query.CreatedBefore?.ToString("O");
+                }
+
+                if (Request.Query.ContainsKey("eventType"))
+                {
+                    routeValues["eventType"] = query.EventTypes;
+                }
+
+                nextLink = Url.Link(ROUTE_CONSENTEVENTS, routeValues);
             }
 
             // Return paginated result

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enterprise/Controllers/ConsentController.cs
@@ -148,11 +148,11 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetConsentStatusChanges(
-            [FromQuery] string? continuationToken = null,
-            [FromQuery] DateTime? createdAfter = null,
-            [FromQuery] DateTime? createdBefore = null,
-            [FromQuery] string[]? eventTypes = null,
-            [FromQuery] Guid? consentRequestId = null, 
+            [FromQuery(Name = "continuationToken")] string? continuationToken = null,
+            [FromQuery(Name = "createdAfter")] DateTime? createdAfter = null,
+            [FromQuery(Name = "createdBefore")] DateTime? createdBefore = null,
+            [FromQuery(Name = "eventTypes")] string[]? eventTypes = null,
+            [FromQuery(Name = "consentRequestId")] Guid? consentRequestId = null, 
             CancellationToken cancellationToken = default)
         {
             int pageSize = _consentSettings.CurrentValue.EventsPageSize;
@@ -187,11 +187,17 @@ namespace Altinn.AccessManagement.Api.Enterprise.Controllers
             string? nextLink = null;
             if (dtos.Count == pageSize)
             {
-                DateTimeOffset created = changes.Last().ChangedDate;
-                Guid consenteventid = changes.Last().ConsentEventId;
-                var token = $"{created:O}|{consenteventid}";
-                string nextToken = Convert.ToBase64String(Encoding.UTF8.GetBytes(token));
-                nextLink = $"{Request.Scheme}://{Request.Host}{Request.Path}?continuationToken={Uri.EscapeDataString(nextToken)}";
+                Guid consentEventId = changes.Last().ConsentEventId;
+                string nextToken = Convert.ToBase64String(consentEventId.ToByteArray());
+
+                // Rebuild query string with all existing parameters, replacing/adding continuationToken
+                var queryParams = Request.Query
+                    .Where(kv => !kv.Key.Equals("continuationToken", StringComparison.OrdinalIgnoreCase))
+                    .SelectMany(kv => kv.Value.Select(v => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(v ?? string.Empty)}"))
+                    .Append($"continuationToken={Uri.EscapeDataString(nextToken)}")
+                    .ToList();
+
+                nextLink = $"{Request.Scheme}://{Request.Host}{Request.Path}?{string.Join("&", queryParams)}";
             }
 
             // Return paginated result

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Configuration/ConsentSettings.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Configuration/ConsentSettings.cs
@@ -8,6 +8,14 @@ namespace Altinn.AccessManagement.Core.Configuration
 {
     public class ConsentSettings
     {
-        public int LatestChangesPageSize { get; set; } = 1000;
+        /// <summary>
+        /// The number of consent events to retrieve per page when querying the consent events
+        /// </summary>
+        public int EventsPageSize { get; set; } = 100;
+        
+        /// <summary>
+        /// The number of seconds to wait before considering a consent event as final. This setting is used to introduce a safety lag when processing consent events, ensuring that any recent changes are fully propagated and reducing the risk of inconsistencies. Adjusting this value can help balance the trade-off between data freshness and consistency.
+        /// </summary>
+        public int EventsSafetyLagSeconds { get; set; } = 5;
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Configuration/ConsentSettings.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Configuration/ConsentSettings.cs
@@ -11,11 +11,6 @@ namespace Altinn.AccessManagement.Core.Configuration
         /// <summary>
         /// The number of consent events to retrieve per page when querying the consent events
         /// </summary>
-        public int EventsPageSize { get; set; } = 100;
-        
-        /// <summary>
-        /// The number of seconds to wait before considering a consent event as final. This setting is used to introduce a safety lag when processing consent events, ensuring that any recent changes are fully propagated and reducing the risk of inconsistencies. Adjusting this value can help balance the trade-off between data freshness and consistency.
-        /// </summary>
-        public int EventsSafetyLagSeconds { get; set; } = 5;
+        public int EventsPageSize { get; set; } = 100;        
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ConsentEventsQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ConsentEventsQuery.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Altinn.AccessManagement.Core.Models
+{
+    /// <summary>
+    /// Represents the parameters used to query consent events for a specific party, with optional filters for consent
+    /// request, event types, creation date range, and pagination.
+    /// </summary>
+    /// <param name="PartyUuid">The unique identifier of the party whose consent events are being queried.</param>
+    /// <param name="ConsentRequestId">The unique identifier of the consent request to filter events by. If null, events from all consent requests are
+    /// included.</param>
+    /// <param name="EventTypes">An array of event type names to filter the results. If null, events of all types are included.</param>
+    /// <param name="CreatedAfter">The earliest creation date and time, in UTC, for events to include in the results. Only events created after
+    /// this date are returned. If null, no lower bound is applied.</param>
+    /// <param name="CreatedBefore">The latest creation date and time, in UTC, for events to include in the results. Only events created before this
+    /// date are returned. If null, no upper bound is applied.</param>
+    /// <param name="Cursor">A pagination cursor indicating the position in the result set from which to continue retrieving events. If null,
+    /// retrieval starts from the beginning.</param>
+    public record ConsentEventsQuery(
+        Guid? ConsentRequestId,
+        string[]? EventTypes,
+        DateTimeOffset? CreatedAfter,
+        DateTimeOffset? CreatedBefore,
+        string? ContinuationToken);
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ConsentEventsQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ConsentEventsQuery.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Altinn.AccessManagement.Core.Models
+﻿namespace Altinn.AccessManagement.Core.Models
 {
     /// <summary>
     /// Represents the parameters used to query consent events for a specific party, with optional filters for consent
     /// request, event types, creation date range, and pagination.
     /// </summary>
-    /// <param name="PartyUuid">The unique identifier of the party whose consent events are being queried.</param>
     /// <param name="ConsentRequestId">The unique identifier of the consent request to filter events by. If null, events from all consent requests are
     /// included.</param>
     /// <param name="EventTypes">An array of event type names to filter the results. If null, events of all types are included.</param>
@@ -16,7 +11,7 @@ namespace Altinn.AccessManagement.Core.Models
     /// this date are returned. If null, no lower bound is applied.</param>
     /// <param name="CreatedBefore">The latest creation date and time, in UTC, for events to include in the results. Only events created before this
     /// date are returned. If null, no upper bound is applied.</param>
-    /// <param name="Cursor">A pagination cursor indicating the position in the result set from which to continue retrieving events. If null,
+    /// <param name="ContinuationToken">A pagination cursor indicating the position in the result set from which to continue retrieving events. If null,
     /// retrieval starts from the beginning.</param>
     public record ConsentEventsQuery(
         Guid? ConsentRequestId,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ConsentEventsQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Models/ConsentEventsQuery.cs
@@ -11,12 +11,12 @@
     /// this date are returned. If null, no lower bound is applied.</param>
     /// <param name="CreatedBefore">The latest creation date and time, in UTC, for events to include in the results. Only events created before this
     /// date are returned. If null, no upper bound is applied.</param>
-    /// <param name="ContinuationToken">A pagination cursor indicating the position in the result set from which to continue retrieving events. If null,
+    /// <param name="ContinueFrom">A pagination cursor id indicating the position in the result set from which to continue retrieving events. If null,
     /// retrieval starts from the beginning.</param>
     public record ConsentEventsQuery(
         Guid? ConsentRequestId,
         string[]? EventTypes,
         DateTimeOffset? CreatedAfter,
         DateTimeOffset? CreatedBefore,
-        string? ContinuationToken);
+        Guid? ContinueFrom);
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Repositories/Interfaces/IConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Repositories/Interfaces/IConsentRepository.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.AccessManagement.Core.Models.Consent;
+﻿using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.Core.Models.Consent;
 using Altinn.Authorization.ProblemDetails;
 
 namespace Altinn.AccessManagement.Core.Repositories.Interfaces
@@ -59,13 +60,14 @@ namespace Altinn.AccessManagement.Core.Repositories.Interfaces
         Task<int> GetConsentRequestCountForParty(Guid fromPartyUuid, ConsentRequestStatusType status, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Returns a list of consents that had status changes for a specific party, ordered by change date (newest first).
+        /// Returns a list of consent events for a specific party, ordered by change date (newest first).
         /// </summary>
-        /// <param name="partyUuid">The party UUID to get status changes for</param>
-        /// <param name="continuationToken">Optional continuation token from previous response</param>
+        /// <param name="partyUuid">The party UUID to get consent events for</param>
+        /// <param name="query">Query parameters to filter consent events</param>
+        /// <param name="safetyLagSeconds">Number of seconds to wait before considering a consent event as final.</param>
         /// <param name="pageSize">Number of items to return</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>List of consent status changes</returns>
-        Task<Result<List<ConsentStatusChange>>> GetConsentStatusChangesForParty(Guid partyUuid, string? continuationToken, int pageSize, CancellationToken cancellationToken);
+        /// <returns>List of consent events</returns>
+        Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery query, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken);
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Repositories/Interfaces/IConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Repositories/Interfaces/IConsentRepository.cs
@@ -64,10 +64,9 @@ namespace Altinn.AccessManagement.Core.Repositories.Interfaces
         /// </summary>
         /// <param name="partyUuid">The party UUID to get consent events for</param>
         /// <param name="query">Query parameters to filter consent events</param>
-        /// <param name="safetyLagSeconds">Number of seconds to wait before considering a consent event as final.</param>
         /// <param name="pageSize">Number of items to return</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of consent events</returns>
-        Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery query, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken);
+        Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery query, int pageSize, CancellationToken cancellationToken);
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Repositories/Interfaces/IConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Repositories/Interfaces/IConsentRepository.cs
@@ -60,7 +60,7 @@ namespace Altinn.AccessManagement.Core.Repositories.Interfaces
         Task<int> GetConsentRequestCountForParty(Guid fromPartyUuid, ConsentRequestStatusType status, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Returns a list of consent events for a specific party, ordered by change date (newest first).
+        /// Returns a list of consent events for a specific party, ordered by change date (oldest first).
         /// </summary>
         /// <param name="partyUuid">The party UUID to get consent events for</param>
         /// <param name="query">Query parameters to filter consent events</param>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
@@ -1046,7 +1046,7 @@ namespace Altinn.AccessManagement.Core.Services
         }
 
         /// <inheritdoc/>
-        public async Task<Result<List<ConsentStatusChange>>> GetConsentStatusChangesForParty(ConsentPartyUrn consentReceiver, string? continuationToken, int pageSize, CancellationToken cancellationToken)
+        public async Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(ConsentPartyUrn consentReceiver, ConsentEventsQuery query, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken)
         {
             ValidationErrorBuilder validationErrorBuilder = default;
 
@@ -1062,7 +1062,7 @@ namespace Altinn.AccessManagement.Core.Services
 
             ConsentPartyUrn consentedToParty = await MapFromExternalIdenity(consentReceiver, cancellationToken);
             consentedToParty.IsPartyUuid(out Guid partyUuid);
-            Result<List<ConsentStatusChange>> result = await _consentRepository.GetConsentStatusChangesForParty(partyUuid, continuationToken, pageSize, cancellationToken);
+            Result<List<ConsentStatusChange>> result = await _consentRepository.GetConsentEventsForParty(partyUuid, query, safetyLagSeconds, pageSize, cancellationToken);
 
             if (result.IsProblem)
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
@@ -1052,7 +1052,7 @@ namespace Altinn.AccessManagement.Core.Services
 
             if (pageSize <= 0 || pageSize > 1000)
             {
-                validationErrorBuilder.Add(ValidationErrors.InvalidPageSizeForConsentStatusChanges, "pageSize");
+                validationErrorBuilder.Add(ValidationErrors.InvalidPageSizeForConsentEvents, "pageSize");
             }
 
             if (validationErrorBuilder.TryBuild(out var errorResult))

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/ConsentService.cs
@@ -1046,7 +1046,7 @@ namespace Altinn.AccessManagement.Core.Services
         }
 
         /// <inheritdoc/>
-        public async Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(ConsentPartyUrn consentReceiver, ConsentEventsQuery query, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken)
+        public async Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(ConsentPartyUrn consentReceiver, ConsentEventsQuery query, int pageSize, CancellationToken cancellationToken)
         {
             ValidationErrorBuilder validationErrorBuilder = default;
 
@@ -1062,7 +1062,7 @@ namespace Altinn.AccessManagement.Core.Services
 
             ConsentPartyUrn consentedToParty = await MapFromExternalIdenity(consentReceiver, cancellationToken);
             consentedToParty.IsPartyUuid(out Guid partyUuid);
-            Result<List<ConsentStatusChange>> result = await _consentRepository.GetConsentEventsForParty(partyUuid, query, safetyLagSeconds, pageSize, cancellationToken);
+            Result<List<ConsentStatusChange>> result = await _consentRepository.GetConsentEventsForParty(partyUuid, query, pageSize, cancellationToken);
 
             if (result.IsProblem)
             {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/Interfaces/IConsent.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/Interfaces/IConsent.cs
@@ -83,7 +83,7 @@ namespace Altinn.AccessManagement.Core.Services.Interfaces
         Task<Result<int>> GetConsentRequestCountForParty(Guid offeredByParty, ConsentRequestStatusType status, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Returns a list of consent events for a specific party, ordered by change date (newest first).
+        /// Returns a list of consent events for a specific party, ordered by change date (oldest first).
         /// </summary>
         /// <param name="consentReceiver">The consent receiver that checks for events</param>
         /// <param name="query">The query parameters to filter the consent events</param>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/Interfaces/IConsent.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/Interfaces/IConsent.cs
@@ -87,10 +87,9 @@ namespace Altinn.AccessManagement.Core.Services.Interfaces
         /// </summary>
         /// <param name="consentReceiver">The consent receiver that checks for events</param>
         /// <param name="query">The query parameters to filter the consent events</param>
-        /// <param name="safetyLagSeconds">Number of seconds to wait before considering a consent event as final.</param>
         /// <param name="pageSize">Number of items to return</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List of consent events</returns>
-        Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(ConsentPartyUrn consentReceiver, ConsentEventsQuery query, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken);
+        Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(ConsentPartyUrn consentReceiver, ConsentEventsQuery query, int pageSize, CancellationToken cancellationToken);
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/Interfaces/IConsent.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/Interfaces/IConsent.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.AccessManagement.Core.Models.Consent;
+﻿using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.Core.Models.Consent;
 using Altinn.Authorization.ProblemDetails;
 
 namespace Altinn.AccessManagement.Core.Services.Interfaces
@@ -82,13 +83,14 @@ namespace Altinn.AccessManagement.Core.Services.Interfaces
         Task<Result<int>> GetConsentRequestCountForParty(Guid offeredByParty, ConsentRequestStatusType status, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Returns a list of consents that had status changes for a specific party, ordered by change date (newest first).
+        /// Returns a list of consent events for a specific party, ordered by change date (newest first).
         /// </summary>
-        /// <param name="consentReceiver">The consent receiver that checks for status changes</param>
-        /// <param name="continuationToken">Optional continuation token from previous response</param>
+        /// <param name="consentReceiver">The consent receiver that checks for events</param>
+        /// <param name="query">The query parameters to filter the consent events</param>
+        /// <param name="safetyLagSeconds">Number of seconds to wait before considering a consent event as final.</param>
         /// <param name="pageSize">Number of items to return</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>List of consent status changes</returns>
-        Task<Result<List<ConsentStatusChange>>> GetConsentStatusChangesForParty(ConsentPartyUrn consentReceiver, string? continuationToken, int pageSize, CancellationToken cancellationToken);
+        /// <returns>List of consent events</returns>
+        Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(ConsentPartyUrn consentReceiver, ConsentEventsQuery query, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken);
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Configuration/PostgreSQLSettings.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Configuration/PostgreSQLSettings.cs
@@ -1,4 +1,4 @@
-namespace Altinn.AccessManagement.Persistence.Configuration
+﻿namespace Altinn.AccessManagement.Persistence.Configuration
 {
     /// <summary>
     /// Settings for Postgres database
@@ -14,5 +14,10 @@ namespace Altinn.AccessManagement.Persistence.Configuration
         /// Password for app user for the postgres db
         /// </summary>
         public string AuthorizationDbPwd { get; set; }
+
+        /// <summary>
+        /// The number of seconds to wait before considering a consent event as final. This setting is used to introduce a safety lag when processing consent events, ensuring that any recent changes are fully propagated and reducing the risk of inconsistencies. Adjusting this value can help balance the trade-off between data freshness and consistency.
+        /// </summary>
+        public int ConsentEventsSafetyLagSeconds { get; set; } = 300;
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Configuration/PostgreSQLSettings.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Configuration/PostgreSQLSettings.cs
@@ -18,6 +18,6 @@
         /// <summary>
         /// The number of seconds to wait before considering a consent event as final. This setting is used to introduce a safety lag when processing consent events, ensuring that any recent changes are fully propagated and reducing the risk of inconsistencies. Adjusting this value can help balance the trade-off between data freshness and consistency.
         /// </summary>
-        public int ConsentEventsSafetyLagSeconds { get; set; } = 300;
+        public int ConsentEventsSafetyLag { get; set; } = 300;
     }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
@@ -589,7 +589,7 @@ namespace Altinn.AccessManagement.Persistence.Consent
             return consentContext;
         }
 
-        public async Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery consentEventsQuery, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken)
+        public async Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery consentEventsQuery, int pageSize, CancellationToken cancellationToken)
         {
             var uuid7SafetyBound = Guid.CreateVersion7(_timeProvider.GetUtcNow().AddSeconds(-_consentRequestSafetyLagSeconds.TotalSeconds));
             var consentStatusChanges = new List<ConsentStatusChange>();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text;
 using Altinn.AccessManagement.Core.Extensions;
+using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.Consent;
 using Altinn.AccessManagement.Core.Repositories.Interfaces;
 using Altinn.AccessManagement.Persistence.Extensions;
@@ -584,16 +585,16 @@ namespace Altinn.AccessManagement.Persistence.Consent
             return consentContext;
         }
 
-        public async Task<Result<List<ConsentStatusChange>>> GetConsentStatusChangesForParty(Guid partyUuid, string? continuationToken, int pageSize, CancellationToken cancellationToken)
+        public async Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery consentEventsQuery, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken)
         {
             // Parse continuation token to get cursor UUID
             Guid cursorEventId = default;
             DateTimeOffset cursorCreated = default;
-            if (!string.IsNullOrEmpty(continuationToken))
+            if (!string.IsNullOrEmpty(consentEventsQuery.ContinuationToken))
             {
                 try
                 {
-                    var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(continuationToken));
+                    var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(consentEventsQuery.ContinuationToken));
                     var parts = decoded.Split('|');
                     if (parts.Length != 2)
                     {
@@ -609,44 +610,37 @@ namespace Altinn.AccessManagement.Persistence.Consent
                 }
             }
 
+            var uuid7SafetyBound = Guid.CreateVersion7(DateTimeOffset.UtcNow.AddSeconds(-safetyLagSeconds));
             var consentStatusChanges = new List<ConsentStatusChange>();
 
-            string consentChangesQuery = $@"WITH latest_events AS (
-                                SELECT
-                                ce.consenteventid,
-                                ce.consentrequestid,
-                                ce.eventtype,
-                                ce.created,
-                                ce.performedbyparty
-                                FROM consent.consentevent ce
-                                INNER JOIN consent.consentrequest cr ON ce.consentrequestid = cr.consentrequestid
-                                WHERE
-                                cr.topartyuuid = @partyUuid
-                                AND ce.eventtype <> 'created'
-                                -- Only consider events before the cursor for paging
-                                AND (
-                                    @cursorCreated IS NULL
-                                    OR
-                                    (ce.created, ce.consenteventid) < (@cursorCreated, @cursorEventId)
-                                )
-                                -- Only the latest event per consentrequest
-                                AND NOT EXISTS (
-                                    SELECT 1
-                                    FROM consent.consentevent ce2
-                                    WHERE
-                                    ce2.consentrequestid = ce.consentrequestid
-                                    AND ce2.eventtype <> 'created'
-                                    AND (ce2.created, ce2.consenteventid) > (ce.created, ce.consenteventid)
-                                    )
-                                )
-                                SELECT *
-                                FROM latest_events
-                                ORDER BY created DESC, consenteventid DESC
-                                LIMIT @pagesize";
+            string consentChangesQuery = $@"SELECT
+                                        ce.consentrequestid,
+                                        ce.consenteventid,
+                                        ce.eventtype,
+                                        ce.created
+                                        FROM consent.consentevent ce
+                                        INNER JOIN consent.consentrequest cr
+                                        ON ce.consentrequestid = cr.consentrequestid
+                                        WHERE
+                                        cr.topartyuuid = @partyUuid
+                                        AND ce.eventtype <> 'created'
+                                        AND ce.consenteventid < @uuid7SafetyBound
+                                        AND (@consentRequestId IS NULL OR ce.consentrequestid = @consentRequestId)
+                                        AND (@eventTypes      IS NULL OR ce.eventtype = ANY(@eventTypes::consent.event_type[]))
+                                        AND (@createdAfter     IS NULL OR ce.created >= @createdAfter)
+                                        AND (@createdBefore    IS NULL OR ce.created <  @createdBefore)
+                                        AND (@cursorEventId   IS NULL OR ce.consenteventid > @cursorEventId)
+                                        ORDER BY ce.consenteventid ASC
+                                        LIMIT @pagesize";
             await using var pgcom = _db.CreateCommand(consentChangesQuery);
             pgcom.Parameters.AddWithValue("@partyUuid", NpgsqlTypes.NpgsqlDbType.Uuid, partyUuid);
             pgcom.Parameters.AddWithValue("@cursorEventId", NpgsqlTypes.NpgsqlDbType.Uuid, cursorEventId == Guid.Empty ? DBNull.Value : cursorEventId);
-            pgcom.Parameters.AddWithValue("@cursorCreated", NpgsqlTypes.NpgsqlDbType.TimestampTz, cursorCreated == DateTimeOffset.MinValue ? DBNull.Value : cursorCreated);
+            pgcom.Parameters.AddWithValue("@consentRequestId", NpgsqlDbType.Uuid, consentEventsQuery.ConsentRequestId.HasValue ? (object)consentEventsQuery.ConsentRequestId.Value : DBNull.Value);
+            pgcom.Parameters.AddWithValue("@eventTypes", NpgsqlDbType.Array | NpgsqlDbType.Text, consentEventsQuery.EventTypes is not null ? (object)consentEventsQuery.EventTypes : DBNull.Value);
+            pgcom.Parameters.AddWithValue("@createdAfter", NpgsqlDbType.TimestampTz, consentEventsQuery.CreatedAfter.HasValue ? (object)consentEventsQuery.CreatedAfter.Value : DBNull.Value);
+            pgcom.Parameters.AddWithValue("@createdBefore", NpgsqlDbType.TimestampTz,consentEventsQuery.CreatedBefore.HasValue ? (object)consentEventsQuery.CreatedBefore.Value : DBNull.Value);
+            pgcom.Parameters.AddWithValue("@uuid7SafetyBound", NpgsqlTypes.NpgsqlDbType.Uuid, uuid7SafetyBound);
+            pgcom.Parameters.AddWithValue("@consentRequestId", NpgsqlTypes.NpgsqlDbType.Uuid, consentEventsQuery.ConsentRequestId == null ? DBNull.Value : consentEventsQuery.ConsentRequestId);
             pgcom.Parameters.AddWithValue("@pageSize", NpgsqlTypes.NpgsqlDbType.Integer, pageSize);
 
             await using var reader = await pgcom.ExecuteReaderAsync(cancellationToken);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
@@ -594,15 +594,8 @@ namespace Altinn.AccessManagement.Persistence.Consent
             {
                 try
                 {
-                    var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(consentEventsQuery.ContinuationToken));
-                    var parts = decoded.Split('|');
-                    if (parts.Length != 2)
-                    {
-                        throw new FormatException("Invalid continuation token format.");
-                    }
-
-                    cursorCreated = DateTimeOffset.Parse(parts[0], null, DateTimeStyles.RoundtripKind);
-                    cursorEventId = Guid.Parse(parts[1]);
+                    byte[] bytes = Convert.FromBase64String(consentEventsQuery.ContinuationToken);
+                    cursorEventId = new Guid(bytes);
                 }
                 catch
                 {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
@@ -1,15 +1,17 @@
-﻿using System.Data;
-using System.Globalization;
-using System.Text;
-using Altinn.AccessManagement.Core.Extensions;
+﻿using Altinn.AccessManagement.Core.Extensions;
 using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.Consent;
 using Altinn.AccessManagement.Core.Repositories.Interfaces;
+using Altinn.AccessManagement.Persistence.Configuration;
 using Altinn.AccessManagement.Persistence.Extensions;
 using Altinn.Authorization.ProblemDetails;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using Npgsql;
 using NpgsqlTypes;
+using System.Data;
+using System.Globalization;
+using System.Text;
 
 namespace Altinn.AccessManagement.Persistence.Consent
 {
@@ -19,9 +21,11 @@ namespace Altinn.AccessManagement.Persistence.Consent
     /// <remarks>
     /// Initializes a new instance of the <see cref="ConsentRepository"/> class
     /// </remarks>
-    public class ConsentRepository(NpgsqlDataSource db) : IConsentRepository
+    public class ConsentRepository(NpgsqlDataSource db, IOptions<PostgreSQLSettings> config, TimeProvider timeProvider) : IConsentRepository
     {
         private readonly NpgsqlDataSource _db = db;
+        private readonly TimeSpan _consentRequestSafetyLagSeconds = TimeSpan.FromSeconds(config.Value.ConsentEventsSafetyLagSeconds);
+        private readonly TimeProvider _timeProvider = timeProvider;
 
         private const string PARAM_CONSENT_REQUEST_ID = "consentRequestId";
         private const string PARAM_PERFORMED_BY_PARTY = "performedByParty";
@@ -32,7 +36,7 @@ namespace Altinn.AccessManagement.Persistence.Consent
         private const string PARAM_REVOKED = "revokedTime";
         private const string PARAM_CONSENT_RIGHT_ID = "consentRightId";
         private const string PARAM_CONSENT_CONTEXT_ID = "contextId";
-        private const string PARAM_LANGAUGE = "language";
+        private const string PARAM_LANGAUGE = "language";        
 
         private const string EventQuery = /*strpsql*/@"
                 INSERT INTO consent.consentevent (consentEventId, consentRequestId, eventtype, created, performedByParty)
@@ -48,7 +52,7 @@ namespace Altinn.AccessManagement.Persistence.Consent
         /// <inheritdoc/>
         public async Task AcceptConsentRequest(Guid consentRequestId, Guid performedByParty, ConsentContext context, CancellationToken cancellationToken = default)
         {
-            DateTimeOffset consentedTime = DateTime.UtcNow;
+            DateTimeOffset consentedTime = _timeProvider.GetUtcNow();
 
             const string updateConsentRequestQuery = /*strpsql*/@"
                     UPDATE consent.consentrequest set status = 'accepted', consented = @consentedTime  WHERE consentRequestId= @consentRequestId and status = 'created'";
@@ -587,26 +591,10 @@ namespace Altinn.AccessManagement.Persistence.Consent
 
         public async Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery consentEventsQuery, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken)
         {
-            // Parse continuation token to get cursor UUID
-            Guid cursorEventId = default;
-            DateTimeOffset cursorCreated = default;
-            if (!string.IsNullOrEmpty(consentEventsQuery.ContinuationToken))
-            {
-                try
-                {
-                    byte[] bytes = Convert.FromBase64String(consentEventsQuery.ContinuationToken);
-                    cursorEventId = new Guid(bytes);
-                }
-                catch
-                {
-                    // Invalid token, ignore and start from beginning
-                }
-            }
-
-            var uuid7SafetyBound = Guid.CreateVersion7(DateTimeOffset.UtcNow.AddSeconds(-safetyLagSeconds));
+            var uuid7SafetyBound = Guid.CreateVersion7(_timeProvider.GetUtcNow().AddSeconds(-_consentRequestSafetyLagSeconds.TotalSeconds));
             var consentStatusChanges = new List<ConsentStatusChange>();
 
-            string consentChangesQuery = $@"SELECT
+            const string consentChangesQuery = @"SELECT
                                         ce.consentrequestid,
                                         ce.consenteventid,
                                         ce.eventtype,
@@ -622,13 +610,12 @@ namespace Altinn.AccessManagement.Persistence.Consent
                                         AND (@eventTypes      IS NULL OR ce.eventtype = ANY(@eventTypes::consent.event_type[]))
                                         AND (@createdAfter     IS NULL OR ce.created >= @createdAfter)
                                         AND (@createdBefore    IS NULL OR ce.created <  @createdBefore)
-                                        AND (@cursorEventId   IS NULL OR ce.consenteventid > @cursorEventId)
+                                        AND (@continueFrom   IS NULL OR ce.consenteventid > @continueFrom)
                                         ORDER BY ce.consenteventid ASC
-                                        LIMIT @pagesize";
+                                        LIMIT @pageSize";
             await using var pgcom = _db.CreateCommand(consentChangesQuery);
             pgcom.Parameters.AddWithValue("@partyUuid", NpgsqlTypes.NpgsqlDbType.Uuid, partyUuid);
-            pgcom.Parameters.AddWithValue("@cursorEventId", NpgsqlTypes.NpgsqlDbType.Uuid, cursorEventId == Guid.Empty ? DBNull.Value : cursorEventId);
-            pgcom.Parameters.AddWithValue("@consentRequestId", NpgsqlDbType.Uuid, consentEventsQuery.ConsentRequestId.HasValue ? (object)consentEventsQuery.ConsentRequestId.Value : DBNull.Value);
+            pgcom.Parameters.AddWithValue("@continueFrom", NpgsqlTypes.NpgsqlDbType.Uuid, consentEventsQuery.ContinueFrom.HasValue ? (object)consentEventsQuery.ContinueFrom.Value : DBNull.Value);
             pgcom.Parameters.AddWithValue("@eventTypes", NpgsqlDbType.Array | NpgsqlDbType.Text, consentEventsQuery.EventTypes is not null ? (object)consentEventsQuery.EventTypes : DBNull.Value);
             pgcom.Parameters.AddWithValue("@createdAfter", NpgsqlDbType.TimestampTz, consentEventsQuery.CreatedAfter.HasValue ? (object)consentEventsQuery.CreatedAfter.Value : DBNull.Value);
             pgcom.Parameters.AddWithValue("@createdBefore", NpgsqlDbType.TimestampTz,consentEventsQuery.CreatedBefore.HasValue ? (object)consentEventsQuery.CreatedBefore.Value : DBNull.Value);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
@@ -24,7 +24,7 @@ namespace Altinn.AccessManagement.Persistence.Consent
     public class ConsentRepository(NpgsqlDataSource db, IOptions<PostgreSQLSettings> config, TimeProvider timeProvider) : IConsentRepository
     {
         private readonly NpgsqlDataSource _db = db;
-        private readonly TimeSpan _consentRequestSafetyLagSeconds = TimeSpan.FromSeconds(config.Value.ConsentEventsSafetyLagSeconds);
+        private readonly TimeSpan _consentRequestSafetyLag = TimeSpan.FromSeconds(config.Value.ConsentEventsSafetyLag);
         private readonly TimeProvider _timeProvider = timeProvider;
 
         private const string PARAM_CONSENT_REQUEST_ID = "consentRequestId";
@@ -591,7 +591,7 @@ namespace Altinn.AccessManagement.Persistence.Consent
 
         public async Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery consentEventsQuery, int pageSize, CancellationToken cancellationToken)
         {
-            var uuid7SafetyBound = Guid.CreateVersion7(_timeProvider.GetUtcNow().AddSeconds(-_consentRequestSafetyLagSeconds.TotalSeconds));
+            var uuid7SafetyBound = Guid.CreateVersion7(_timeProvider.GetUtcNow() - _consentRequestSafetyLag);
             var consentStatusChanges = new List<ConsentStatusChange>();
 
             const string consentChangesQuery = @"SELECT

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Altinn.AccessManagement.csproj
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Altinn.AccessManagement.csproj
@@ -27,7 +27,7 @@
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
         <PackageReference Include="OpenTelemetry.Exporter.Console" />
         <PackageReference Include="Swashbuckle.AspNetCore" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" />
         <PackageReference Include="Yuniql.AspNetCore" />
         <PackageReference Include="Yuniql.PostgreSql" />

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.json
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.json
@@ -32,7 +32,8 @@
     "AdminConnectionString": "Host=localhost;Port=5432;Username=platform_authorization_admin;Password={0};Database=authorizationdb;Include Error Detail=true",
     "ConnectionString": "Host=localhost;Port=5432;Username=platform_authorization;Password={0};Database=authorizationdb;Include Error Detail=true",
     "AuthorizationDbAdminPwd": "Password",
-    "AuthorizationDbPwd": "Password"
+    "AuthorizationDbPwd": "Password",
+    "ConsentEventsSafetyLagSeconds": 300
   },
   "AzureStorageConfiguration": {
     "MetadataAccountName": "devstoreaccount1",

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.json
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.json
@@ -33,7 +33,7 @@
     "ConnectionString": "Host=localhost;Port=5432;Username=platform_authorization;Password={0};Database=authorizationdb;Include Error Detail=true",
     "AuthorizationDbAdminPwd": "Password",
     "AuthorizationDbPwd": "Password",
-    "ConsentEventsSafetyLagSeconds": 300
+    "ConsentEventsSafetyLag": 300
   },
   "AzureStorageConfiguration": {
     "MetadataAccountName": "devstoreaccount1",
@@ -105,8 +105,7 @@
     "MaxDegreeOfParallelism": 5
   },
   "Consent": {
-    "EventsPageSize": 100,
-    "EventsSafetyLagSeconds": 300
+    "EventsPageSize": 100
   },
   "ServiceOwnerDelegation": {
     "PackageWhiteList": {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.json
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.json
@@ -104,7 +104,8 @@
     "MaxDegreeOfParallelism": 5
   },
   "Consent": {
-    "LatestChangesPageSize": 1000
+    "EventsPageSize": 100,
+    "EventsSafetyLagSeconds": 300
   },
   "ServiceOwnerDelegation": {
     "PackageWhiteList": {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
@@ -784,36 +784,107 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             Assert.Equal(SeededTotal, allItems.Count);
         }
 
-        /// <summary>
-        /// An invalid/garbage continuationToken is silently ignored and the response
-        /// equals the first page of an unfiltered request.
-        /// </summary>
         [Fact]
-        public async Task GetConsentStatusChanges_InvalidContinuationToken_StartsFromBeginning()
+        public async Task GetConsentEvents_WithInvalidEventType_ReturnsBadRequest()
         {
-            string badToken = Uri.EscapeDataString("not!!a$$valid##base64");
+            SetupMockPartyRepository();
 
-            HttpClient client = GetAuthorizedReadClient();
+            HttpClient client = GetTestClient();
+            string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            var responseWithBad = await client.GetAsync(
-                $"/accessmanagement/api/v1/enterprise/consentrequests/events?continuationToken={badToken}",
+            HttpResponseMessage response = await client.GetAsync(
+                "/accessmanagement/api/v1/enterprise/consentrequests/events?eventTypes=invalidtype",
                 TestContext.Current.CancellationToken);
-            var responseClean = await client.GetAsync(
-                "/accessmanagement/api/v1/enterprise/consentrequests/events",
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(content, _jsonOptions);
+            Assert.Equal(ValidationErrors.InvalidEventType.ErrorCode, problemDetails.Errors.ToList()[0].ErrorCode);
+        }
+
+        [Fact]
+        public async Task GetConsentEvents_WithCreatedAfterAfterCreatedBefore_ReturnsBadRequest()
+        {
+            SetupMockPartyRepository();
+
+            HttpClient client = GetTestClient();
+            string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            string createdAfter = Uri.EscapeDataString(DateTimeOffset.UtcNow.AddDays(1).ToString("O"));
+            string createdBefore = Uri.EscapeDataString(DateTimeOffset.UtcNow.ToString("O"));
+
+            HttpResponseMessage response = await client.GetAsync(
+                $"/accessmanagement/api/v1/enterprise/consentrequests/events?createdAfter={createdAfter}&createdBefore={createdBefore}",
                 TestContext.Current.CancellationToken);
 
-            Assert.Equal(HttpStatusCode.OK, responseWithBad.StatusCode);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(content, _jsonOptions);
+            Assert.Equal(ValidationErrors.InvalidDateRange.ErrorCode, problemDetails.Errors.ToList()[0].ErrorCode);
+        }
 
-            var resultWithBad = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
-                await responseWithBad.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
-            var resultClean = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
-                await responseClean.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+        [Fact]
+        public async Task GetConsentEvents_WithCreatedAfterEqualToCreatedBefore_ReturnsBadRequest()
+        {
+            SetupMockPartyRepository();
 
-            // Invalid token must not skip any data — same first page as the clean request
-            Assert.Equal(PageSize, resultWithBad.Items.Count());
-            Assert.Equal(
-                resultClean.Items.Select(i => i.ConsentRequestId),
-                resultWithBad.Items.Select(i => i.ConsentRequestId));
+            HttpClient client = GetTestClient();
+            string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            string timestamp = Uri.EscapeDataString(DateTimeOffset.UtcNow.ToString("O"));
+
+            HttpResponseMessage response = await client.GetAsync(
+                $"/accessmanagement/api/v1/enterprise/consentrequests/events?createdAfter={timestamp}&createdBefore={timestamp}",
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(content, _jsonOptions);
+            Assert.Equal(ValidationErrors.InvalidDateRange.ErrorCode, problemDetails.Errors.ToList()[0].ErrorCode);
+        }
+
+        [Fact]
+        public async Task GetConsentEvents_WithInvalidContinuationToken_ReturnsBadRequest()
+        {
+            SetupMockPartyRepository();
+
+            HttpClient client = GetTestClient();
+            string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            HttpResponseMessage response = await client.GetAsync(
+                "/accessmanagement/api/v1/enterprise/consentrequests/events?continuationToken=notvalidbase64!!!",
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(content, _jsonOptions);
+            Assert.Equal(ValidationErrors.InvalidContinuationToken.ErrorCode, problemDetails.Errors.ToList()[0].ErrorCode);
+        }
+
+        [Fact]
+        public async Task GetConsentEvents_WithWrongLengthContinuationToken_ReturnsBadRequest()
+        {
+            SetupMockPartyRepository();
+
+            HttpClient client = GetTestClient();
+            string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // Valid base64 but not 16 bytes (a GUID)
+            string shortToken = Uri.EscapeDataString(Convert.ToBase64String(new byte[] { 1, 2, 3 }));
+
+            HttpResponseMessage response = await client.GetAsync(
+                $"/accessmanagement/api/v1/enterprise/consentrequests/events?continuationToken={shortToken}",
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(content, _jsonOptions);
+            Assert.Equal(ValidationErrors.InvalidContinuationToken.ErrorCode, problemDetails.Errors.ToList()[0].ErrorCode);
         }
 
         /// <summary>

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
@@ -53,6 +53,21 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         private LegacyApiFixture _fixture = null!;
         private readonly ITestOutputHelper _output;
 
+        // ── Seeded consent ID buckets ─────────────────────────────────────────
+        // Populated by CreateAndUpdateConsentsForGet so every test can reference
+        // exact IDs without repeating setup logic.
+        private List<Guid> _acceptedConsentIds = [];   // 5 IDs (indexes 0-4)
+        private List<Guid> _rejectedConsentIds = [];   // 5 IDs (indexes 5-9)
+        private List<Guid> _revokedConsentIds = [];   // 3 IDs (subset of accepted, indexes 0-2)
+
+        // ── Seeded event counts (derived from numberOfConsents=10) ────────────
+        // accepted=5, rejected=5, revoked=3  →  total=13 events across 3 pages
+        private const int SeededAccepted = 5;
+        private const int SeededRejected = 5;
+        private const int SeededRevoked = 3;
+        private const int SeededTotal = SeededAccepted + SeededRejected + SeededRevoked; // 13
+        private const int PageSize = 5;
+
         private static readonly Altinn.AccessMgmt.PersistenceEF.Models.ResourceType ConsentResourceType = new()
         {
             Id = Guid.Parse("0196b0c0-0000-7000-8000-000000000001"),
@@ -487,6 +502,353 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             Assert.Null(page3.Links.Next); // No more data → terminates correctly
         }
 
+        /// <summary>
+        /// eventTypes=accepted → exactly 5 seeded accepted events.
+        /// Fits exactly one full page; the follow-up page is empty (no next link).
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_FilterByEventTypeAccepted_ReturnsAllAcceptedAcrossPages()
+        {
+            var allItems = await FetchAllPages("/accessmanagement/api/v1/enterprise/consentrequests/events?eventTypes=accepted");
+
+            Assert.Equal(SeededAccepted, allItems.Count);
+            Assert.All(allItems, item => Assert.Equal("accepted", item.EventType, StringComparer.OrdinalIgnoreCase));
+            ////Every accepted consent ID must be represented exactly once
+            Assert.Equal(_acceptedConsentIds.ToHashSet(), allItems.Select(i => i.ConsentRequestId).ToHashSet());
+        }
+
+        /// <summary>
+        /// eventTypes=rejected → exactly 5 seeded rejected events.
+        /// Fits exactly one full page; the follow-up page is empty (no next link).
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_FilterByEventTypeRejected_ReturnsAllRejectedAcrossPages()
+        {
+            var allItems = await FetchAllPages("/accessmanagement/api/v1/enterprise/consentrequests/events?eventTypes=rejected");
+
+            Assert.Equal(SeededRejected, allItems.Count);
+            Assert.All(allItems, item => Assert.Equal("rejected", item.EventType, StringComparer.OrdinalIgnoreCase));
+            Assert.Equal(_rejectedConsentIds.ToHashSet(), allItems.Select(i => i.ConsentRequestId).ToHashSet());
+        }
+
+        /// <summary>
+        /// eventTypes=revoked → exactly 3 seeded revoked events.
+        /// Fewer than one page, so no next link on the first (and only) response.
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_FilterByEventTypeRevoked_ReturnsAllRevokedInOnePage()
+        {
+            HttpClient client = GetAuthorizedReadClient();
+
+            string url = "/accessmanagement/api/v1/enterprise/consentrequests/events?eventTypes=revoked";
+            HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+            Assert.Equal(SeededRevoked, result.Items.Count());
+            Assert.Null(result.Links.Next); // 3 < pageSize=5 → no next link
+            Assert.All(result.Items, item => Assert.Equal("revoked", item.EventType, StringComparer.OrdinalIgnoreCase));
+            Assert.Equal(_revokedConsentIds.ToHashSet(), result.Items.Select(i => i.ConsentRequestId).ToHashSet());
+        }
+
+        /// <summary>
+        /// eventTypes=accepted&eventTypes=revoked → 5 accepted + 3 revoked = 8 events.
+        /// Spans two pages (5 + 3). Verifies correct counts and that no rejected events leak in.
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_FilterByAcceptedAndRevoked_Returns8EventsAcrossTwoPages()
+        {
+            const int expectedTotal = SeededAccepted + SeededRevoked; // 8
+            var allowedTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "accepted", "revoked" };
+
+            HttpClient client = GetAuthorizedReadClient();
+
+            // Page 1 – expect a full page since 8 > pageSize=5
+            string url = "/accessmanagement/api/v1/enterprise/consentrequests/events?eventTypes=accepted&eventTypes=revoked";
+            var response1 = await client.GetAsync(url, TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+            var page1 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await response1.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+            Assert.Equal(PageSize, page1.Items.Count());
+            Assert.NotNull(page1.Links.Next);
+            Assert.All(page1.Items, item => Assert.Contains(item.EventType, allowedTypes));
+
+            // Page 2 – expect remaining 3 items and no next link
+            var response2 = await client.GetAsync(page1.Links.Next, TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+            var page2 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await response2.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+            Assert.Equal(expectedTotal - PageSize, page2.Items.Count()); // 3
+            Assert.Null(page2.Links.Next);
+            Assert.All(page2.Items, item => Assert.Contains(item.EventType, allowedTypes));
+
+            // Aggregate assertions
+            var allItems = page1.Items.Concat(page2.Items).ToList();
+            Assert.Equal(expectedTotal, allItems.Count);
+            Assert.Equal(SeededAccepted, allItems.Count(i => i.EventType.Equals("accepted", StringComparison.OrdinalIgnoreCase)));
+            Assert.Equal(SeededRevoked, allItems.Count(i => i.EventType.Equals("revoked", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        /// <summary>
+        /// consentRequestId=&lt;revokedId&gt; → that consent was accepted then revoked,
+        /// so exactly 2 events are expected (accepted + revoked), both in one page.
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_FilterByConsentRequestId_RevokedConsent_ReturnsTwoEvents()
+        {
+            // _revokedConsentIds[0] was accepted first, then revoked → 2 non-created events
+            Guid targetId = _revokedConsentIds[0];
+
+            HttpClient client = GetAuthorizedReadClient();
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events?consentRequestId={targetId}";
+            var response = await client.GetAsync(url, TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+            Assert.Equal(2, result.Items.Count()); // accepted + revoked
+            Assert.Null(result.Links.Next);        // 2 < pageSize=5
+            Assert.All(result.Items, item => Assert.Equal(targetId, item.ConsentRequestId));
+
+            var eventTypes = result.Items.Select(i => i.EventType).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("accepted", eventTypes);
+            Assert.Contains("revoked", eventTypes);
+        }
+
+        /// <summary>
+        /// consentRequestId=&lt;acceptedOnlyId&gt; → consent was accepted but NOT revoked,
+        /// so exactly 1 event expected (accepted).
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_FilterByConsentRequestId_AcceptedOnlyConsent_ReturnsOneEvent()
+        {
+            // _acceptedConsentIds[3] was accepted but not revoked (only indexes 0-2 were revoked)
+            Guid targetId = _acceptedConsentIds[3];
+
+            HttpClient client = GetAuthorizedReadClient();
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events?consentRequestId={targetId}";
+            var response = await client.GetAsync(url, TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+            Assert.Equal(1, result.Items.Count());
+            Assert.Null(result.Links.Next);
+            Assert.Equal(targetId, result.Items.Single().ConsentRequestId);
+            Assert.Equal("accepted", result.Items.Single().EventType, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// consentRequestId=&lt;rejectedId&gt; → exactly 1 event (rejected).
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_FilterByConsentRequestId_RejectedConsent_ReturnsOneEvent()
+        {
+            Guid targetId = _rejectedConsentIds[0];
+
+            HttpClient client = GetAuthorizedReadClient();
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events?consentRequestId={targetId}";
+            var response = await client.GetAsync(url, TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+            Assert.Equal(1, result.Items.Count());
+            Assert.Null(result.Links.Next);
+            Assert.Equal(targetId, result.Items.Single().ConsentRequestId);
+            Assert.Equal("rejected", result.Items.Single().EventType, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// consentRequestId + eventTypes=revoked → for a revoked consent, only the revoked event is returned.
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_FilterByConsentRequestIdAndEventType_ReturnsOnlyMatchingEvent()
+        {
+            Guid targetId = _revokedConsentIds[0];
+
+            HttpClient client = GetAuthorizedReadClient();
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events?consentRequestId={targetId}&eventTypes=revoked";
+            var response = await client.GetAsync(url, TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+            Assert.Equal(1, result.Items.Count());
+            Assert.Null(result.Links.Next);
+            Assert.Equal(targetId, result.Items.Single().ConsentRequestId);
+            Assert.Equal("revoked", result.Items.Single().EventType, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// createdAfter=tomorrow → no events fall after a future timestamp, result is empty.
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_CreatedAfterFuture_ReturnsEmpty()
+        {
+            string futureTimestamp = Uri.EscapeDataString(DateTimeOffset.UtcNow.AddDays(1).ToString("O"));
+
+            HttpClient client = GetAuthorizedReadClient();
+            var response = await client.GetAsync(
+                $"/accessmanagement/api/v1/enterprise/consentrequests/events?createdAfter={futureTimestamp}",
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+            Assert.Empty(result.Items);
+            Assert.Null(result.Links.Next);
+        }
+
+        /// <summary>
+        /// createdAfter=yesterday → all 13 seeded events fall after that bound.
+        /// Verifies count across all pages and that ordering is ascending.
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_CreatedAfterYesterday_ReturnsAllEventsAcrossPages()
+        {
+            string pastTimestamp = Uri.EscapeDataString(DateTimeOffset.UtcNow.AddDays(-1).ToString("O"));
+            var allItems = await FetchAllPages(
+                $"/accessmanagement/api/v1/enterprise/consentrequests/events?createdAfter={pastTimestamp}");
+
+            Assert.Equal(SeededTotal, allItems.Count);
+
+            // All events must be after the lower bound
+            DateTimeOffset lowerBound = DateTimeOffset.UtcNow.AddDays(-1);
+            Assert.All(allItems, item => Assert.True(item.ChangedDate >= lowerBound));
+
+            // Ascending order must be preserved across pages
+            for (int i = 1; i < allItems.Count; i++)
+            {
+                Assert.True(allItems[i - 1].ChangedDate <= allItems[i].ChangedDate,
+                    $"Order violation at index {i}");
+            }
+        }
+
+        /// <summary>
+        /// createdBefore=yesterday → no events fall before a past lower bound, result is empty.
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_CreatedBeforeYesterday_ReturnsEmpty()
+        {
+            string pastTimestamp = Uri.EscapeDataString(DateTimeOffset.UtcNow.AddDays(-1).ToString("O"));
+
+            HttpClient client = GetAuthorizedReadClient();
+            var response = await client.GetAsync(
+                $"/accessmanagement/api/v1/enterprise/consentrequests/events?createdBefore={pastTimestamp}",
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+            Assert.Empty(result.Items);
+            Assert.Null(result.Links.Next);
+        }
+
+        /// <summary>
+        /// createdBefore=tomorrow → all 13 seeded events fall before that upper bound.
+        /// Verifies count across all pages.
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_CreatedBeforeTomorrow_ReturnsAllEventsAcrossPages()
+        {
+            string futureTimestamp = Uri.EscapeDataString(DateTimeOffset.UtcNow.AddDays(1).ToString("O"));
+            var allItems = await FetchAllPages(
+                $"/accessmanagement/api/v1/enterprise/consentrequests/events?createdBefore={futureTimestamp}");
+
+            Assert.Equal(SeededTotal, allItems.Count);
+        }
+
+        /// <summary>
+        /// createdAfter=yesterday + createdBefore=tomorrow → time window contains all 13 events.
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_CreatedAfterAndBeforeCombined_ReturnsAllEventsWithinWindow()
+        {
+            string after = Uri.EscapeDataString(DateTimeOffset.UtcNow.AddDays(-1).ToString("O"));
+            string before = Uri.EscapeDataString(DateTimeOffset.UtcNow.AddDays(1).ToString("O"));
+
+            var allItems = await FetchAllPages(
+                $"/accessmanagement/api/v1/enterprise/consentrequests/events?createdAfter={after}&createdBefore={before}");
+
+            Assert.Equal(SeededTotal, allItems.Count);
+        }
+
+        /// <summary>
+        /// An invalid/garbage continuationToken is silently ignored and the response
+        /// equals the first page of an unfiltered request.
+        /// </summary>
+        [Fact]
+        public async Task GetConsentStatusChanges_InvalidContinuationToken_StartsFromBeginning()
+        {
+            string badToken = Uri.EscapeDataString("not!!a$$valid##base64");
+
+            HttpClient client = GetAuthorizedReadClient();
+
+            var responseWithBad = await client.GetAsync(
+                $"/accessmanagement/api/v1/enterprise/consentrequests/events?continuationToken={badToken}",
+                TestContext.Current.CancellationToken);
+            var responseClean = await client.GetAsync(
+                "/accessmanagement/api/v1/enterprise/consentrequests/events",
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, responseWithBad.StatusCode);
+
+            var resultWithBad = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await responseWithBad.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+            var resultClean = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                await responseClean.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+            // Invalid token must not skip any data — same first page as the clean request
+            Assert.Equal(PageSize, resultWithBad.Items.Count());
+            Assert.Equal(
+                resultClean.Items.Select(i => i.ConsentRequestId),
+                resultWithBad.Items.Select(i => i.ConsentRequestId));
+        }
+
+        /// <summary>
+        /// Follows all next-page links for a given start URL and returns every item collected.
+        /// Uses the read-scoped Maskinporten token for 810419512.
+        /// </summary>
+        private async Task<List<ConsentStatusChangeDto>> FetchAllPages(string startUrl)
+        {
+            HttpClient client = GetAuthorizedReadClient();
+            var all = new List<ConsentStatusChangeDto>();
+            string? nextUrl = startUrl;
+
+            while (nextUrl != null)
+            {
+                var response = await client.GetAsync(nextUrl, TestContext.Current.CancellationToken);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var page = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                    await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+
+                all.AddRange(page.Items);
+                nextUrl = page.Links.Next;
+            }
+
+            return all;
+        }
+
+        private HttpClient GetAuthorizedReadClient()
+        {
+            HttpClient client = GetTestClient();
+            string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            return client;
+        }
+
         private async Task CreateAndUpdateConsentsForGet(int numberOfConsents)
         {
             var createdConsentIds = new List<Guid>();
@@ -561,6 +923,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
                 acceptClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 HttpResponseMessage acceptResponse = await acceptClient.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{consentId}/accept/", httpContent);
                 acceptResponse.EnsureSuccessStatusCode();
+                _acceptedConsentIds.Add(consentId);
                 if (acceptedConsentIdsToBeRevoked.Count < 3)
                 {
                     acceptedConsentIdsToBeRevoked.Add(consentId);
@@ -576,6 +939,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
                 rejectClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 HttpResponseMessage rejectResponse = await rejectClient.PostAsync($"accessmanagement/api/v1/bff/consentrequests/{consentId}/reject/", null);
                 rejectResponse.EnsureSuccessStatusCode();
+                _rejectedConsentIds.Add(consentId);
             }
 
             // Optionally revoke some
@@ -587,6 +951,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
                 revokeClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 HttpResponseMessage revokeResponse = await revokeClient.PostAsync($"accessmanagement/api/v1/bff/consents/{consentId}/revoke/", null);
                 revokeResponse.EnsureSuccessStatusCode();
+                _revokedConsentIds.Add(consentId);
             }
         }
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
@@ -230,7 +230,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         {
             HttpClient client = GetTestClient();
 
-            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events";
             HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -248,7 +248,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.wite");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events";
             HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -258,7 +258,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         /// Test: Getting consent status changes returns OK with paginated data ordered newest first.
         /// </summary>
         [Fact]
-        public async Task GetConsentStatusChanges_ValidRequest_ReturnsOkWithDataOrderedNewestFirst()
+        public async Task GetConsentStatusChanges_ValidRequest_ReturnsOkWithDataOrderedOldestFirst()
         {
             HttpClient client = GetTestClient();
             Guid partyUuid = Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181");
@@ -266,7 +266,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events";
             HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
             string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
@@ -298,7 +298,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             // Fetch first page (pageSize=5)
             string readToken = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", readToken);
-            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events";
             HttpResponseMessage responsePage1 = await client.GetAsync(url, TestContext.Current.CancellationToken);
             string responseContent1 = await responsePage1.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
@@ -321,16 +321,18 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
                 Assert.Equal(numberOfConsents - resultPage1.Items.Count(), resultPage2.Items.Count());
                 var page2ConsentIds = resultPage2.Items.Select(i => i.ConsentRequestId).ToHashSet();
 
-                // No consentrequest should appear on both pages
-                Assert.Empty(page1ConsentIds.Intersect(page2ConsentIds));
+                // Page 3 - empty, terminates pagination
+                var response3 = await client.GetAsync(resultPage2.Links.Next, TestContext.Current.CancellationToken);
+                var page3 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
+                    await response3.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
+                Assert.Equal(3, page3.Items.Count());
+                Assert.Null(page3.Links.Next); // No more data → terminates correctly
 
-                // All returned events should be the latest for their consentrequest
-                var allItems = resultPage1.Items.Concat(resultPage2.Items).ToList();
-                Assert.Equal(numberOfConsents, allItems.Count);
+                var allItems = resultPage1.Items.Concat(resultPage2.Items).Concat(page3.Items).ToList();
 
                 Assert.Equal(revoked, allItems.FindAll(i => i.EventType.Equals("revoked", StringComparison.OrdinalIgnoreCase)).Count());
                 Assert.Equal(rejected, allItems.FindAll(i => i.EventType.Equals("rejected", StringComparison.OrdinalIgnoreCase)).Count());
-                Assert.Equal(accepted - revoked, allItems.FindAll(i => i.EventType.Equals("accepted", StringComparison.OrdinalIgnoreCase)).Count());
+                Assert.Equal(accepted, allItems.FindAll(i => i.EventType.Equals("accepted", StringComparison.OrdinalIgnoreCase)).Count());
             }
         }
 
@@ -345,7 +347,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", readToken);
 
             // Fetch first page
-            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events";
             HttpResponseMessage responsePage1 = await client.GetAsync(url, TestContext.Current.CancellationToken);
             string responseContent1 = await responsePage1.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, responsePage1.StatusCode);
@@ -371,9 +373,9 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
                 var prev = allItems[i - 1];
                 var curr = allItems[i];
                 int dateCompare = prev.ChangedDate.CompareTo(curr.ChangedDate);
-                if (dateCompare > 0)
+                if (dateCompare < 0)
                 {
-                    // OK, previous is newer
+                    // OK, previous is older
                     continue;
                 }
                 else
@@ -401,8 +403,8 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Pass a different pageSize than what's configured (config = 5)
-            string urlWithParam = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?pageSize=100";
-            string urlWithoutParam = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
+            string urlWithParam = $"/accessmanagement/api/v1/enterprise/consentrequests/events?pageSize=100";
+            string urlWithoutParam = $"/accessmanagement/api/v1/enterprise/consentrequests/events";
 
             var responseWith = await client.GetAsync(urlWithParam, TestContext.Current.CancellationToken);
             var responseWithout = await client.GetAsync(urlWithoutParam, TestContext.Current.CancellationToken);
@@ -412,7 +414,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
 
             // Both should return config-driven page size (5), not 100
             Assert.Equal(resultWithout.Items.Count(), resultWith.Items.Count());
-            Assert.Equal(5, resultWith.Items.Count()); // Matches LatestChangesPageSize from PostConfigure
+            Assert.Equal(5, resultWith.Items.Count()); // Matches EventsPageSize from PostConfigure
         }
 
         [Fact]
@@ -423,14 +425,14 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events";
             HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
                 await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
 
-            // LatestChangesPageSize is set to 5 in PostConfigure — assert exactly that
+            // EventsPageSize is set to 5 in PostConfigure — assert exactly that
             Assert.Equal(5, result.Items.Count());
         }
 
@@ -442,7 +444,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string token = PrincipalUtil.GetMaskinportenToken("810419512", "altinn:consentrequests.read");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/latestchanges";
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events";
             HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
             var result = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
@@ -464,7 +466,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             // Page 1
-            var response1 = await client.GetAsync("/accessmanagement/api/v1/enterprise/consentrequests/latestchanges", TestContext.Current.CancellationToken);
+            var response1 = await client.GetAsync("/accessmanagement/api/v1/enterprise/consentrequests/events", TestContext.Current.CancellationToken);
             var page1 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
                 await response1.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
             Assert.Equal(5, page1.Items.Count());
@@ -481,7 +483,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             var response3 = await client.GetAsync(page2.Links.Next, TestContext.Current.CancellationToken);
             var page3 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
                 await response3.Content.ReadAsStringAsync(TestContext.Current.CancellationToken), _jsonOptions);
-            Assert.Empty(page3.Items);
+            Assert.Equal(3, page3.Items.Count());
             Assert.Null(page3.Links.Next); // No more data → terminates correctly
         }
 
@@ -596,9 +598,9 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             List<ConsentStatusChangeDto> items = result.Items.ToList();
             Assert.Equal(5, items.Count);
 
-            // Verify ordering (newest first)
-            Assert.True(items[0].ChangedDate > items[1].ChangedDate);
-            Assert.True(items[1].ChangedDate > items[2].ChangedDate);
+            // Verify ordering (oldest first)
+            Assert.True(items[0].ChangedDate < items[1].ChangedDate);
+            Assert.True(items[1].ChangedDate < items[2].ChangedDate);
         }
 
         private readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
@@ -503,13 +503,13 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         }
 
         /// <summary>
-        /// eventTypes=accepted → exactly 5 seeded accepted events.
+        /// eventType=accepted → exactly 5 seeded accepted events.
         /// Fits exactly one full page; the follow-up page is empty (no next link).
         /// </summary>
         [Fact]
         public async Task GetConsentStatusChanges_FilterByEventTypeAccepted_ReturnsAllAcceptedAcrossPages()
         {
-            var allItems = await FetchAllPages("/accessmanagement/api/v1/enterprise/consentrequests/events?eventTypes=accepted");
+            var allItems = await FetchAllPages("/accessmanagement/api/v1/enterprise/consentrequests/events?eventType=accepted");
 
             Assert.Equal(SeededAccepted, allItems.Count);
             Assert.All(allItems, item => Assert.Equal("accepted", item.EventType, StringComparer.OrdinalIgnoreCase));
@@ -518,13 +518,13 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         }
 
         /// <summary>
-        /// eventTypes=rejected → exactly 5 seeded rejected events.
+        /// eventType=rejected → exactly 5 seeded rejected events.
         /// Fits exactly one full page; the follow-up page is empty (no next link).
         /// </summary>
         [Fact]
         public async Task GetConsentStatusChanges_FilterByEventTypeRejected_ReturnsAllRejectedAcrossPages()
         {
-            var allItems = await FetchAllPages("/accessmanagement/api/v1/enterprise/consentrequests/events?eventTypes=rejected");
+            var allItems = await FetchAllPages("/accessmanagement/api/v1/enterprise/consentrequests/events?eventType=rejected");
 
             Assert.Equal(SeededRejected, allItems.Count);
             Assert.All(allItems, item => Assert.Equal("rejected", item.EventType, StringComparer.OrdinalIgnoreCase));
@@ -532,7 +532,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         }
 
         /// <summary>
-        /// eventTypes=revoked → exactly 3 seeded revoked events.
+        /// eventType=revoked → exactly 3 seeded revoked events.
         /// Fewer than one page, so no next link on the first (and only) response.
         /// </summary>
         [Fact]
@@ -540,7 +540,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         {
             HttpClient client = GetAuthorizedReadClient();
 
-            string url = "/accessmanagement/api/v1/enterprise/consentrequests/events?eventTypes=revoked";
+            string url = "/accessmanagement/api/v1/enterprise/consentrequests/events?eventType=revoked";
             HttpResponseMessage response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -554,7 +554,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         }
 
         /// <summary>
-        /// eventTypes=accepted&eventTypes=revoked → 5 accepted + 3 revoked = 8 events.
+        /// eventType=accepted&eventType=revoked → 5 accepted + 3 revoked = 8 events.
         /// Spans two pages (5 + 3). Verifies correct counts and that no rejected events leak in.
         /// </summary>
         [Fact]
@@ -566,7 +566,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             HttpClient client = GetAuthorizedReadClient();
 
             // Page 1 – expect a full page since 8 > pageSize=5
-            string url = "/accessmanagement/api/v1/enterprise/consentrequests/events?eventTypes=accepted&eventTypes=revoked";
+            string url = "/accessmanagement/api/v1/enterprise/consentrequests/events?eventType=accepted&eventType=revoked";
             var response1 = await client.GetAsync(url, TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
             var page1 = JsonSerializer.Deserialize<PaginatedResult<ConsentStatusChangeDto>>(
@@ -667,7 +667,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
         }
 
         /// <summary>
-        /// consentRequestId + eventTypes=revoked → for a revoked consent, only the revoked event is returned.
+        /// consentRequestId + eventType=revoked → for a revoked consent, only the revoked event is returned.
         /// </summary>
         [Fact]
         public async Task GetConsentStatusChanges_FilterByConsentRequestIdAndEventType_ReturnsOnlyMatchingEvent()
@@ -675,7 +675,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             Guid targetId = _revokedConsentIds[0];
 
             HttpClient client = GetAuthorizedReadClient();
-            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events?consentRequestId={targetId}&eventTypes=revoked";
+            string url = $"/accessmanagement/api/v1/enterprise/consentrequests/events?consentRequestId={targetId}&eventType=revoked";
             var response = await client.GetAsync(url, TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -794,13 +794,14 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             HttpResponseMessage response = await client.GetAsync(
-                "/accessmanagement/api/v1/enterprise/consentrequests/events?eventTypes=invalidtype",
+                "/accessmanagement/api/v1/enterprise/consentrequests/events?eventType=invalidtype",
                 TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(content, _jsonOptions);
             Assert.Equal(ValidationErrors.InvalidEventType.ErrorCode, problemDetails.Errors.ToList()[0].ErrorCode);
+            Assert.Contains("$QUERY/eventType", problemDetails.Errors.ToList()[0].Paths);
         }
 
         [Fact]
@@ -823,6 +824,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(content, _jsonOptions);
             Assert.Equal(ValidationErrors.InvalidDateRange.ErrorCode, problemDetails.Errors.ToList()[0].ErrorCode);
+            Assert.Contains("$QUERY/createdAfter", problemDetails.Errors.ToList()[0].Paths);
         }
 
         [Fact]
@@ -844,6 +846,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(content, _jsonOptions);
             Assert.Equal(ValidationErrors.InvalidDateRange.ErrorCode, problemDetails.Errors.ToList()[0].ErrorCode);
+            Assert.Contains("$QUERY/createdAfter", problemDetails.Errors.ToList()[0].Paths);
         }
 
         [Fact]
@@ -863,6 +866,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(content, _jsonOptions);
             Assert.Equal(ValidationErrors.InvalidContinuationToken.ErrorCode, problemDetails.Errors.ToList()[0].ErrorCode);
+            Assert.Contains("$QUERY/continuationToken", problemDetails.Errors.ToList()[0].Paths);
         }
 
         [Fact]
@@ -885,6 +889,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
             string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             AltinnValidationProblemDetails problemDetails = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(content, _jsonOptions);
             Assert.Equal(ValidationErrors.InvalidContinuationToken.ErrorCode, problemDetails.Errors.ToList()[0].ErrorCode);
+            Assert.Contains("$QUERY/continuationToken", problemDetails.Errors.ToList()[0].Paths);
         }
 
         /// <summary>

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConsentRepositoryMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConsentRepositoryMock.cs
@@ -70,7 +70,7 @@ namespace AccessMgmt.Tests.Mocks
             throw new NotImplementedException();
         }
 
-        public Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery query, int pageSize, int safetyLagSeconds, CancellationToken cancellationToken)
+        public Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery query, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken)
         {
             // Return test data based on partyUuid
             // Empty party UUID returns empty list

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConsentRepositoryMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConsentRepositoryMock.cs
@@ -107,11 +107,11 @@ namespace AccessMgmt.Tests.Mocks
 
             // Apply continuation token filtering (items older than the cursor)
             IEnumerable<ConsentStatusChange> filtered = allChanges;
-            if (!string.IsNullOrEmpty(query.ContinuationToken))
+            if (query.ContinueFrom.HasValue)
             {
                 try
                 {
-                    byte[] data = Convert.FromBase64String(query.ContinuationToken);
+                    byte[] data = Convert.FromBase64String(query.ContinueFrom.Value.ToString());
                     long ticks = BitConverter.ToInt64(data, 0);
                     DateTimeOffset cursorTimestamp = new DateTimeOffset(ticks, TimeSpan.Zero);
                     filtered = allChanges.Where(c => c.ChangedDate < cursorTimestamp);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConsentRepositoryMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConsentRepositoryMock.cs
@@ -70,7 +70,7 @@ namespace AccessMgmt.Tests.Mocks
             throw new NotImplementedException();
         }
 
-        public Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery query, int safetyLagSeconds, int pageSize, CancellationToken cancellationToken)
+        public Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery query, int pageSize, CancellationToken cancellationToken)
         {
             // Return test data based on partyUuid
             // Empty party UUID returns empty list

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConsentRepositoryMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConsentRepositoryMock.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.Consent;
 using Altinn.AccessManagement.Core.Repositories.Interfaces;
 using Altinn.Authorization.ProblemDetails;
@@ -69,7 +70,7 @@ namespace AccessMgmt.Tests.Mocks
             throw new NotImplementedException();
         }
 
-        public Task<Result<List<ConsentStatusChange>>> GetConsentStatusChangesForParty(Guid partyUuid, string continuationToken, int pageSize, CancellationToken cancellationToken)
+        public Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery query, int pageSize, int safetyLagSeconds, CancellationToken cancellationToken)
         {
             // Return test data based on partyUuid
             // Empty party UUID returns empty list
@@ -106,11 +107,11 @@ namespace AccessMgmt.Tests.Mocks
 
             // Apply continuation token filtering (items older than the cursor)
             IEnumerable<ConsentStatusChange> filtered = allChanges;
-            if (!string.IsNullOrEmpty(continuationToken))
+            if (!string.IsNullOrEmpty(query.ContinuationToken))
             {
                 try
                 {
-                    byte[] data = Convert.FromBase64String(continuationToken);
+                    byte[] data = Convert.FromBase64String(query.ContinuationToken);
                     long ticks = BitConverter.ToInt64(data, 0);
                     DateTimeOffset cursorTimestamp = new DateTimeOffset(ticks, TimeSpan.Zero);
                     filtered = allChanges.Where(c => c.ChangedDate < cursorTimestamp);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
@@ -387,13 +387,13 @@ public class ConsentServiceTests
         var query = new ConsentEventsQuery(null, null, null, null, null);
 
         _consentRepositoryMock
-            .Setup(r => r.GetConsentEventsForParty(partyUuid, query, 5, 100, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetConsentEventsForParty(partyUuid, query, 100, It.IsAny<CancellationToken>()))
             .ReturnsAsync(repoResult);
 
         var service = CreateService();
 
         // Act
-        var result = await service.GetConsentEventsForParty(receiver, query, safetyLagSeconds: 5, pageSize: 100, CancellationToken.None);
+        var result = await service.GetConsentEventsForParty(receiver, query, pageSize: 100, CancellationToken.None);
 
         // Assert
         result.IsProblem.Should().BeFalse();
@@ -402,7 +402,7 @@ public class ConsentServiceTests
         // The repo must be called with the *resolved* internal partyUuid, not
         // the external identity. Verify with the exact partyUuid we expect.
         _consentRepositoryMock.Verify(
-            r => r.GetConsentEventsForParty(partyUuid, query, 5, 100, It.IsAny<CancellationToken>()),
+            r => r.GetConsentEventsForParty(partyUuid, query, 100, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -428,14 +428,14 @@ public class ConsentServiceTests
             });
 
         _consentRepositoryMock
-            .Setup(r => r.GetConsentEventsForParty(resolvedPartyUuid, It.IsAny<ConsentEventsQuery>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetConsentEventsForParty(resolvedPartyUuid, It.IsAny<ConsentEventsQuery>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ConsentStatusChange>());
 
         var service = CreateService();
         var query = new ConsentEventsQuery(null, null, null, null, new Guid("cd12b899-0795-4a3c-a65f-f8de792ff382"));
 
         // Act
-        var result = await service.GetConsentEventsForParty(receiver, query, safetyLagSeconds: 5, pageSize: 25, CancellationToken.None);
+        var result = await service.GetConsentEventsForParty(receiver, query, pageSize: 25, CancellationToken.None);
 
         // Assert
         result.IsProblem.Should().BeFalse();
@@ -446,7 +446,7 @@ public class ConsentServiceTests
             "the org number must be resolved through the AM party service before the repository is queried");
 
         _consentRepositoryMock.Verify(
-            r => r.GetConsentEventsForParty(resolvedPartyUuid, query, 5, 25, It.IsAny<CancellationToken>()),
+            r => r.GetConsentEventsForParty(resolvedPartyUuid, query, 25, It.IsAny<CancellationToken>()),
             Times.Once,
             "the repository must receive the resolved partyUuid plus the caller's pagination args verbatim");
     }
@@ -463,14 +463,14 @@ public class ConsentServiceTests
         var receiver = ConsentPartyUrn.PartyUuid.Create(partyUuid);
 
         _consentRepositoryMock
-            .Setup(r => r.GetConsentEventsForParty(partyUuid, It.IsAny<ConsentEventsQuery>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetConsentEventsForParty(partyUuid, It.IsAny<ConsentEventsQuery>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Problems.ConsentNotFound);
 
         var service = CreateService();
         var query = new ConsentEventsQuery(null, null, null, null, null);
 
         // Act
-        var result = await service.GetConsentEventsForParty(receiver, query, 5, 100, CancellationToken.None);
+        var result = await service.GetConsentEventsForParty(receiver, query, pageSize: 100, CancellationToken.None);
 
         // Assert — `Result<T>.Problem` exposes a `ProblemInstance` materialised
         // from the descriptor, not the descriptor itself, so `BeSameAs` would

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Metrics;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.Core.Configuration;
 using Altinn.AccessManagement.Core.Errors;
+using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.Consent;
 using Altinn.AccessManagement.Core.Models.Party;
 using Altinn.AccessManagement.Core.Models.ResourceRegistry;
@@ -383,14 +384,16 @@ public class ConsentServiceTests
             },
         };
 
+        var query = new ConsentEventsQuery(null, null, null, null, null);
+
         _consentRepositoryMock
-            .Setup(r => r.GetConsentStatusChangesForParty(partyUuid, null, 100, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetConsentEventsForParty(partyUuid, query, 5, 100, It.IsAny<CancellationToken>()))
             .ReturnsAsync(repoResult);
 
         var service = CreateService();
 
         // Act
-        var result = await service.GetConsentStatusChangesForParty(receiver, continuationToken: null, pageSize: 100, CancellationToken.None);
+        var result = await service.GetConsentEventsForParty(receiver, query, safetyLagSeconds: 5, pageSize: 100, CancellationToken.None);
 
         // Assert
         result.IsProblem.Should().BeFalse();
@@ -399,7 +402,7 @@ public class ConsentServiceTests
         // The repo must be called with the *resolved* internal partyUuid, not
         // the external identity. Verify with the exact partyUuid we expect.
         _consentRepositoryMock.Verify(
-            r => r.GetConsentStatusChangesForParty(partyUuid, null, 100, It.IsAny<CancellationToken>()),
+            r => r.GetConsentEventsForParty(partyUuid, query, 5, 100, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -425,13 +428,14 @@ public class ConsentServiceTests
             });
 
         _consentRepositoryMock
-            .Setup(r => r.GetConsentStatusChangesForParty(resolvedPartyUuid, It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetConsentEventsForParty(resolvedPartyUuid, It.IsAny<ConsentEventsQuery>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<ConsentStatusChange>());
 
         var service = CreateService();
+        var query = new ConsentEventsQuery(null, null, null, null, "abc");
 
         // Act
-        var result = await service.GetConsentStatusChangesForParty(receiver, continuationToken: "abc", pageSize: 25, CancellationToken.None);
+        var result = await service.GetConsentEventsForParty(receiver, query, safetyLagSeconds: 5, pageSize: 25, CancellationToken.None);
 
         // Assert
         result.IsProblem.Should().BeFalse();
@@ -442,7 +446,7 @@ public class ConsentServiceTests
             "the org number must be resolved through the AM party service before the repository is queried");
 
         _consentRepositoryMock.Verify(
-            r => r.GetConsentStatusChangesForParty(resolvedPartyUuid, "abc", 25, It.IsAny<CancellationToken>()),
+            r => r.GetConsentEventsForParty(resolvedPartyUuid, query, 5, 25, It.IsAny<CancellationToken>()),
             Times.Once,
             "the repository must receive the resolved partyUuid plus the caller's pagination args verbatim");
     }
@@ -459,13 +463,14 @@ public class ConsentServiceTests
         var receiver = ConsentPartyUrn.PartyUuid.Create(partyUuid);
 
         _consentRepositoryMock
-            .Setup(r => r.GetConsentStatusChangesForParty(partyUuid, It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetConsentEventsForParty(partyUuid, It.IsAny<ConsentEventsQuery>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Problems.ConsentNotFound);
 
         var service = CreateService();
+        var query = new ConsentEventsQuery(null, null, null, null, null);
 
         // Act
-        var result = await service.GetConsentStatusChangesForParty(receiver, null, 100, CancellationToken.None);
+        var result = await service.GetConsentEventsForParty(receiver, query, 5, 100, CancellationToken.None);
 
         // Assert — `Result<T>.Problem` exposes a `ProblemInstance` materialised
         // from the descriptor, not the descriptor itself, so `BeSameAs` would

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
@@ -432,7 +432,7 @@ public class ConsentServiceTests
             .ReturnsAsync(new List<ConsentStatusChange>());
 
         var service = CreateService();
-        var query = new ConsentEventsQuery(null, null, null, null, "abc");
+        var query = new ConsentEventsQuery(null, null, null, null, new Guid("cd12b899-0795-4a3c-a65f-f8de792ff382"));
 
         // Act
         var result = await service.GetConsentEventsForParty(receiver, query, safetyLagSeconds: 5, pageSize: 25, CancellationToken.None);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/appsettings.test.json
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/appsettings.test.json
@@ -36,6 +36,7 @@
     "UseNewQueryRepo": true
   },
   "Consent": {
-    "LatestChangesPageSize": 5
+    "EventsPageSize": 5,
+    "EventsSafetyLagSeconds": 0
   }
 }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/appsettings.test.json
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/appsettings.test.json
@@ -21,7 +21,8 @@
     "ApplicationCollection": "applications"
   },
   "PostgreSQLSettings": {
-    "EnableDBConnection": "false"
+    "EnableDBConnection": "false",
+    "ConsentEventsSafetyLagSeconds": 0
   },
   "GeneralSettings": {
     "BridgeApiEndpoint": "http://localhost:88/sblbridge/authorization/api/",
@@ -36,7 +37,6 @@
     "UseNewQueryRepo": true
   },
   "Consent": {
-    "EventsPageSize": 5,
-    "EventsSafetyLagSeconds": 0
+    "EventsPageSize": 5
   }
 }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/appsettings.test.json
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/appsettings.test.json
@@ -22,7 +22,7 @@
   },
   "PostgreSQLSettings": {
     "EnableDBConnection": "false",
-    "ConsentEventsSafetyLagSeconds": 0
+    "ConsentEventsSafetyLag": 0
   },
   "GeneralSettings": {
     "BridgeApiEndpoint": "http://localhost:88/sblbridge/authorization/api/",

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/ValidationErrors.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/ValidationErrors.cs
@@ -1,12 +1,14 @@
 ﻿#nullable enable
 
 using Altinn.Authorization.ProblemDetails;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Altinn.AccessManagement.Core.Errors;
 
 /// <summary>
 /// Validation errors for the Access Management.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public static class ValidationErrors
 {
     private static readonly ValidationErrorDescriptorFactory _factory

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/ValidationErrors.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/ValidationErrors.cs
@@ -255,8 +255,26 @@ public static class ValidationErrors
         = _factory.Create(49, $"One or more resources is not delegable.");
 
     /// <summary>
-    /// Invalid page size for consent status changes. The page size must be between 1 and 1000
+    /// Invalid page size for consent events. The page size must be between 1 and 1000
     /// </summary>
-    public static ValidationErrorDescriptor InvalidPageSizeForConsentStatusChanges { get; }
+    public static ValidationErrorDescriptor InvalidPageSizeForConsentEvents { get; }
     = _factory.Create(50, $"Page size must be between 1 and 1000.");
+
+    /// <summary>
+    /// createdAfter must be before createdBefore when both are specified.
+    /// </summary>
+    public static ValidationErrorDescriptor InvalidDateRange { get; }
+    = _factory.Create(51, $"'createdAfter' must be earlier than 'createdBefore'.");
+
+    /// <summary>
+    /// One or more of the provided event types are not valid.
+    /// </summary>
+    public static ValidationErrorDescriptor InvalidEventType { get; }
+    = _factory.Create(52, $"One or more event types are invalid. Valid values are: rejected, accepted, revoked, deleted, used.");
+
+    /// <summary>
+    /// The continuation token is not valid.
+    /// </summary>
+    public static ValidationErrorDescriptor InvalidContinuationToken { get; }
+    = _factory.Create(53, $"The continuation token is invalid.");
 }


### PR DESCRIPTION
1. Change the api route from "latestchanges" to "events"
2. update the query to return all events, sorted by oldest first
3. Return events created before 5 minutes
4. Filter by consentrequestid, event type, createdbefore, createdafter

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
