### PR TITLE
Show fully-qualified test names; normalize PEP test namespaces

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/xunit.runner.json
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/xunit.runner.json
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/xunit.runner.json
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/xunit.runner.json
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/xunit.runner.json
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/xunit.runner.json
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/xunit.runner.json
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Lease.Tests/xunit.runner.json
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Lease.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/xunit.runner.json
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }

--- a/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/xunit.runner.json
+++ b/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/AppAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/AppAccessHandlerTest.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Altinn.AccessManagement.Core.Models;
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+using Altinn.Common.PEP.Authorization;
 using Altinn.Common.PEP.Configuration;
 using Altinn.Common.PEP.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -12,7 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 
-namespace Altinn.Common.PEP.Authorization
+namespace Altinn.Authorization.PEP.Tests
 {
     public class AppAccessHandlerTest
     {

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/DecisionHelperTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/DecisionHelperTest.cs
@@ -10,7 +10,7 @@ using Altinn.Common.PEP.Models;
 
 using Xunit;
 
-namespace UnitTests
+namespace Altinn.Authorization.PEP.Tests
 {
     public class DecisionHelperTest
     {

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ResourceAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ResourceAccessHandlerTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+using Altinn.Common.PEP.Authorization;
 using Altinn.Common.PEP.Configuration;
 using Altinn.Common.PEP.Interfaces;
 
@@ -16,7 +17,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
-namespace Altinn.Common.PEP.Authorization
+namespace Altinn.Authorization.PEP.Tests
 {
     public class ResourceAccessHandlerTest
     {

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ScopeAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ScopeAccessHandlerTest.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Authorization;
 
 using Xunit;
 
-namespace UnitTests
+namespace Altinn.Authorization.PEP.Tests
 {
     public class ScopeAccessHandlerTest
     {

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/xunit.runner.json
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/xunit.runner.json
@@ -3,8 +3,8 @@
   "parallelizeAssembly": true,
   "parallelizeTestCollections": true,
   "maxParallelThreads": 4,
-  "methodDisplay": "method",
-  "methodDisplayOptions": "all",
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false
 }


### PR DESCRIPTION
## What

- In all 11 `xunit.runner.json`: set `methodDisplay` to `classAndMethod` and `methodDisplayOptions` to `none`. A test run now shows `Namespace.Class.Method`, with the underscores in `Method_Scenario_Expected` names preserved instead of replaced with spaces.
- Move 4 PEP test files out of the bare `UnitTests` and the production `Altinn.Common.PEP.Authorization` namespaces into `Altinn.Authorization.PEP.Tests` (adding `using Altinn.Common.PEP.Authorization` to the two that referenced the handlers by namespace).

## Why

From a full test run it was hard to tell where a test lived: output carried only the bare method name, and `methodDisplayOptions: all` flattened the underscore-delimited names into spaced words.

## Verified

- `Altinn.Authorization.PEP.Tests` builds (0 errors) and passes (92/92). TRX `testName` now reads e.g. `Altinn.Authorization.PEP.Tests.AppAccessHandlerTest.HandleRequirementAsync_TC01Async`.
- The change to the other test projects is configuration only.

Closes #3360
Related to #3359
