### PR TITLE
fix: handle invalid party query parameter without a 500

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Authorization/AuthorizationHandler/EndUserResourceAccessHandler.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Authorization/AuthorizationHandler/EndUserResourceAccessHandler.cs
@@ -51,16 +51,12 @@ namespace Altinn.AccessManagement.Api.Enduser.Authorization.AuthorizationHandler
 
             if (DecisionHelper.GetPartyParam(httpContext) is null)
             {
-                // The 'party' query parameter is missing or not a valid GUID. Treat it as no
-                // access instead of letting CreateDecisionRequest throw and surface as a 500.
-                if (!requirement.AllowAllowUnauthorizedParty)
-                {
-                    context.Fail();
-                    return;
-                }
-
-                httpContext.Items["HasRequestedPermission"] = false;
-                context.Succeed(requirement);
+                // The 'party' query parameter is missing or not a valid GUID. A valid party is
+                // always required: AllowAllowUnauthorizedParty only governs whether the user must
+                // be authorized for an otherwise valid party, it does not excuse a missing or
+                // malformed party. Fail here instead of letting CreateDecisionRequest throw and
+                // surface as a 500.
+                context.Fail();
                 return;
             }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Authorization/AuthorizationHandler/EndUserResourceAccessHandler.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Authorization/AuthorizationHandler/EndUserResourceAccessHandler.cs
@@ -49,6 +49,23 @@ namespace Altinn.AccessManagement.Api.Enduser.Authorization.AuthorizationHandler
                 return;
             }
 
+            if (DecisionHelper.GetPartyParam(httpContext) is null)
+            {
+                // The 'party' query parameter is missing or not a valid GUID. Treat it as no
+                // access instead of letting CreateDecisionRequest throw and surface as a 500.
+                if (!requirement.AllowAllowUnauthorizedParty)
+                {
+                    context.Fail();
+                    await Task.CompletedTask;
+                    return;
+                }
+
+                httpContext.Items.Add("HasRequestedPermission", false);
+                context.Succeed(requirement);
+                await Task.CompletedTask;
+                return;
+            }
+
             XacmlJsonRequestRoot request = DecisionHelper.CreateDecisionRequest(context, requirement, httpContext.Request.Query);
 
             XacmlJsonResponse response = await _pdp.GetDecisionForRequest(request);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Authorization/AuthorizationHandler/EndUserResourceAccessHandler.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Authorization/AuthorizationHandler/EndUserResourceAccessHandler.cs
@@ -56,13 +56,11 @@ namespace Altinn.AccessManagement.Api.Enduser.Authorization.AuthorizationHandler
                 if (!requirement.AllowAllowUnauthorizedParty)
                 {
                     context.Fail();
-                    await Task.CompletedTask;
                     return;
                 }
 
-                httpContext.Items.Add("HasRequestedPermission", false);
+                httpContext.Items["HasRequestedPermission"] = false;
                 context.Succeed(requirement);
-                await Task.CompletedTask;
                 return;
             }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/EndUserResourceAccessHandlerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/EndUserResourceAccessHandlerTest.cs
@@ -75,6 +75,19 @@ public class EndUserResourceAccessHandlerTest
     }
 
     [Fact]
+    public async Task HandleRequirement_MissingPartyParam_AllowUnauthorizedParty_Succeeds()
+    {
+        var (handler, pdp, httpContext) = CreateSut(string.Empty);
+        var context = Ctx(new EndUserResourceAccessRequirement("read", "res", allowAllowUnauthorizedParty: true));
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeTrue();
+        httpContext.Items["HasRequestedPermission"].Should().Be(false);
+        pdp.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Never);
+    }
+
+    [Fact]
     public async Task HandleRequirement_ValidParty_PdpPermit_Succeeds()
     {
         var (handler, pdp, httpContext) = CreateSut($"?party={Guid.NewGuid()}");

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/EndUserResourceAccessHandlerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/EndUserResourceAccessHandlerTest.cs
@@ -1,0 +1,90 @@
+using System.Security.Claims;
+using Altinn.AccessManagement.Api.Enduser.Authorization.AuthorizationHandler;
+using Altinn.AccessManagement.Api.Enduser.Authorization.AuthorizationRequirement;
+using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+using Altinn.Common.PEP.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Altinn.AccessManagement.Enduser.Api.Tests.AuthorizationHelpers;
+
+/// <summary>
+/// Tests for <see cref="EndUserResourceAccessHandler"/>, focused on the handling of a
+/// missing or malformed <c>party</c> query parameter (which previously surfaced as a 500).
+/// </summary>
+public class EndUserResourceAccessHandlerTest
+{
+    private static (EndUserResourceAccessHandler Handler, Mock<IPDP> Pdp, HttpContext HttpContext) CreateSut(string queryString)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString(queryString);
+
+        var accessor = new Mock<IHttpContextAccessor>();
+        accessor.Setup(a => a.HttpContext).Returns(httpContext);
+
+        var pdp = new Mock<IPDP>();
+
+        var handler = new EndUserResourceAccessHandler(
+            accessor.Object,
+            pdp.Object,
+            NullLogger<EndUserResourceAccessHandler>.Instance);
+
+        return (handler, pdp, httpContext);
+    }
+
+    private static AuthorizationHandlerContext Ctx(EndUserResourceAccessRequirement requirement)
+        => new([requirement], new ClaimsPrincipal(new ClaimsIdentity("test")), null);
+
+    [Fact]
+    public async Task HandleRequirement_InvalidPartyParam_Fails_WithoutCallingPdp()
+    {
+        var (handler, pdp, _) = CreateSut("?party=not-a-guid");
+        var context = Ctx(new EndUserResourceAccessRequirement("read", "altinn_maskinporten_scope_delegation", false));
+
+        await handler.HandleAsync(context);
+
+        context.HasFailed.Should().BeTrue();
+        context.HasSucceeded.Should().BeFalse();
+        pdp.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleRequirement_MissingPartyParam_Fails()
+    {
+        var (handler, _, _) = CreateSut(string.Empty);
+        var context = Ctx(new EndUserResourceAccessRequirement("read", "altinn_maskinporten_scope_delegation", false));
+
+        await handler.HandleAsync(context);
+
+        context.HasFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleRequirement_InvalidPartyParam_AllowUnauthorizedParty_Succeeds()
+    {
+        var (handler, pdp, httpContext) = CreateSut("?party=not-a-guid");
+        var context = Ctx(new EndUserResourceAccessRequirement("read", "res", allowAllowUnauthorizedParty: true));
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeTrue();
+        httpContext.Items["HasRequestedPermission"].Should().Be(false);
+        pdp.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleRequirement_ValidParty_PdpPermit_Succeeds()
+    {
+        var (handler, pdp, httpContext) = CreateSut($"?party={Guid.NewGuid()}");
+        pdp.Setup(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+           .ReturnsAsync(new XacmlJsonResponse { Response = [new() { Decision = "Permit" }] });
+        var context = Ctx(new EndUserResourceAccessRequirement("read", "res", false));
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeTrue();
+        httpContext.Items["HasRequestedPermission"].Should().Be(true);
+    }
+}

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/EndUserResourceAccessHandlerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/EndUserResourceAccessHandlerTest.cs
@@ -88,6 +88,42 @@ public class EndUserResourceAccessHandlerTest
     }
 
     [Fact]
+    public async Task HandleRequirement_EmptyPartyParam_Fails()
+    {
+        var (handler, pdp, _) = CreateSut("?party=");
+        var context = Ctx(new EndUserResourceAccessRequirement("read", "altinn_maskinporten_scope_delegation", false));
+
+        await handler.HandleAsync(context);
+
+        context.HasFailed.Should().BeTrue();
+        pdp.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleRequirement_EmptyPartyParam_AllowUnauthorizedParty_Succeeds()
+    {
+        var (handler, pdp, httpContext) = CreateSut("?party=");
+        var context = Ctx(new EndUserResourceAccessRequirement("read", "res", allowAllowUnauthorizedParty: true));
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeTrue();
+        httpContext.Items["HasRequestedPermission"].Should().Be(false);
+        pdp.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleRequirement_WhitespacePartyParam_Fails()
+    {
+        var (handler, _, _) = CreateSut("?party=%20");
+        var context = Ctx(new EndUserResourceAccessRequirement("read", "altinn_maskinporten_scope_delegation", false));
+
+        await handler.HandleAsync(context);
+
+        context.HasFailed.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task HandleRequirement_ValidParty_PdpPermit_Succeeds()
     {
         var (handler, pdp, httpContext) = CreateSut($"?party={Guid.NewGuid()}");

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/EndUserResourceAccessHandlerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/EndUserResourceAccessHandlerTest.cs
@@ -62,28 +62,17 @@ public class EndUserResourceAccessHandlerTest
     }
 
     [Fact]
-    public async Task HandleRequirement_InvalidPartyParam_AllowUnauthorizedParty_Succeeds()
+    public async Task HandleRequirement_InvalidPartyParam_WithAllowUnauthorizedParty_StillFails()
     {
-        var (handler, pdp, httpContext) = CreateSut("?party=not-a-guid");
+        // AllowAllowUnauthorizedParty only governs whether the user must be authorized for an
+        // otherwise valid party. It does not excuse a missing or malformed party.
+        var (handler, pdp, _) = CreateSut("?party=not-a-guid");
         var context = Ctx(new EndUserResourceAccessRequirement("read", "res", allowAllowUnauthorizedParty: true));
 
         await handler.HandleAsync(context);
 
-        context.HasSucceeded.Should().BeTrue();
-        httpContext.Items["HasRequestedPermission"].Should().Be(false);
-        pdp.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task HandleRequirement_MissingPartyParam_AllowUnauthorizedParty_Succeeds()
-    {
-        var (handler, pdp, httpContext) = CreateSut(string.Empty);
-        var context = Ctx(new EndUserResourceAccessRequirement("read", "res", allowAllowUnauthorizedParty: true));
-
-        await handler.HandleAsync(context);
-
-        context.HasSucceeded.Should().BeTrue();
-        httpContext.Items["HasRequestedPermission"].Should().Be(false);
+        context.HasFailed.Should().BeTrue();
+        context.HasSucceeded.Should().BeFalse();
         pdp.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Never);
     }
 
@@ -96,19 +85,6 @@ public class EndUserResourceAccessHandlerTest
         await handler.HandleAsync(context);
 
         context.HasFailed.Should().BeTrue();
-        pdp.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task HandleRequirement_EmptyPartyParam_AllowUnauthorizedParty_Succeeds()
-    {
-        var (handler, pdp, httpContext) = CreateSut("?party=");
-        var context = Ctx(new EndUserResourceAccessRequirement("read", "res", allowAllowUnauthorizedParty: true));
-
-        await handler.HandleAsync(context);
-
-        context.HasSucceeded.Should().BeTrue();
-        httpContext.Items["HasRequestedPermission"].Should().Be(false);
         pdp.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Never);
     }
 


### PR DESCRIPTION
## Summary
- `EndUserResourceAccessHandler` passed the raw `party` query parameter to `DecisionHelper.CreateDecisionRequest`, which threw an `ArgumentException` when `party` was missing or not a valid GUID. The exception surfaced as a 500 Internal Server Error.
- The handler now validates `party` up front: it fails the authorization requirement gracefully (403), or succeeds without permission for policies that allow unauthorized parties.
- Applies to every enduser endpoint using `EndUserResourceAccessRequirement`, not just `maskinportensuppliers`.

Fixes #3193

## Test plan
- Added unit tests for `EndUserResourceAccessHandler` covering missing, invalid and valid `party` values.
- `Altinn.AccessManagement.Enduser.Api.Tests` passes (382 tests).