### PR TITLE
fix: handle NULL values when reading consent request redirecturl column from database

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
@@ -385,7 +385,9 @@ namespace Altinn.AccessManagement.Persistence.Consent
                         : await reader.GetFieldValueAsync<Dictionary<string, string>>("requestMessage", cancellationToken: cancellationToken),
                     ConsentRequestStatus = await reader.GetFieldValueAsync<ConsentRequestStatusType>("status", cancellationToken: cancellationToken),
                     Consented = await reader.GetFieldValueAsync<DateTimeOffset?>("consented", cancellationToken: cancellationToken),
-                    RedirectUrl = await reader.GetFieldValueAsync<string>("redirectUrl", cancellationToken: cancellationToken),
+                    RedirectUrl = await reader.IsDBNullAsync(reader.GetOrdinal("redirectUrl"), cancellationToken: cancellationToken)
+                        ? null
+                        : await reader.GetFieldValueAsync<string>("redirectUrl", cancellationToken: cancellationToken),
                     ConsentRequestEvents = consentRequestEvents,
                     TemplateId = await reader.GetFieldValueAsync<string>("templateId", cancellationToken: cancellationToken),
                     TemplateVersion = await reader.GetFieldValueAsync<int?>("templateVersion", cancellationToken: cancellationToken),
@@ -524,7 +526,9 @@ namespace Altinn.AccessManagement.Persistence.Consent
                         : await reader.GetFieldValueAsync<Dictionary<string, string>>("requestMessage", cancellationToken: cancellationToken),
                     ConsentRequestStatus = await reader.GetFieldValueAsync<ConsentRequestStatusType>("status", cancellationToken: cancellationToken),
                     Consented = await reader.GetFieldValueAsync<DateTimeOffset?>("consented", cancellationToken: cancellationToken),
-                    RedirectUrl = await reader.GetFieldValueAsync<string>("redirectUrl", cancellationToken: cancellationToken),
+                    RedirectUrl = await reader.IsDBNullAsync(reader.GetOrdinal("redirectUrl"), cancellationToken: cancellationToken)
+                        ? null
+                        : await reader.GetFieldValueAsync<string>("redirectUrl", cancellationToken: cancellationToken),
                     ConsentRequestEvents = await GetEvents(consentRequestId, cancellationToken: cancellationToken),
                     TemplateId = await reader.GetFieldValueAsync<string>("templateId", cancellationToken: cancellationToken),
                     TemplateVersion = await reader.GetFieldValueAsync<int?>("templateVersion", cancellationToken: cancellationToken),

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
@@ -386,7 +386,7 @@ namespace Altinn.AccessManagement.Persistence.Consent
                     ConsentRequestStatus = await reader.GetFieldValueAsync<ConsentRequestStatusType>("status", cancellationToken: cancellationToken),
                     Consented = await reader.GetFieldValueAsync<DateTimeOffset?>("consented", cancellationToken: cancellationToken),
                     RedirectUrl = await reader.IsDBNullAsync(reader.GetOrdinal("redirectUrl"), cancellationToken: cancellationToken)
-                        ? null
+                        ? string.Empty
                         : await reader.GetFieldValueAsync<string>("redirectUrl", cancellationToken: cancellationToken),
                     ConsentRequestEvents = consentRequestEvents,
                     TemplateId = await reader.GetFieldValueAsync<string>("templateId", cancellationToken: cancellationToken),
@@ -527,7 +527,7 @@ namespace Altinn.AccessManagement.Persistence.Consent
                     ConsentRequestStatus = await reader.GetFieldValueAsync<ConsentRequestStatusType>("status", cancellationToken: cancellationToken),
                     Consented = await reader.GetFieldValueAsync<DateTimeOffset?>("consented", cancellationToken: cancellationToken),
                     RedirectUrl = await reader.IsDBNullAsync(reader.GetOrdinal("redirectUrl"), cancellationToken: cancellationToken)
-                        ? null
+                        ? string.Empty
                         : await reader.GetFieldValueAsync<string>("redirectUrl", cancellationToken: cancellationToken),
                     ConsentRequestEvents = await GetEvents(consentRequestId, cancellationToken: cancellationToken),
                     TemplateId = await reader.GetFieldValueAsync<string>("templateId", cancellationToken: cancellationToken),

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
@@ -601,8 +601,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
             string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             List<ConsentRequestDetailsBffDto> consentRequestList = JsonSerializer.Deserialize<List<ConsentRequestDetailsBffDto>>(responseText, _jsonOptions);
-            Assert.Single(consentRequestList.Where(r => r.Id == requestId && r.RedirectUrl == null).ToList());
-        }
+            Assert.Single(consentRequestList, r => r.Id == requestId && r.RedirectUrl == string.Empty);
 
         [Fact]
         public async Task ListRequests_One_Valid_Hidden_One_Valid_Show()

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
@@ -591,15 +591,14 @@ namespace AccessMgmt.Tests.Controllers.Bff
         [Fact]
         public async Task ListRequests_One_Valid_Without_RedirectUrl()
         {
-            SetupMockPartyRepository();
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed78");
             IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
-            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
             HttpClient client = GetTestClient();
             string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5");
-            string responseText = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             List<ConsentRequestDetailsBffDto> consentRequestList = JsonSerializer.Deserialize<List<ConsentRequestDetailsBffDto>>(responseText, _jsonOptions);
             Assert.Single(consentRequestList.Where(r => r.Id == requestId && r.RedirectUrl == null).ToList());

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
@@ -589,6 +589,23 @@ namespace AccessMgmt.Tests.Controllers.Bff
         }
 
         [Fact]
+        public async Task ListRequests_One_Valid_Without_RedirectUrl()
+        {
+            SetupMockPartyRepository();
+            Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed78");
+            IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), default);
+            HttpClient client = GetTestClient();
+            string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/list/d5b861c8-8e3b-44cd-9952-5315e5990cf5");
+            string responseText = await response.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            List<ConsentRequestDetailsBffDto> consentRequestList = JsonSerializer.Deserialize<List<ConsentRequestDetailsBffDto>>(responseText, _jsonOptions);
+            Assert.Single(consentRequestList.Where(r => r.Id == requestId && r.RedirectUrl == null).ToList());
+        }
+
+        [Fact]
         public async Task ListRequests_One_Valid_Hidden_One_Valid_Show()
         {
             Guid requestId = Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed44");

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Data/Consent/consent_request_e2071c55-6adf-487b-af05-9198a230ed78.json
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Data/Consent/consent_request_e2071c55-6adf-487b-af05-9198a230ed78.json
@@ -1,0 +1,44 @@
+{
+  "iD": "e2071c55-6adf-487b-af05-9198a230ed78",
+  "from": "urn:altinn:party:uuid:d5b861c8-8e3b-44cd-9952-5315e5990cf5",
+  "to": "urn:altinn:party:uuid:8ef5e5fa-94e1-4869-8635-df86b6219181",
+  "validTo": "2019-09-30T10:30:00.000",
+  "requestMessage": {
+    "nb": "Ved å samtykke, gir du Skatteetaten rett til å utlevere opplysninger om deg direkte til DNB BANK ASA. Banken får opplysningene for å behandle søknad om finansiering.",
+    "nn": "Ved å samtykke, gir du Skatteetaten rett til å utlevere opplysningar om deg direkte til DNB BANK ASA. Banken får opplysningane for å behandle søknad om finansiering.",
+    "en": "By consenting, you give the Tax Administration the right to disclose information about you directly to DNB BANK ASA. The bank receives the information to process the financing application."
+  },
+  "consentRights": [
+    {
+      "action": ["read"],
+      "resource": [
+        {
+          "type": "urn:altinn:resource",
+          "value": "ttd_skattegrunnlag",
+          "version": "1"
+        }
+      ],
+      "metadata": {
+        "fraOgMed": "2017-06",
+        "tilOgMed": "2017-08"
+      }
+    },
+    {
+      "action": ["read"],
+      "resource": [
+        {
+          "type": "urn:altinn:resource",
+          "value": "ttd_inntektsopplysninger",
+          "version": "4"
+        }
+      ],
+      "metadata": {
+        "inntektsaar": "2016"
+      }
+    }
+  ],
+  "portalViewMode": "Hide",
+  "redirectUrl": null,
+  "templateId": "sblanesoknad",
+  "templateVersion": 1
+}


### PR DESCRIPTION
## Description
- Seems like migrated consents might have no redirecturl, and this would crash when reading the consents from database

## Related Issue(s)
- [from Application Insights](https://portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/DataModel~/%7B%22eventId%22%3A%228ce90e60-5b3f-11f1-a815-7ced8df42514%22%2C%22timestamp%22%3A%222026-05-29T09%3A19%3A49.8312159Z%22%7D/ComponentId~/%7B%22Name%22%3A%22at22-platform-ai%22%2C%22ResourceGroup%22%3A%22altinnplatform-at22-rg%22%2C%22SubscriptionId%22%3A%22de41df22-8dd0-435b-98dd-6152cd371e92%22%7D)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
