### PR TITLE
feat: add include params for access packages, resources, instances on enduser GET /connections

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ConnectionsController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ConnectionsController.cs
@@ -63,6 +63,9 @@ public class ConnectionsController(
         [FromQuery, FromHeader] PagingInput paging,
         [FromQuery] bool includeClientDelegations = true,
         [FromQuery] bool includeAgentConnections = true,
+        [FromQuery] bool includeAccessPackages = false,
+        [FromQuery] bool includeResources = false,
+        [FromQuery] bool includeInstances = false,
         CancellationToken cancellationToken = default)
     {
         var validationErrors = ValidationComposer.Validate(ConnectionValidation.ValidateReadConnection(party.ToString(), from?.ToString(), to?.ToString()));
@@ -77,6 +80,9 @@ public class ConnectionsController(
             to,
             includeClientDelegations,
             includeAgentConnections,
+            includeAccessPackages,
+            includeResources,
+            includeInstances,
             ConfigureConnections,
             cancellationToken
         );
@@ -118,8 +124,8 @@ public class ConnectionsController(
             null,
             includeClientDelegations: true,
             includeAgentConnections: true,
-            ConfigureConnections,
-            cancellationToken
+            configureConnections: ConfigureConnections,
+            cancellationToken: cancellationToken
         );
 
         if (result.IsProblem)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
@@ -55,7 +55,7 @@ public partial class ConnectionService(
     ISingleRightsService singleRightsService,
     IFeatureManager featureManager) : IConnectionService
 {
-    public async Task<Result<IEnumerable<ConnectionDto>>> Get(Guid party, Guid? fromId, Guid? toId, bool includeClientDelegations = true, bool includeAgentConnections = true, Action<ConnectionOptions> configureConnections = null, CancellationToken cancellationToken = default)
+    public async Task<Result<IEnumerable<ConnectionDto>>> Get(Guid party, Guid? fromId, Guid? toId, bool includeClientDelegations = true, bool includeAgentConnections = true, bool includeAccessPackages = false, bool includeResources = false, bool includeInstances = false, Action<ConnectionOptions> configureConnections = null, CancellationToken cancellationToken = default)
     {
         var options = new ConnectionOptions(configureConnections);
         var (from, to) = await GetFromAndToEntities(fromId, toId, cancellationToken);
@@ -84,8 +84,9 @@ public partial class ConnectionService(
                 IncludeKeyRole = true,
                 IncludeMainUnitConnections = true,
                 IncludeDelegation = includeClientDelegations,
-                IncludePackages = false,
-                IncludeResources = false,
+                IncludePackages = includeAccessPackages,
+                IncludeResources = includeResources,
+                IncludeInstances = includeInstances,
                 EnrichPackageResources = false,
                 ExcludeDeleted = false,
                 ExcludeRoleIds = includeAgentConnections ? null : [RoleConstants.Agent.Id],

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IConnectionService.cs
@@ -16,7 +16,7 @@ public interface IConnectionService
     /// <summary>
     /// Get Connections
     /// </summary>
-    Task<Result<IEnumerable<ConnectionDto>>> Get(Guid party, Guid? fromId, Guid? toId, bool includeClientDelegations = true, bool includeAgentConnections = true, Action<ConnectionOptions> configureConnections = null, CancellationToken cancellationToken = default);
+    Task<Result<IEnumerable<ConnectionDto>>> Get(Guid party, Guid? fromId, Guid? toId, bool includeClientDelegations = true, bool includeAgentConnections = true, bool includeAccessPackages = false, bool includeResources = false, bool includeInstances = false, Action<ConnectionOptions> configureConnections = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Creates a role assignment between two entities.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperConnectionQuery.cs
@@ -34,6 +34,7 @@ public partial class DtoMapper : IDtoMapper
                 Roles = [.. c.Where(c => c.AssignmentId.HasValue).Select(c => ConvertCompactRole(c.Role)).Where(ro => ro is not null).DistinctBy(t => t.Id)],
                 Resources = [.. c.SelectMany(c => c.Resources).Select(r => Convert(r)).Where(re => re is not null).DistinctBy(t => t.Id)],
                 Packages = [.. c.SelectMany(c => c.Packages).Select(p => Convert(p)).Where(pa => pa is not null).DistinctBy(t => t.Id)],
+                Instances = [.. c.SelectMany(c => c.Instances).Select(i => Convert(i)).Where(i => i is not null).DistinctBy(t => t.InstanceId)],
                 Connections = ConvertSubConnectionsToOthers(subconnections),
             };
         });
@@ -67,6 +68,7 @@ public partial class DtoMapper : IDtoMapper
                 Roles = [.. c.Where(c => c.AssignmentId.HasValue).Select(c => ConvertCompactRole(c.Role)).Where(ro => ro is not null).DistinctBy(t => t.Id)],
                 Resources = [.. c.SelectMany(c => c.Resources).Select(r => Convert(r)).Where(re => re is not null).DistinctBy(t => t.Id)],
                 Packages = [.. c.SelectMany(c => c.Packages).Select(p => Convert(p)).Where(pa => pa is not null).DistinctBy(t => t.Id)],
+                Instances = [.. c.SelectMany(c => c.Instances).Select(i => Convert(i)).Where(i => i is not null).DistinctBy(t => t.InstanceId)],
                 Connections = ConvertSubConnectionsFromOthers(subconnections),
             };
         });
@@ -161,6 +163,13 @@ public partial class DtoMapper : IDtoMapper
                     .Where(re => re is not null)
                     .DistinctBy(t => t.Id)
                     .ToList(),
+                Instances = res
+                    .Where(t => t.FromId == connection.FromId && t.Instances != null)
+                    .SelectMany(t => t.Instances)
+                    .Select(i => Convert(i))
+                    .Where(i => i is not null)
+                    .DistinctBy(t => t.InstanceId)
+                    .ToList(),
 
                 Connections = new()
             };
@@ -200,6 +209,13 @@ public partial class DtoMapper : IDtoMapper
                     .Where(r => r is not null)
                     .DistinctBy(t => t.Id)
                     .ToList(),
+                Instances = res
+                    .Where(t => t.ToId == connection.ToId && t.Instances != null)
+                    .SelectMany(t => t.Instances)
+                    .Select(i => Convert(i))
+                    .Where(i => i is not null)
+                    .DistinctBy(t => t.InstanceId)
+                    .ToList(),
 
                 Connections = new()
             };
@@ -225,6 +241,15 @@ public partial class DtoMapper : IDtoMapper
             Id = resource.Id,
             Name = resource.Name,
             RefId = resource.RefId
+        };
+    }
+
+    public static ConnectionInstanceDto Convert(ConnectionQueryInstance instance)
+    {
+        return new ConnectionInstanceDto()
+        {
+            ResourceId = instance.ResourceId,
+            InstanceId = instance.InstanceId,
         };
     }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperConnectionQuery.cs
@@ -248,7 +248,7 @@ public partial class DtoMapper : IDtoMapper
     {
         return new ConnectionInstanceDto()
         {
-            ResourceId = instance.ResourceId,
+            ResourceRefId = instance.ResourceRefId,
             InstanceId = instance.InstanceId,
         };
     }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapperConnectionQuery.cs
@@ -34,7 +34,7 @@ public partial class DtoMapper : IDtoMapper
                 Roles = [.. c.Where(c => c.AssignmentId.HasValue).Select(c => ConvertCompactRole(c.Role)).Where(ro => ro is not null).DistinctBy(t => t.Id)],
                 Resources = [.. c.SelectMany(c => c.Resources).Select(r => Convert(r)).Where(re => re is not null).DistinctBy(t => t.Id)],
                 Packages = [.. c.SelectMany(c => c.Packages).Select(p => Convert(p)).Where(pa => pa is not null).DistinctBy(t => t.Id)],
-                Instances = [.. c.SelectMany(c => c.Instances).Select(i => Convert(i)).Where(i => i is not null).DistinctBy(t => t.InstanceId)],
+                Instances = [.. c.SelectMany(c => c.Instances).Select(i => Convert(i)).Where(i => i is not null).DistinctBy(t => (t.ResourceRefId, t.InstanceId))],
                 Connections = ConvertSubConnectionsToOthers(subconnections),
             };
         });
@@ -68,7 +68,7 @@ public partial class DtoMapper : IDtoMapper
                 Roles = [.. c.Where(c => c.AssignmentId.HasValue).Select(c => ConvertCompactRole(c.Role)).Where(ro => ro is not null).DistinctBy(t => t.Id)],
                 Resources = [.. c.SelectMany(c => c.Resources).Select(r => Convert(r)).Where(re => re is not null).DistinctBy(t => t.Id)],
                 Packages = [.. c.SelectMany(c => c.Packages).Select(p => Convert(p)).Where(pa => pa is not null).DistinctBy(t => t.Id)],
-                Instances = [.. c.SelectMany(c => c.Instances).Select(i => Convert(i)).Where(i => i is not null).DistinctBy(t => t.InstanceId)],
+                Instances = [.. c.SelectMany(c => c.Instances).Select(i => Convert(i)).Where(i => i is not null).DistinctBy(t => (t.ResourceRefId, t.InstanceId))],
                 Connections = ConvertSubConnectionsFromOthers(subconnections),
             };
         });
@@ -168,7 +168,7 @@ public partial class DtoMapper : IDtoMapper
                     .SelectMany(t => t.Instances)
                     .Select(i => Convert(i))
                     .Where(i => i is not null)
-                    .DistinctBy(t => t.InstanceId)
+                    .DistinctBy(t => (t.ResourceRefId, t.InstanceId))
                     .ToList(),
 
                 Connections = new()
@@ -214,7 +214,7 @@ public partial class DtoMapper : IDtoMapper
                     .SelectMany(t => t.Instances)
                     .Select(i => Convert(i))
                     .Where(i => i is not null)
-                    .DistinctBy(t => t.InstanceId)
+                    .DistinctBy(t => (t.ResourceRefId, t.InstanceId))
                     .ToList(),
 
                 Connections = new()

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/InternalConnectionsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/InternalConnectionsControllerTest.cs
@@ -36,7 +36,7 @@ public class InternalConnectionsControllerTest
     public async Task GetConnections_Success_ReturnsOk()
     {
         var svc = new Mock<IConnectionService>();
-        svc.Setup(s => s.Get(Party, Party, To, true, true, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
+        svc.Setup(s => s.Get(Party, Party, To, true, true, false, false, false, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(new Result<IEnumerable<ConnectionDto>>([]));
 
         var result = await CreateSut(svc.Object).GetConnections(Connection, new PagingInput(), TestContext.Current.CancellationToken);
@@ -48,7 +48,7 @@ public class InternalConnectionsControllerTest
     public async Task GetConnections_Problem_ReturnsActionResult()
     {
         var svc = new Mock<IConnectionService>();
-        svc.Setup(s => s.Get(Party, Party, To, true, true, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
+        svc.Setup(s => s.Get(Party, Party, To, true, true, false, false, false, It.IsAny<Action<ConnectionOptions>>(), It.IsAny<CancellationToken>()))
            .ReturnsAsync(MakeValidationProblem());
 
         var result = await CreateSut(svc.Object).GetConnections(Connection, new PagingInput(), TestContext.Current.CancellationToken);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/Mappers/DtoMapperConnectionQueryTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/Mappers/DtoMapperConnectionQueryTest.cs
@@ -50,6 +50,14 @@ public class DtoMapperConnectionQueryTest
         RefId = "ref-1",
     };
 
+    private static ConnectionQueryInstance MakeQueryInstance(string resourceRefId = "urn:altinn:resource:dialog", string instanceId = "51599233/df333e75") => new()
+    {
+        Id = Guid.NewGuid(),
+        ResourceId = Guid.NewGuid(),
+        InstanceId = instanceId,
+        ResourceRefId = resourceRefId,
+    };
+
     private static ConnectionQueryExtendedRecord MakeRecord(
         Entity from,
         Entity to,
@@ -57,7 +65,8 @@ public class DtoMapperConnectionQueryTest
         ConnectionReason reason = ConnectionReason.Assignment,
         Guid? viaId = null,
         List<ConnectionQueryPackage>? packages = null,
-        List<ConnectionQueryResource>? resources = null) =>
+        List<ConnectionQueryResource>? resources = null,
+        List<ConnectionQueryInstance>? instances = null) =>
         new()
         {
             FromId = from.Id,
@@ -71,6 +80,7 @@ public class DtoMapperConnectionQueryTest
             Role = role,
             Packages = packages ?? [],
             Resources = resources ?? [],
+            Instances = instances ?? [],
         };
 
     /// <summary>Creates a <see cref="Connection"/> (old model, Reason is string).</summary>
@@ -200,6 +210,61 @@ public class DtoMapperConnectionQueryTest
         result[0].Packages.Should().ContainSingle(p => p.Id == pkg.Id);
     }
 
+    [Fact]
+    public void ConvertToOthers_InstancesOnRecord_MappedToDto()
+    {
+        var from = MakeEntity();
+        var to = MakeEntity();
+        var role = MakeRole();
+        var inst = MakeQueryInstance("urn:altinn:resource:dialog", "51599233/df333e75");
+        var rec = MakeRecord(from, to, role, instances: [inst]);
+
+        var result = DtoMapper.ConvertToOthers([rec]);
+
+        result.Should().ContainSingle();
+        result[0].Instances.Should().ContainSingle();
+        result[0].Instances[0].ResourceRefId.Should().Be("urn:altinn:resource:dialog");
+        result[0].Instances[0].InstanceId.Should().Be("51599233/df333e75");
+    }
+
+    [Fact]
+    public void ConvertToOthers_SameInstanceIdAcrossDifferentResources_BothPreserved()
+    {
+        // InstanceId is scoped to a resource (see ConnectionQueryInstance docs),
+        // so the same string can legitimately appear under two different RefIds.
+        // Deduping on InstanceId alone would silently drop one of them.
+        var from = MakeEntity();
+        var to = MakeEntity();
+        var role = MakeRole();
+        var instA = MakeQueryInstance("urn:altinn:resource:dialog-a", "shared-instance-id");
+        var instB = MakeQueryInstance("urn:altinn:resource:dialog-b", "shared-instance-id");
+        var rec = MakeRecord(from, to, role, instances: [instA, instB]);
+
+        var result = DtoMapper.ConvertToOthers([rec]);
+
+        result.Should().ContainSingle();
+        result[0].Instances.Should().HaveCount(2);
+        result[0].Instances.Select(i => i.ResourceRefId).Should().BeEquivalentTo(
+            ["urn:altinn:resource:dialog-a", "urn:altinn:resource:dialog-b"]);
+    }
+
+    [Fact]
+    public void ConvertToOthers_DuplicateInstanceOnSameResource_Deduplicated()
+    {
+        var from = MakeEntity();
+        var to = MakeEntity();
+        var role = MakeRole();
+        var instA = MakeQueryInstance("urn:altinn:resource:dialog", "instance-1");
+        var instB = MakeQueryInstance("urn:altinn:resource:dialog", "instance-1");
+        var rec1 = MakeRecord(from, to, role, instances: [instA]);
+        var rec2 = MakeRecord(from, to, role, instances: [instB]);
+
+        var result = DtoMapper.ConvertToOthers([rec1, rec2]);
+
+        result.Should().ContainSingle();
+        result[0].Instances.Should().ContainSingle();
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // ConvertFromOthers
     // ══════════════════════════════════════════════════════════════════════════
@@ -266,6 +331,23 @@ public class DtoMapperConnectionQueryTest
         result[0].Roles.Should().ContainSingle();
     }
 
+    [Fact]
+    public void ConvertFromOthers_InstancesOnRecord_MappedToDto()
+    {
+        var from = MakeEntity();
+        var to = MakeEntity();
+        var role = MakeRole();
+        var inst = MakeQueryInstance("urn:altinn:resource:dialog", "51599233/df333e75");
+        var rec = MakeRecord(from, to, role, instances: [inst]);
+
+        var result = DtoMapper.ConvertFromOthers([rec]);
+
+        result.Should().ContainSingle();
+        result[0].Instances.Should().ContainSingle();
+        result[0].Instances[0].ResourceRefId.Should().Be("urn:altinn:resource:dialog");
+        result[0].Instances[0].InstanceId.Should().Be("51599233/df333e75");
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // ConvertSubConnectionsToOthers
     // ══════════════════════════════════════════════════════════════════════════
@@ -300,6 +382,27 @@ public class DtoMapperConnectionQueryTest
         result[0].Packages.Should().ContainSingle(p => p.Id == pkg.Id);
     }
 
+    [Fact]
+    public void ConvertSubConnectionsToOthers_InstancesFilteredByToId()
+    {
+        var from = MakeEntity("From");
+        var toA = MakeEntity("ToA");
+        var toB = MakeEntity("ToB");
+        var role = MakeRole();
+        var instA = MakeQueryInstance("urn:altinn:resource:a", "inst-a");
+        var instB = MakeQueryInstance("urn:altinn:resource:b", "inst-b");
+        var recA = MakeRecord(from, toA, role, instances: [instA]);
+        var recB = MakeRecord(from, toB, role, instances: [instB]);
+
+        var result = DtoMapper.ConvertSubConnectionsToOthers([recA, recB]);
+
+        result.Should().HaveCount(2);
+        var dtoA = result.Single(c => c.Party!.Id == toA.Id);
+        var dtoB = result.Single(c => c.Party!.Id == toB.Id);
+        dtoA.Instances.Should().ContainSingle(i => i.InstanceId == "inst-a");
+        dtoB.Instances.Should().ContainSingle(i => i.InstanceId == "inst-b");
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // ConvertSubConnectionsFromOthers
     // ══════════════════════════════════════════════════════════════════════════
@@ -326,6 +429,27 @@ public class DtoMapperConnectionQueryTest
         result[0].Party!.Id.Should().Be(from.Id);
         result[0].Roles.Should().HaveCount(2);
         result[0].Resources.Should().ContainSingle(r => r.Id == res.Id);
+    }
+
+    [Fact]
+    public void ConvertSubConnectionsFromOthers_InstancesFilteredByFromId()
+    {
+        var fromA = MakeEntity("FromA");
+        var fromB = MakeEntity("FromB");
+        var to = MakeEntity("To");
+        var role = MakeRole();
+        var instA = MakeQueryInstance("urn:altinn:resource:a", "inst-a");
+        var instB = MakeQueryInstance("urn:altinn:resource:b", "inst-b");
+        var recA = MakeRecord(fromA, to, role, instances: [instA]);
+        var recB = MakeRecord(fromB, to, role, instances: [instB]);
+
+        var result = DtoMapper.ConvertSubConnectionsFromOthers([recA, recB]);
+
+        result.Should().HaveCount(2);
+        var dtoA = result.Single(c => c.Party!.Id == fromA.Id);
+        var dtoB = result.Single(c => c.Party!.Id == fromB.Id);
+        dtoA.Instances.Should().ContainSingle(i => i.InstanceId == "inst-a");
+        dtoB.Instances.Should().ContainSingle(i => i.InstanceId == "inst-b");
     }
 
     // ══════════════════════════════════════════════════════════════════════════

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/ConnectionDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/ConnectionDto.cs
@@ -26,6 +26,11 @@ public class ConnectionDto
     public List<ResourceDto> Resources { get; set; } = new();
 
     /// <summary>
+    /// Resource instance accesses for the given party
+    /// </summary>
+    public List<ConnectionInstanceDto> Instances { get; set; } = new();
+
+    /// <summary>
     /// Sub-connections of the party where the same access applies
     /// </summary>
     public List<ConnectionDto> Connections { get; set; } = new();

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/ConnectionInstanceDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/ConnectionInstanceDto.cs
@@ -1,0 +1,19 @@
+namespace Altinn.Authorization.Api.Contracts.AccessManagement;
+
+/// <summary>
+/// Instance reference exposed on a <see cref="ConnectionDto"/>. The instance belongs to the resource
+/// identified by <see cref="ResourceId"/>, which the caller can correlate with
+/// <see cref="ConnectionDto.Resources"/> when also requested.
+/// </summary>
+public class ConnectionInstanceDto
+{
+    /// <summary>
+    /// Identifier of the resource the instance belongs to.
+    /// </summary>
+    public Guid ResourceId { get; set; }
+
+    /// <summary>
+    /// Instance identifier scoped to the resource (e.g., "51599233/df333e75-5896-4254-a69f-146736eaf668").
+    /// </summary>
+    public string InstanceId { get; set; } = string.Empty;
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/ConnectionInstanceDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/ConnectionInstanceDto.cs
@@ -2,15 +2,15 @@ namespace Altinn.Authorization.Api.Contracts.AccessManagement;
 
 /// <summary>
 /// Instance reference exposed on a <see cref="ConnectionDto"/>. The instance belongs to the resource
-/// identified by <see cref="ResourceId"/>, which the caller can correlate with
-/// <see cref="ConnectionDto.Resources"/> when also requested.
+/// identified by <see cref="ResourceRefId"/>, which the caller can correlate with
+/// <see cref="ResourceDto.RefId"/> on entries in <see cref="ConnectionDto.Resources"/> when also requested.
 /// </summary>
 public class ConnectionInstanceDto
 {
     /// <summary>
-    /// Identifier of the resource the instance belongs to.
+    /// Reference identifier of the resource the instance belongs to, as registered in the Resource Registry.
     /// </summary>
-    public Guid ResourceId { get; set; }
+    public string ResourceRefId { get; set; } = string.Empty;
 
     /// <summary>
     /// Instance identifier scoped to the resource (e.g., "51599233/df333e75-5896-4254-a69f-146736eaf668").


### PR DESCRIPTION
## Summary

- Adds three optional query params on `GET /accessmanagement/api/v1/enduser/connections`:
  - `includeAccessPackages` (bool, default false)
  - `includeResources` (bool, default false)
  - `includeInstances` (bool, default false)
- Lets a caller fetch connections together with the access packages, direct resources and resource instances given or received from a party in a single request, instead of iterating over the per-type sibling endpoints (`/connections/accesspackages`, `/connections/resources`, `/connections/resources/instances`) and stitching the result together.
- The `ConnectionQueryFilter` flags + EF loaders for packages / resources / instances already existed; the controller previously hardcoded the package and resource flags to `false` and never set the instance flag. This wires the params through `ConnectionService.Get` to those flags.
- `ConnectionDto` already had `Packages` and `Resources` collections (populated by `DtoMapper` when the query loads them). A new `Instances: List<ConnectionInstanceDto>` is added on `ConnectionDto`, and a new `ConnectionInstanceDto { Guid ResourceId; string InstanceId; }` contract is introduced so the caller can correlate each instance with the matching entry in `Resources`.
- All three params default to `false`, so existing callers and the internal `GetAvailableUsers` call site keep their current behavior.

## Test plan

- [x] `dotnet build` on `Altinn.AccessManagement.csproj` + `Altinn.AccessManagement.Enduser.Api.Tests.csproj` + `Altinn.AccessMgmt.Core.Tests.csproj` — succeeds with 0 errors.
- [ ] Manual: `GET /enduser/connections?party={p}&includeAccessPackages=true` → connection rows now include populated `Packages`; sub-connections too.
- [ ] Manual: `GET /enduser/connections?party={p}&includeResources=true` → `Resources` populated.
- [ ] Manual: `GET /enduser/connections?party={p}&includeInstances=true` → `Instances` populated with `ResourceId` + `InstanceId`; combine with `includeResources=true` to resolve each instance's parent resource.
- [ ] Manual: omit all three flags → response identical to current behavior (no regression for existing portal/sluttbrukersystem callers).

Closes #3071