### PR TITLE
ci: disable SonarCloud for Altinn.Authorization.Api.Contracts

### DIFF
--- a/src/libs/Altinn.Authorization.Api.Contracts/conf.json
+++ b/src/libs/Altinn.Authorization.Api.Contracts/conf.json
@@ -1,2 +1,3 @@
 {
+  "sonarcloud": false
 }


### PR DESCRIPTION
## Summary

- Disables SonarCloud analysis for `Altinn.Authorization.Api.Contracts` by setting `"sonarcloud": false` in its `conf.json`.
- The library has no test project (none has ever existed) and its 106 source files are all DTO/contract types. The few files with parsing/validation logic (`StringIdentifier`, `AccessPackageIdentifier`, the `*RoleCode` types) are already marked `[ExcludeFromCodeCoverage]`.
- Without a test project there is no coverage report to feed SonarCloud, so any new code (e.g. adding one DTO property) fails the `new_coverage` gate at 0% against a baseline that physically cannot exist.
- Matches the existing pattern in `src/apps/Altinn.Register/conf.json`.

## Test plan

- [ ] CI run: the `Altinn.Authorization.Api.Contracts` matrix entry no longer attempts SonarCloud upload; verticals with real test coverage (AccessManagement, Authorization) still run normally.
- [ ] PR #3191 (open) re-runs Sonar without the 0% gate on `Authorization Altinn.Authorization.Api.Contracts`.

Refs #3203
