### PR TITLE
Enrich entities from connectionquery rather than separately

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -424,7 +424,7 @@ public class AuthorizedPartiesServiceEf(
         Guid toId,
         CancellationToken cancellationToken = default)
     {
-        List<ConnectionQueryExtendedRecord> connections = await repoService.GetConnectionsFromOthers(toId, filters: filter, ct: cancellationToken);
+        List<ConnectionQueryExtendedRecord> connections = await repoService.GetConnectionsFromOthers(toId, filters: filter, enrichEntities: true, ct: cancellationToken);
 
         // Post-query filtering of connections when resource/provider filters are active
         if (filter.ProviderCode != null || filter.AnyOfResourceIds?.Length > 0)
@@ -432,9 +432,8 @@ public class AuthorizedPartiesServiceEf(
             connections = FilterConnections(connections, filter);
         }
 
-        var fromUuids = connections.Select(c => c.FromId).Distinct();
-        var fromParties = await repoService.GetEntities(fromUuids, cancellationToken);
-        var fromSubUnits = await repoService.GetSubunits(fromUuids, cancellationToken);
+        var fromParties = connections.Select(c => c.From).Distinct().ToList();
+        var fromSubUnits = connections.Select(c => c.From).Distinct().Where(e => e.ParentId.HasValue).ToList();
 
         (Dictionary<Guid, AuthorizedParty> parties, IEnumerable<AuthorizedParty> authorizedParties) = BuildDictionaryFromEntities(fromParties, fromSubUnits);
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -432,8 +432,9 @@ public class AuthorizedPartiesServiceEf(
             connections = FilterConnections(connections, filter);
         }
 
-        var fromParties = connections.Select(c => c.From).Distinct().ToList();
-        var fromSubUnits = connections.Select(c => c.From).Distinct().Where(e => e.ParentId.HasValue).ToList();
+        var fromEntities = connections.Select(c => c.From).DistinctBy(e => e.Id).ToList();
+        var fromParties = fromEntities;
+        var fromSubUnits = fromEntities.Where(e => e.ParentId.HasValue).ToList();
 
         (Dictionary<Guid, AuthorizedParty> parties, IEnumerable<AuthorizedParty> authorizedParties) = BuildDictionaryFromEntities(fromParties, fromSubUnits);
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
@@ -106,6 +106,7 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
     public async Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthers(
         Guid toId,
         AuthorizedPartiesFilters filters = null,
+        bool enrichEntities = false,
         CancellationToken ct = default)
     {
         return await connectionQuery.GetConnectionsAsync(
@@ -113,7 +114,7 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
         {
             ToIds = [toId],
             FromIds = filters?.PartyFilter?.Keys.ToList(),
-            EnrichEntities = false,
+            EnrichEntities = enrichEntities,
             IncludeSubConnections = true,
             IncludeKeyRole = filters?.IncludePartiesViaKeyRoles == AuthorizedPartiesIncludeFilter.True ? true : false,
             IncludeMainUnitConnections = true,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IAuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IAuthorizedPartyRepoServiceEf.cs
@@ -97,7 +97,7 @@ public interface IAuthorizedPartyRepoServiceEf
     /// Get all connections the to party has any access to in one query, for usage in the new AuthorizedPartiesServiceEf implementation.
     /// </summary>
     /// <returns>Enumerable of package permissions</returns>
-    Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthers(Guid toId, AuthorizedPartiesFilters filters = null, CancellationToken ct = default);
+    Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthers(Guid toId, AuthorizedPartiesFilters filters = null, bool enrichEntities = false, CancellationToken ct = default);
 
     /// <summary>
     /// Get all connections the to party has any access packages for, for usage in the AuthorizedPartiesServiceEfOld implementation.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -874,6 +874,7 @@ public class ConnectionQuery(AppDbContext db)
                 Username = e.Username,
                 TypeId = e.TypeId,
                 VariantId = e.VariantId,
+                EmailIdentifier = e.EmailIdentifier,
                 Parent = e.Parent != null ? new Entity()
                 {
                     Id = e.Parent.Id,
@@ -889,7 +890,8 @@ public class ConnectionQuery(AppDbContext db)
                     UserId = e.Parent.UserId,
                     Username = e.Parent.Username,
                     TypeId = e.Parent.TypeId,
-                    VariantId = e.Parent.VariantId
+                    VariantId = e.Parent.VariantId,
+                    EmailIdentifier = e.Parent.EmailIdentifier
                 }
                 : null
             })
@@ -925,7 +927,7 @@ public class ConnectionQuery(AppDbContext db)
                     UserId = e.UserId,
                     Username = e.Username,
                     TypeId = e.TypeId,
-                    VariantId = e.VariantId,
+                    VariantId = e.VariantId
                 })
                 .Distinct()
                 .AsNoTracking()

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/AuthorizedParties/AsAuthenticatedUser/GET_AuthorizedParties_IdpEmailUser.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/AuthorizedParties/AsAuthenticatedUser/GET_AuthorizedParties_IdpEmailUser.bru
@@ -63,6 +63,7 @@ tests {
     const targetParty = allParties.find(party => party.partyUuid === testdata.idportenEmailUser.partyUuid);
   
     assert.exists(targetParty, 'Party with partyUuid '+testdata.idportenEmailUser.partyUuid+' should exist');
+    assert.equal(targetParty.emailId, testdata.idportenEmailUser.emailId, "Expected EmailId should exist");
     assertIncludeMembersIgnoreCase(targetParty.authorizedRoles, ["SELN"]);
   
   });

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/AuthorizedParties/AsEndUserSystem/GET_EUS_AuthorizedParties_IdpEmailUser.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/AuthorizedParties/AsEndUserSystem/GET_EUS_AuthorizedParties_IdpEmailUser.bru
@@ -62,7 +62,8 @@ tests {
     const targetParty = allParties.find(party => party.partyUuid === testdata.idportenEmailUser.partyUuid);
   
     assert.exists(targetParty, 'Party with partyUuid '+testdata.idportenEmailUser.partyUuid+' should exist');
-    assertIncludeMembersIgnoreCase(targetParty.authorizedRoles, ["seln", "selvregistrert"]);
+    assert.equal(targetParty.emailId, testdata.idportenEmailUser.emailId, "Expected EmailId should exist");
+    assertIncludeMembersIgnoreCase(targetParty.authorizedRoles, ["seln", "selvregistrert"]);  
   
   });
 }

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/AuthorizedParties/AsServiceOwner/POST_Admin_AuthorizedParties_IdpEmailUser.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/AuthorizedParties/AsServiceOwner/POST_Admin_AuthorizedParties_IdpEmailUser.bru
@@ -68,6 +68,7 @@ tests {
     const targetParty = allParties.find(party => party.partyUuid === testdata.idportenEmailUser.partyUuid);
   
     assert.exists(targetParty, 'Party with partyUuid '+testdata.idportenEmailUser.partyUuid+' should exist');
+    assert.equal(targetParty.emailId, testdata.idportenEmailUser.emailId, "Expected EmailId should exist");
     assertIncludeMembersIgnoreCase(targetParty.authorizedRoles, ["SELN"]);
   
   });


### PR DESCRIPTION
## Description
- Enrich entities from connectionquery rather than separately. The query in connectionquery is twice as fast for large requests because all the unused audit-columns are left out

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
