### PR TITLE
fix(accmgmt): correct vergemal-namsmannen package URN prefix

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/PackageConstants.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/PackageConstants.cs
@@ -7097,7 +7097,7 @@ public static class PackageConstants
             Name = "Namsmannen - Tvangsfullbyrdelse, herunder behandling i forliksrådet",
             Code = "vergemal-namsmannen-tvangsfullbyrdelse-forliksradet",
             Description = "Gjelder representasjon i saker om tvangsfullbyrdelse etter tvangsfullbyrdelsesloven, herunder eventuell behandling i forliksrådet av slike saker og oppfølging av saken hos innkrevingsmyndigheten.",
-            Urn = "urn:altinn:accesspackage:namsmannen-tvangsfullbyrdelse-forliksradet",
+            Urn = "urn:altinn:accesspackage:vergemal-namsmannen-tvangsfullbyrdelse-forliksradet",
             IsDelegable = false,
             IsAssignable = false,
             IsAvailableForServiceOwners = true,


### PR DESCRIPTION
Corrects the URN of the guardianship access package "Namsmannen - Tvangsfullbyrdelse, herunder behandling i forliksrådet" in `PackageConstants.cs`, which was missing the `vergemal-` prefix used by every other package in the Guardianship area group.

- Before: `urn:altinn:accesspackage:namsmannen-tvangsfullbyrdelse-forliksradet`
- After: `urn:altinn:accesspackage:vergemal-namsmannen-tvangsfullbyrdelse-forliksradet`

The package's `Code` was already `vergemal-namsmannen-tvangsfullbyrdelse-forliksradet`, so the URN was inconsistent with its own code and with its sibling `vergemal-namsmannen-gjeldsordning`. No code referenced the old un-prefixed URN string.

Once this is deployed, the `vergemal-` allow-list exception added for this URN in the PrivatePerson delegationcheck Bruno test (#3208) can be removed.


Closes #3345
