### PR TITLE
fix: instance delegation authorize returns NotApplicable for dialog-id/correspondence instances (#3276)

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Altinn.AccessManagement.Core.csproj
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Altinn.AccessManagement.Core.csproj
@@ -18,6 +18,10 @@
     </ItemGroup>
 
     <ItemGroup>
+      <InternalsVisibleTo Include="AccessMgmt.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
       <ProjectReference Include="..\..\..\..\libs\Altinn.Authorization.Api.Contracts\src\Altinn.Authorization.Api.Contracts\Altinn.Authorization.Api.Contracts.csproj" />
       <ProjectReference Include="..\..\..\..\pkgs\Altinn.Authorization.ABAC\src\Altinn.Authorization.ABAC\Altinn.Authorization.ABAC.csproj" />
       <ProjectReference Include="..\..\..\..\libs\Altinn.Authorization.Host\src\Altinn.Authorization.Host.Pipeline\Altinn.Authorization.Host.Pipeline.csproj" />

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/AppsInstanceDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/AppsInstanceDelegationService.cs
@@ -244,6 +244,26 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
         }
     }
 
+    /// <summary>
+    /// Builds the instance identifier to persist for an instance delegation.
+    /// Altinn Apps supply a bare instance guid which must be qualified with the apps instance-id urn and the
+    /// instance owner party id (urn:altinn:instance-id:{partyId}/{guid}) so the PDP can match it on authorize.
+    /// Dialogporten and Correspondence already supply a fully qualified instance urn
+    /// (urn:altinn:dialog-id:..., urn:altinn:correspondence-id:...) which must be stored verbatim; qualifying it
+    /// would produce a value the PDP can never match, yielding NotApplicable instead of Permit.
+    /// </summary>
+    internal static string BuildInstanceStorageId(int partyId, string instanceId)
+    {
+        if (instanceId.StartsWith(AuthzConstants.InstanceUrnPrefixes.Apps, StringComparison.OrdinalIgnoreCase)
+            || instanceId.StartsWith(AuthzConstants.InstanceUrnPrefixes.Correspondence, StringComparison.OrdinalIgnoreCase)
+            || instanceId.StartsWith(AuthzConstants.InstanceUrnPrefixes.Dialog, StringComparison.OrdinalIgnoreCase))
+        {
+            return instanceId;
+        }
+
+        return $"{AltinnXacmlConstants.MatchAttributeIdentifiers.InstanceAttribute}:{partyId}/{instanceId}";
+    }
+
     /// <inheritdoc/>
     public async Task<Result<AppsInstanceDelegationResponse>> Delegate(AppsInstanceDelegationRequest request, CancellationToken cancellationToken = default)
     {
@@ -263,8 +283,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
                 return invalidParty!;
             }
 
-            string instanceUrn = $"{AltinnXacmlConstants.MatchAttributeIdentifiers.InstanceAttribute}:{party.PartyId}/{instanceId}";
-            request.InstanceId = instanceUrn;
+            request.InstanceId = BuildInstanceStorageId(party.PartyId, instanceId);
         }
 
         (ValidationErrorBuilder Errors, InstanceRight RulesToHandle, List<RightInternal> RightsAppCantHandle) input = await SetUpDelegationOrRevokeRequest(request, cancellationToken);
@@ -510,8 +529,7 @@ public class AppsInstanceDelegationService : IAppsInstanceDelegationService
                 return invalidParty!;
             }
 
-            string instanceUrn = $"{AltinnXacmlConstants.MatchAttributeIdentifiers.InstanceAttribute}:{party.PartyId}/{instanceId}";
-            request.InstanceId = instanceUrn;
+            request.InstanceId = BuildInstanceStorageId(party.PartyId, instanceId);
         }
 
         (ValidationErrorBuilder Errors, InstanceRight RulesToHandle, List<RightInternal> RightsAppCantHandle) input = await SetUpDelegationOrRevokeRequest(request, cancellationToken);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/AppsInstanceDelegationServiceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/AppsInstanceDelegationServiceTest.cs
@@ -1,0 +1,70 @@
+using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessManagement.Core.Services.Implementation;
+
+namespace Altinn.AccessManagement.Tests.Services;
+
+/// <summary>
+/// Pure-logic unit tests for <see cref="AppsInstanceDelegationService.BuildInstanceStorageId"/>.
+///
+/// Regression coverage for the instance-urn translation bug (issue #3276): when the EF persistence
+/// path was active (at23), every instance delegation got the Altinn Apps instance-id prefix
+/// (urn:altinn:instance-id:{partyId}/) prepended. That is correct for Altinn Apps, which supply a
+/// bare instance guid, but wrong for Dialogporten/Correspondence, which already supply a fully
+/// qualified instance urn. The malformed value could never be matched by the PDP on authorize, so
+/// Permit decisions silently became NotApplicable.
+/// </summary>
+public class AppsInstanceDelegationServiceTest
+{
+    private const int PartyId = 50083510;
+
+    [Fact]
+    public void BuildInstanceStorageId_BareAppInstanceGuid_QualifiesWithAppsInstanceUrnAndPartyId()
+    {
+        // Altinn Apps deliver a bare instance guid that must be qualified so the PDP can match it.
+        var result = AppsInstanceDelegationService.BuildInstanceStorageId(PartyId, "0191579e-72bc-7977-af5d-f9e92af4393b");
+
+        result.Should().Be("urn:altinn:instance-id:50083510/0191579e-72bc-7977-af5d-f9e92af4393b");
+    }
+
+    [Fact]
+    public void BuildInstanceStorageId_DialogPortenUrn_StoredVerbatim()
+    {
+        // Dialogporten dialogs arrive as a complete urn and must be stored as-is (issue #3276).
+        const string dialogUrn = "urn:altinn:dialog-id:019e7305-5158-708f-b91d-e9af7a06b31b";
+
+        var result = AppsInstanceDelegationService.BuildInstanceStorageId(PartyId, dialogUrn);
+
+        result.Should().Be(dialogUrn);
+    }
+
+    [Fact]
+    public void BuildInstanceStorageId_CorrespondenceUrn_StoredVerbatim()
+    {
+        const string correspondenceUrn = "urn:altinn:correspondence-id:019e7305-5158-708f-b91d-e9af7a06b31b";
+
+        var result = AppsInstanceDelegationService.BuildInstanceStorageId(PartyId, correspondenceUrn);
+
+        result.Should().Be(correspondenceUrn);
+    }
+
+    [Fact]
+    public void BuildInstanceStorageId_AlreadyQualifiedAppsUrn_NotDoubleQualified()
+    {
+        // Guards against re-prefixing an already qualified apps instance urn.
+        const string appsUrn = AuthzConstants.InstanceUrnPrefixes.Apps + "50083510/0191579e-72bc-7977-af5d-f9e92af4393b";
+
+        var result = AppsInstanceDelegationService.BuildInstanceStorageId(PartyId, appsUrn);
+
+        result.Should().Be(appsUrn);
+    }
+
+    [Theory]
+    [InlineData("URN:ALTINN:DIALOG-ID:019e7305-5158-708f-b91d-e9af7a06b31b")]
+    [InlineData("Urn:Altinn:Correspondence-Id:019e7305-5158-708f-b91d-e9af7a06b31b")]
+    public void BuildInstanceStorageId_PrefixMatchIsCaseInsensitive_StoredVerbatim(string instanceUrn)
+    {
+        var result = AppsInstanceDelegationService.BuildInstanceStorageId(PartyId, instanceUrn);
+
+        result.Should().Be(instanceUrn);
+    }
+}


### PR DESCRIPTION
## Hva

PDP `authorize` for instansdelegeringer av Dialogporten-dialoger ga `NotApplicable` der `Permit` var forventet (observert i at23).

Når EF-persisteringen er aktiv ble instans-id-en til **alle** instansdelegeringer fra plattform-token Apps-APIet kvalifisert med Altinn Apps-prefikset:

```
urn:altinn:instance-id:{partyId}/{instanceId}
```

Det er riktig bare for Altinn Apps, som sender en bar instans-guid. Dialogporten og Correspondence sender en allerede ferdig kvalifisert urn (`urn:altinn:dialog-id:<guid>`), så lagret verdi ble:

```
urn:altinn:instance-id:50083510/urn:altinn:dialog-id:019e7305-...   (lagret)
urn:altinn:dialog-id:019e7305-...                                    (det PDP slår opp)
```

Disse matcher aldri, så autorisering faller gjennom til `NotApplicable`. Den gamle persisteringen (tt02) lagret urn-en verbatim og matchet derfor.

## Endring

- Ny `BuildInstanceStorageId`: kvalifiserer kun bare app-instans-id-er, og lagrer allerede kvalifiserte instans-urn-er (dialog-id / correspondence-id / instance-id) verbatim. Brukt i både `Delegate` og `Revoke`.
- Enhetstester for formatlogikken (app-guid kvalifiseres, dialog-id/correspondence lagres uendret, ingen dobbel-kvalifisering, case-insensitiv prefiksmatch).

## Merknad

Fikser nye delegeringer. Eksisterende rader skrevet med feil `InstanceId` i at23 må re-delegeres (testdata, ingen datamigrering).

Closes #3276