### PR TITLE
Add Unit/Integration category traits to all test classes

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -42,6 +42,16 @@
                 </PackageReference>
             </ItemGroup>
 
+            <!-- Shared [UnitTest] / [IntegrationTest] category markers, compiled
+                 into every test assembly (linked, so no project reference needed).
+                 Only meaningful for xUnit v3 (ITraitAttribute). -->
+            <ItemGroup Condition=" '$(IsTestProject)' == 'true' And '$(XUnitVersion)' == 'v3' ">
+                <Compile Include="$(MSBuildThisFileDirectory)testing\TestCategories.cs">
+                    <Link>Properties\TestCategories.cs</Link>
+                </Compile>
+                <Using Include="Altinn.Authorization.Testing" />
+            </ItemGroup>
+
             <ItemGroup Condition=" '$(IsTestLibrary)' == 'true' ">
                 <PackageReference Include="xunit.assert" Condition=" '$(XUnitVersion)' == 'v2' " />
                 <PackageReference Include="xunit.extensibility.core" Condition=" '$(XUnitVersion)' == 'v2' " />

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Asserters/AsserterTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Asserters/AsserterTests.cs
@@ -5,6 +5,7 @@ namespace Altinn.AccessManagement.Tests.Asserters;
 /// <summary>
 /// summary
 /// </summary>
+[UnitTest]
 public class AsserterTests
 {
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Asserters/AttributeMatchAsserterTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Asserters/AttributeMatchAsserterTests.cs
@@ -11,6 +11,7 @@ namespace Altinn.AccessManagement.Tests.Asserters;
 /// <summary>
 /// summary
 /// </summary>
+[UnitTest]
 public class AttributeMatchAsserterTests
 {
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Configuration/ConsentMigrationSettingsValidationTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Configuration/ConsentMigrationSettingsValidationTests.cs
@@ -6,6 +6,7 @@ namespace AccessMgmt.Tests.Configuration;
 /// <summary>
 /// Tests for <see cref="ConsentMigrationSettings"/> validation
 /// </summary>
+[UnitTest]
 public class ConsentMigrationSettingsValidationTests
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Altinn2RightsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Altinn2RightsControllerTest.cs
@@ -33,6 +33,7 @@ namespace Altinn.AccessManagement.Tests.Controllers;
 /// <summary>
 /// Controller test for <see cref="RightsInternalController"/>
 /// </summary>
+[IntegrationTest]
 public class Altinn2RightsControllerTest : IClassFixture<ApiFixture>
 {
     private readonly ApiFixture _fixture;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Bff/ConsentControllerTestBFF.cs
@@ -43,6 +43,7 @@ namespace AccessMgmt.Tests.Controllers.Bff
     /// <c>WebApplicationFixture</c> provided via
     /// <c>PostgresServer.NewEFDatabase()</c>.
     /// </summary>
+    [IntegrationTest]
     public class ConsentControllerTestBFF : IAsyncLifetime
     {
         private LegacyApiFixture _fixture = null!;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/DelegationsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/DelegationsControllerTest.cs
@@ -35,6 +35,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
     /// <summary>
     /// Test class for <see cref="DelegationsController"></see>
     /// </summary>
+    [IntegrationTest]
     [Collection("DelegationController Tests")]
     public class DelegationsControllerTest : IClassFixture<ApiFixture>
     {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterprise.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterprise.cs
@@ -36,6 +36,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
     /// <summary>
     /// Tests for maskinporten controller for consent
     /// </summary>
+    [IntegrationTest]
     public class ConsentControllerTestEnterprise : IClassFixture<LegacyApiFixture>
     {
         private readonly Mock<IAmPartyRepository> _mockAmPartyRepository;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
@@ -47,6 +47,7 @@ namespace AccessMgmt.Tests.Controllers.Enterprise
     /// <summary>
     /// Tests for maskinporten controller for consent
     /// </summary>
+    [IntegrationTest]
     public class ConsentControllerTestEnterpriseFetchStatusChanges : IAsyncLifetime
     {
         private readonly Mock<IAmPartyRepository> _mockAmPartyRepository;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinPorten/ConsentControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinPorten/ConsentControllerTest.cs
@@ -36,6 +36,7 @@ namespace AccessMgmt.Tests.Controllers.MaskinPorten
     /// <summary>
     /// Tests for maskinporten controller for consent
     /// </summary>
+    [IntegrationTest]
     public class ConsentControllerTest : IClassFixture<LegacyApiFixture>
     {
         private readonly Mock<IAmPartyRepository> _mockAmPartyRepository;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinportenSchemaControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/MaskinportenSchemaControllerTest.cs
@@ -115,6 +115,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
     /// <summary>
     /// Test class for <see cref="MaskinportenSchemaController"></see>
     /// </summary>
+    [IntegrationTest]
     public class MaskinportenSchemaControllerTest : IClassFixture<ApiFixture>
     {
         private readonly ApiFixture _fixture;
@@ -1877,6 +1878,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
     /// <see cref="PepWithPDPAuthorizationMock"/>. Split per recipe rule 6 (one
     /// mutually-exclusive DI configuration per class).
     /// </summary>
+    [IntegrationTest]
     public class MaskinportenSchemaPdpPermitControllerTest : IClassFixture<ApiFixture>
     {
         private readonly ApiFixture _fixture;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/MetadataTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/MetadataTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AccessMgmt.Tests.Controllers.Metadata;
 
+[IntegrationTest]
 public class MetadataTests : IClassFixture<PostgresFixture>
 {
     private readonly AppDbContext _db;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerIntegrationTests.cs
@@ -27,6 +27,7 @@ namespace AccessMgmt.Tests.Controllers.Metadata;
 /// <c>TranslateDeepAsync</c> not recursing into nested DTOs; <c>Accept-Language</c>
 /// locale fallback; empty-vs-missing disambiguation in multi-branch actions.
 /// </summary>
+[IntegrationTest]
 public class PackagesControllerIntegrationTests : IClassFixture<PostgresFixture>
 {
     // Seed-data IDs / URNs / names — kept in sync with the Bruno collection so a

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/PackagesControllerTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace AccessMgmt.Tests.Controllers.Metadata;
 
+[UnitTest]
 public class PackagesControllerTest
 {
     private static PackagesController CreateController(

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/RolesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/RolesControllerTest.cs
@@ -8,6 +8,7 @@ using Moq;
 
 namespace AccessMgmt.Tests.Controllers.Metadata;
 
+[UnitTest]
 public class RolesControllerTest
 {
     // A valid role code that exists in RoleConstants (rettighetshaver).

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/TypesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/Metadata/TypesControllerTest.cs
@@ -3,6 +3,7 @@ using Altinn.Authorization.Api.Contracts.AccessManagement;
 
 namespace AccessMgmt.Tests.Controllers.Metadata;
 
+[UnitTest]
 public class TypesControllerTest
 {
     private static TypesController CreateController() => new TypesController();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PartyControllerTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PartyControllerTests.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.Options;
 // provides one host per IClassFixture<ApiFixture> instance.
 namespace Altinn.AccessManagement.Api.Internal.IntegrationTests.Controllers
 {
+    [IntegrationTest]
     public class PartyControllerTests : IClassFixture<ApiFixture>
     {
         private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PolicyInformationPointControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PolicyInformationPointControllerTest.cs
@@ -22,6 +22,7 @@ namespace Altinn.AccessManagement.Tests.Controllers;
 /// <summary>
 /// Test class for <see cref="PolicyInformationPointController"></see>
 /// </summary>
+[IntegrationTest]
 public class PolicyInformationPointControllerTest : IClassFixture<ApiFixture>
 {
     private readonly HttpClient _client;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PolicyInformationPointResourcesAndInstancesTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PolicyInformationPointResourcesAndInstancesTest.cs
@@ -18,6 +18,7 @@ namespace Altinn.AccessManagement.Tests.Controllers;
 /// Integration tests for the GetAllDelegationChanges endpoint in PolicyInformationPointController.
 /// Tests resource delegations using the database container.
 /// </summary>
+[IntegrationTest]
 public class PolicyInformationPointResourcesAndInstancesTest : IClassFixture<ApiFixture>
 {
     private readonly HttpClient _client;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PolicyInformationPointRolesAndAccessPackagesTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/PolicyInformationPointRolesAndAccessPackagesTest.cs
@@ -12,6 +12,7 @@ namespace Altinn.AccessManagement.Tests.Controllers;
 /// Integration tests for the GetRolesAndAccessPackages endpoint in PolicyInformationPointController.
 /// Reuses test data from <see cref="TestData"/>.
 /// </summary>
+[IntegrationTest]
 public class PolicyInformationPointRolesAndAccessPackagesTest : IClassFixture<ApiFixture>
 {
     private readonly HttpClient _client;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceControllerTest.cs
@@ -32,6 +32,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
     /// <summary>
     /// Tests for AccessManagmet Resource metadata
     /// </summary>
+    [IntegrationTest]
     [Collection("ResourceController Tests")]
     public class ResourceControllerTest : IClassFixture<ApiFixture>
     {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceOwnerAPI/AppsInstanceDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/ResourceOwnerAPI/AppsInstanceDelegationControllerTest.cs
@@ -32,6 +32,7 @@ using Microsoft.Extensions.Options;
 // See: overhaul part-1 step 16
 namespace Altinn.AccessManagement.Tests.Controllers;
 
+[IntegrationTest]
 public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
 {
     private readonly ApiFixture _fixture;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/RightsInternalControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/RightsInternalControllerTest.cs
@@ -34,6 +34,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
     /// <summary>
     /// Test class for <see cref="RightsInternalController"></see>
     /// </summary>
+    [IntegrationTest]
     public class RightsInternalControllerTest : IClassFixture<ApiFixture>
     {
         private readonly ApiFixture _fixture;
@@ -1649,6 +1650,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
     /// <see cref="IPDP"/>. Split out per recipe rule 6 (one mutually-exclusive DI
     /// configuration per class).
     /// </summary>
+    [IntegrationTest]
     public class RightsInternalControllerWithPdpMockTest : IClassFixture<ApiFixture>
     {
         private readonly ApiFixture _fixture;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/V2ResourceControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Controllers/V2ResourceControllerTest.cs
@@ -24,6 +24,7 @@ namespace Altinn.AccessManagement.Tests.Controllers;
 /// <summary>
 /// <see cref="ResourceController"/>
 /// </summary>
+[IntegrationTest]
 public class V2ResourceControllerTest : IClassFixture<LegacyApiFixture>
 {
     private readonly HttpClient _client;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Fixtures/LegacyApiFixtureSmokeTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Fixtures/LegacyApiFixtureSmokeTest.cs
@@ -22,6 +22,7 @@ namespace Altinn.AccessManagement.Tests.Fixtures;
 /// Migration of the six remaining <c>WebApplicationFixture</c> consumers
 /// is tracked as follow-up sub-steps 16.4a/b.
 /// </remarks>
+[IntegrationTest]
 public class LegacyApiFixtureSmokeTest(LegacyApiFixture fixture) : IClassFixture<LegacyApiFixture>
 {
     private LegacyApiFixture Fixture { get; } = fixture;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HealthCheckTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HealthCheckTests.cs
@@ -13,6 +13,7 @@ namespace Altinn.AccessManagement.Tests.Health
     /// <summary>
     /// Health check
     /// </summary>
+    [IntegrationTest]
     public class HealthCheckTests : IClassFixture<ApiFixture>
     {
         private readonly HttpClient _client;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/AuthenticationHelperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/AuthenticationHelperTest.cs
@@ -13,6 +13,7 @@ namespace Altinn.AccessManagement.Tests.Helpers;
 /// path for system-user uuids, and the GetAuthenticatedPartyUuid
 /// composition (PartyUuid wins over SystemUserUuid when both present).
 /// </summary>
+[UnitTest]
 public class AuthenticationHelperTest
 {
     private static HttpContext CtxWith(params Claim[] claims)

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/DelegationHelperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/DelegationHelperTest.cs
@@ -15,6 +15,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
     /// <summary>
     /// Test class for <see cref="DelegationHelper"></see>
     /// </summary>
+    [UnitTest]
     public class DelegationHelperTest
     {
         private PolicyRetrievalPointMock _prpMock = new PolicyRetrievalPointMock(new HttpContextAccessor(), new Mock<ILogger<PolicyRetrievalPointMock>>().Object);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/Extensions/ConsentStatusChangeExtensionsTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/Extensions/ConsentStatusChangeExtensionsTests.cs
@@ -26,6 +26,7 @@ namespace AccessMgmt.Tests.Helpers.Extensions;
 //    FluentAssertions are global usings via Directory.Build.targets, so no
 //    `using` directives are needed for them.
 // ---------------------------------------------------------------------------
+[UnitTest]
 public class ConsentStatusChangeExtensionsTests
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/Extensions/EnumExtensionTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/Extensions/EnumExtensionTest.cs
@@ -3,6 +3,7 @@ using Altinn.AccessManagement.Enums;
 
 namespace Altinn.AccessManagement.Tests.Helpers.Extensions
 {
+    [UnitTest]
     public class EnumExtensionTest
     {
         [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/Extensions/GuidExtensionTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/Extensions/GuidExtensionTest.cs
@@ -2,6 +2,7 @@
 
 namespace Altinn.AccessManagement.Tests.Helpers.Extensions
 {
+    [UnitTest]
     public class GuidExtensionTest
     {
         [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/JwtTokenUtilTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/JwtTokenUtilTest.cs
@@ -9,6 +9,7 @@ namespace Altinn.AccessManagement.Tests.Helpers;
 /// Pins the cookie-first / Authorization-header-fallback resolution chain
 /// and the "Bearer " prefix stripping rules.
 /// </summary>
+[UnitTest]
 public class JwtTokenUtilTest
 {
     private const string CookieName = "AltinnStudioRuntime";

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/PolicyHelperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Helpers/PolicyHelperTest.cs
@@ -14,6 +14,7 @@ namespace Altinn.AccessManagement.Tests.Helpers
     /// <summary>
     /// Test class for <see cref="PolicyHelper"></see>
     /// </summary>
+    [UnitTest]
     public class PolicyHelperTest
     {
         private readonly PolicyRetrievalPointMock _policyRetrievalPointMock;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/HostedServices/ConsentMigrationHostedServiceTests.cs
@@ -14,6 +14,7 @@ namespace AccessMgmt.Tests.HostedServices;
 /// <summary>
 /// Tests for <see cref="ConsentMigrationHostedService"/>
 /// </summary>
+[UnitTest]
 public class ConsentMigrationHostedServiceTests : IDisposable
 {
     private readonly Mock<IConsentMigrationSyncService> _syncServiceMock;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/AssignmentModelTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/AssignmentModelTest.cs
@@ -2,6 +2,7 @@
 
 namespace Altinn.AccessManagement.Tests.Models
 {
+    [UnitTest]
     [Collection("Models Test")]
     public class AssignmentModelTest
     {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/DelegationModelTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/DelegationModelTest.cs
@@ -3,6 +3,7 @@ using Altinn.AccessMgmt.PersistenceEF.Models;
 
 namespace Altinn.AccessManagement.Tests.Models
 {
+    [UnitTest]
     [Collection("Models Test")]
     public class DelegationModelTest
     {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/Urn/ActionIdentifierTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/Urn/ActionIdentifierTest.cs
@@ -3,6 +3,7 @@ using Altinn.AccessManagement.Core.Models.Rights;
 
 namespace Altinn.AccessManagement.Tests.Models.Urn
 {
+    [UnitTest]
     public class ActionIdentifierTest
     {
         private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/Urn/OrganizationNumberTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/Urn/OrganizationNumberTest.cs
@@ -3,6 +3,7 @@ using Altinn.Authorization.Api.Contracts.Register;
 
 namespace Altinn.AccessManagement.Tests.Models.Urn
 {
+    [UnitTest]
     [Collection("Models Test")]
     public class OrganizationNumberTest
     {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/Urn/PersonIdentifierTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/Urn/PersonIdentifierTest.cs
@@ -11,6 +11,7 @@ namespace Altinn.AccessMgmt.Tests.Models.Urn;
 /// PersonIdentifier algorithm), length and content guards, JSON
 /// round-tripping, and equality semantics.
 /// </summary>
+[UnitTest]
 public class PersonIdentifierTest
 {
     // ── Length and content guards ─────────────────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/Urn/ResourceIdentifierTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/Urn/ResourceIdentifierTest.cs
@@ -3,6 +3,7 @@ using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 
 namespace Altinn.AccessManagement.Tests.Models.Urn
 {
+    [UnitTest]
     public class ResourceIdentifierTest
     {
         private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/Urn/ResourceInstanceIdentifierTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Models/Urn/ResourceInstanceIdentifierTest.cs
@@ -3,6 +3,7 @@ using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 
 namespace Altinn.AccessManagement.Tests.Models.Urn
 {
+    [UnitTest]
     public class ResourceInstanceIdentifierTest
     {
         private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/PolicyAdministrationPointTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/PolicyAdministrationPointTest.cs
@@ -24,6 +24,7 @@ namespace Altinn.AccessManagement.Tests
     /// <summary>
     /// Test class for <see cref="PolicyAdministrationPoint"></see>
     /// </summary>
+    [UnitTest]
     [Collection("PolicyAdministrationPointTest")]
     public class PolicyAdministrationPointTest
     {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Queries/ConnectionQueryFilterTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Queries/ConnectionQueryFilterTest.cs
@@ -12,6 +12,7 @@ namespace Altinn.AccessMgmt.Tests.Queries;
 /// unsafe broad-scan queries through Validate or block legitimate
 /// instance-only queries.
 /// </summary>
+[UnitTest]
 public class ConnectionQueryFilterTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Repositories/DelegationMetadataEFRepositoryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Repositories/DelegationMetadataEFRepositoryTests.cs
@@ -20,6 +20,7 @@ namespace Altinn.AccessManagement.Tests.Repositories;
 /// Repository tests for <see cref="DelegationMetadataEF"/> focusing on cascading 
 /// assignment revoke logic for MaskinportenSchema resources and Supplier role assignments.
 /// </summary>
+[IntegrationTest]
 public class DelegationMetadataEFRepositoryTests : IAsyncLifetime
 {
     private PostgresDatabase? _database;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Resolvers/Altinn/AltinnOrganizationResolverTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Resolvers/Altinn/AltinnOrganizationResolverTests.cs
@@ -11,6 +11,7 @@ namespace Altinn.AccessManagement.Tests.Resolvers.Altinn;
 /// <summary>
 /// Resolver tests
 /// </summary>
+[UnitTest]
 [Collection(nameof(AttributeResolver))]
 public class AltinnOrganizationResolverTests
 {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Resolvers/Altinn/AltinnPersonResolverTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Resolvers/Altinn/AltinnPersonResolverTests.cs
@@ -11,6 +11,7 @@ namespace Altinn.AccessManagement.Tests.Resolvers.Altinn;
 /// <summary>
 /// Resolver tests
 /// </summary>
+[UnitTest]
 [Collection(nameof(AttributeResolver))]
 public class AltinnPersonResolverTests
 {

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Resolvers/BaseUrnTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Resolvers/BaseUrnTest.cs
@@ -11,6 +11,7 @@ namespace Altinn.AccessManagement.Tests.Resolvers;
 /// <c>urn:altinn:person:userid</c>) would silently break URN matching
 /// across the entire access-management surface.
 /// </summary>
+[UnitTest]
 public class BaseUrnTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/AMPartyServiceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/AMPartyServiceTest.cs
@@ -14,6 +14,7 @@ namespace AccessMgmt.Tests.Services;
 /// propagation. Heavier DB-bound logic is left to integration tests against
 /// <c>EntityService</c> at the controller level.
 /// </summary>
+[UnitTest]
 public class AMPartyServiceTest
 {
     private static readonly Guid PersonTypeId = EntityTypeConstants.Person.Id;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/AuditServiceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/AuditServiceTest.cs
@@ -16,6 +16,7 @@ namespace AccessMgmt.Tests.Services;
 /// <see cref="AuditServiceOwnerConsumerAttribute"/> branch needs an
 /// <c>AppDbContext</c> lookup and is left to integration tests.
 /// </summary>
+[UnitTest]
 public class AuditServiceTest
 {
     private const string SystemGuid = "00000000-0000-0000-0000-000000000001";

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConnectionQueryTests.cs
@@ -10,6 +10,7 @@ using DelegationPackage = Altinn.AccessMgmt.PersistenceEF.Models.DelegationPacka
 
 namespace AccessMgmt.Tests.Services;
 
+[IntegrationTest]
 public class ConnectionQueryTests : IClassFixture<PostgresFixture>
 {
     private readonly AppDbContext _db;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentMigrationServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentMigrationServiceTests.cs
@@ -13,6 +13,7 @@ namespace AccessMgmt.Tests.Services;
 /// <summary>
 /// Tests for <see cref="ConsentMigrationService"/>
 /// </summary>
+[UnitTest]
 public class ConsentMigrationServiceTests
 {
     private readonly Mock<IConsent> _consentServiceMock;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentMigrationSyncServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentMigrationSyncServiceTests.cs
@@ -14,6 +14,7 @@ namespace AccessMgmt.Tests.Services;
 /// <summary>
 /// Tests for <see cref="ConsentMigrationSyncService"/>
 /// </summary>
+[UnitTest]
 public class ConsentMigrationSyncServiceTests
 {
     private readonly Mock<IServiceProvider> _serviceProviderMock;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/ConsentServiceTests.cs
@@ -21,6 +21,7 @@ namespace AccessMgmt.Tests.Services;
 /// <summary>
 /// Tests for <see cref="ConsentService"/>
 /// </summary>
+[UnitTest]
 public class ConsentServiceTests
 {
     private readonly Mock<ILogger<ConsentService>> _loggerMock;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/DelegationRequestProxyTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/DelegationRequestProxyTest.cs
@@ -10,6 +10,7 @@ using Moq;
 
 namespace AccessMgmt.Tests.Services;
 
+[UnitTest]
 public class DelegationRequestProxyTest
 {
     private static DelegationRequestProxy CreateSut(

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/MaskinportenSupplierServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/MaskinportenSupplierServiceTests.cs
@@ -26,6 +26,7 @@ namespace AccessMgmt.Tests.Services;
 /// This class owns an isolated, additively-seeded set of entities so each mutating test uses a distinct
 /// consumer/supplier pair and the tests stay independent of execution order.
 /// </summary>
+[IntegrationTest]
 public class MaskinportenSupplierServiceTests : IClassFixture<ApiFixture>
 {
     // Distinct org pairs so order-independent: each mutating test owns its own pair.

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/PartyServiceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/PartyServiceTest.cs
@@ -17,6 +17,7 @@ namespace AccessMgmt.Tests.Services;
 /// meaningful; these tests verify the validation branches against a real
 /// (seeded) database.
 /// </summary>
+[IntegrationTest]
 public class PartyServiceTest : IClassFixture<PostgresFixture>
 {
     private readonly AppDbContext _db;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/RequestServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/RequestServiceTests.cs
@@ -28,6 +28,7 @@ using Microsoft.Extensions.Options;
 //          (Pattern A-isolated) — not eligible for sharing.
 namespace AccessMgmt.Tests.Services;
 
+[IntegrationTest]
 public class RequestServiceTests : IClassFixture<PostgresFixture>
 {
     private static readonly AuditValues TestAudit = new(SystemEntityConstants.StaticDataIngest, SystemEntityConstants.StaticDataIngest);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/TranslationServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Services/TranslationServiceTests.cs
@@ -29,6 +29,7 @@ namespace AccessMgmt.Tests.Services;
 /// NOTE: All tests now use normalized ISO 639-2 language codes (eng, nob, nno).
 /// Language code normalization should happen in the middleware before reaching the service.
 /// </summary>
+[IntegrationTest]
 public class TranslationServiceTests : IClassFixture<PostgresFixture>
 {
     private readonly AppDbContext _db;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Translation/DeepTranslationExtensionsTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Translation/DeepTranslationExtensionsTests.cs
@@ -13,6 +13,7 @@ namespace AccessMgmt.Tests.Translation;
 /// <summary>
 /// Tests for DeepTranslationExtensions to ensure nested objects are properly translated.
 /// </summary>
+[IntegrationTest]
 public class DeepTranslationExtensionsTests : IClassFixture<PostgresFixture>
 {
     private readonly PostgresFixture _fixture;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utilities/HashUtilTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utilities/HashUtilTest.cs
@@ -5,6 +5,7 @@ namespace Altinn.AccessManagement.Tests.Utilities;
 /// <summary>
 /// Pure-logic unit tests for <see cref="HashUtil.GetOrderIndependentHashCode{T}"/>.
 /// </summary>
+[UnitTest]
 public class HashUtilTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utilities/IdentifierUtilTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utilities/IdentifierUtilTest.cs
@@ -8,6 +8,7 @@ namespace Altinn.AccessManagement.Tests.Utilities;
 /// Pure-logic unit tests for <see cref="IdentifierUtil"/>.
 /// All methods are static; no DI or containers required.
 /// </summary>
+[UnitTest]
 public class IdentifierUtilTest
 {
     // ── IsValidOrganizationNumber ─────────────────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utilities/MaskinportenSchemaAuthorizerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Utilities/MaskinportenSchemaAuthorizerTest.cs
@@ -18,6 +18,7 @@ namespace Altinn.AccessManagement.Tests.Utilities;
 /// delegations, and a false-negative would block legitimate
 /// supplier/admin lookups.
 /// </summary>
+[UnitTest]
 public class MaskinportenSchemaAuthorizerTest
 {
     private const string AdminScope = AuthzConstants.SCOPE_MASKINPORTEN_DELEGATIONS_ADMIN;

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Internal.Tests/Controllers/InternalConnectionsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Internal.Tests/Controllers/InternalConnectionsControllerTest.cs
@@ -21,6 +21,7 @@ public class InternalConnectionsControllerTest
     /// <summary>
     /// <see cref="InternalConnectionsController.PostSelfIdentifiedUsers(Guid, Guid, CancellationToken)"/>
     /// </summary>
+    [IntegrationTest]
     public class PostSelfIdentifiedUsers : IClassFixture<ApiFixture>
     {
         public PostSelfIdentifiedUsers(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/InternalConnectionsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/InternalConnectionsControllerTest.cs
@@ -12,6 +12,7 @@ using ValidationErrors = Altinn.AccessMgmt.Core.Utils.Models.ValidationErrors;
 
 namespace Altinn.AccessManagement.Api.Tests.Controllers;
 
+[UnitTest]
 public class InternalConnectionsControllerTest
 {
     private static readonly Guid Party = Guid.NewGuid();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/PartyControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/PartyControllerTest.cs
@@ -14,6 +14,7 @@ using ValidationErrors = Altinn.AccessMgmt.Core.Utils.Models.ValidationErrors;
 
 namespace Altinn.AccessManagement.Api.Tests.Controllers;
 
+[UnitTest]
 public class PartyControllerTest
 {
     private static PartyController CreateSut(IPartyService svc)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Controllers/SystemUserClientDelegationControllerTest.cs
@@ -13,6 +13,7 @@ using ValidationErrors = Altinn.AccessMgmt.Core.Utils.Models.ValidationErrors;
 
 namespace Altinn.AccessManagement.Api.Tests.Controllers;
 
+[UnitTest]
 public class SystemUserClientDelegationControllerTest
 {
     private static ProblemInstance MakeProblem() =>

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Extensions/ConsentExtensionsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Extensions/ConsentExtensionsTest.cs
@@ -8,6 +8,7 @@ using Altinn.Authorization.Api.Contracts.Register;
 
 namespace Altinn.AccessManagement.Api.Tests.Extensions;
 
+[UnitTest]
 public class ConsentExtensionsTest
 {
     // ── ConsentResourceAttributeExtensions ──────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Internal/UserUtilTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Internal/UserUtilTest.cs
@@ -10,6 +10,7 @@ namespace Altinn.AccessManagement.Api.Tests.Internal;
 /// would NRE on missing claims or default to <c>Guid.Empty</c> instead
 /// of returning <see langword="null"/>.
 /// </summary>
+[UnitTest]
 public class UserUtilTest
 {
     private const string PartyUuidClaim = "urn:altinn:party:uuid";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Other/ProblemsValidation.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Other/ProblemsValidation.cs
@@ -2,6 +2,7 @@
 
 namespace Altinn.AccessManagement.Api.Tests.Other;
 
+[UnitTest]
 public class ProblemsValidation
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/DecisionHelperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/DecisionHelperTest.cs
@@ -11,6 +11,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.AuthorizationHelpers;
 /// Pure-unit tests for the Api.Enduser-specific
 /// <see cref="DecisionHelper"/>'s accessors and PDP validation.
 /// </summary>
+[UnitTest]
 public class DecisionHelperTest
 {
     private static HttpContext CtxWith(params Claim[] claims)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/EndUserResourceAccessHandlerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/AuthorizationHelpers/EndUserResourceAccessHandlerTest.cs
@@ -14,6 +14,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.AuthorizationHelpers;
 /// Tests for <see cref="EndUserResourceAccessHandler"/>, focused on the handling of a
 /// missing or malformed <c>party</c> query parameter (which previously surfaced as a 500).
 /// </summary>
+[UnitTest]
 public class EndUserResourceAccessHandlerTest
 {
     private static (EndUserResourceAccessHandler Handler, Mock<IPDP> Pdp, HttpContext HttpContext) CreateSut(string queryString)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/AuthorizedPartiesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/AuthorizedPartiesControllerTest.cs
@@ -18,6 +18,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Controllers;
 /// <summary>
 /// Tests for <see cref="Altinn.AccessManagement.Api.Enduser.Controllers.AuthorizedPartiesController"/>
 /// </summary>
+[IntegrationTest]
 public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
 {
     public const string Route = "accessmanagement/api/v1/enduser/authorizedparties";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ClientDelegationControllerTest.cs
@@ -27,6 +27,7 @@ public class ClientDelegationControllerTest
     /// <summary>
     /// <see cref="ClientDelegationController.GetMyClients(List{Guid}?, AccessManagement.Api.Enduser.Models.PagingInput, CancellationToken)"/>
     /// </summary>
+    [IntegrationTest]
     public class GetMyClients : IClassFixture<ApiFixture>
     {
         public GetMyClients(ApiFixture fixture)
@@ -230,6 +231,7 @@ public class ClientDelegationControllerTest
     /// <summary>
     /// <see cref="ClientDelegationController.GetClients(Guid, AccessManagement.Api.Enduser.Models.PagingInput, CancellationToken)"/>
     /// </summary>
+    [IntegrationTest]
     public class GetClients : IClassFixture<ApiFixture>
     {
         public GetClients(ApiFixture fixture)
@@ -465,6 +467,7 @@ public class ClientDelegationControllerTest
     /// <summary>
     /// <see cref="ClientDelegationController.GetAgents(Guid, AccessManagement.Api.Enduser.Models.PagingInput, CancellationToken)"/>
     /// </summary>
+    [IntegrationTest]
     public class GetAgents : IClassFixture<ApiFixture>
     {
         public GetAgents(ApiFixture fixture)
@@ -583,6 +586,7 @@ public class ClientDelegationControllerTest
     /// <summary>
     /// <see cref="ClientDelegationController.AddAgent(Guid, Guid?, AccessManagement.Api.Enduser.Models.PersonInput?, CancellationToken)"/>
     /// </summary>
+    [IntegrationTest]
     public class AddAgent : IClassFixture<ApiFixture>
     {
         public AddAgent(ApiFixture fixture)
@@ -669,6 +673,7 @@ public class ClientDelegationControllerTest
     /// <summary>
     /// <see cref="ClientDelegationController.RemoveAgent(Guid, Guid, bool, CancellationToken)"/>
     /// </summary>
+    [IntegrationTest]
     public class DeleteAgent : IClassFixture<ApiFixture>
     {
         public DeleteAgent(ApiFixture fixture)
@@ -797,6 +802,7 @@ public class ClientDelegationControllerTest
     /// <summary>
     /// <see cref="ClientDelegationController.RemoveAgentsClient(Guid, Guid, Guid, bool, CancellationToken)/>
     /// </summary>
+    [IntegrationTest]
     public class RemoveAnAgentsClient : IClassFixture<ApiFixture>
     {
         public RemoveAnAgentsClient(ApiFixture fixture)
@@ -967,6 +973,7 @@ public class ClientDelegationControllerTest
     /// <summary>
     /// <see cref="ClientDelegationController.DelegateAccessPackageToAgent(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
     /// </summary>
+    [IntegrationTest]
     public class DelegateAccessPackageToAgentWithAgentRole : IClassFixture<ApiFixture>
     {
         public DelegateAccessPackageToAgentWithAgentRole(ApiFixture fixture)
@@ -1161,6 +1168,7 @@ public class ClientDelegationControllerTest
         }
     }
 
+    [IntegrationTest]
     public class DelegateAccessPackageToAgentWithCCRRole : IClassFixture<ApiFixture>
     {
         public DelegateAccessPackageToAgentWithCCRRole(ApiFixture fixture)
@@ -1359,6 +1367,7 @@ public class ClientDelegationControllerTest
     /// <see cref="ClientDelegationController.DelegateAccessPackageToAgent(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
     /// Tests that delegating to a system user without an existing Agent Assignment creates the assignment automatically.
     /// </summary>
+    [IntegrationTest]
     public class DelegateAccessPackageToSystemUserWithoutAgentAssignment : IClassFixture<ApiFixture>
     {
         public DelegateAccessPackageToSystemUserWithoutAgentAssignment(ApiFixture fixture)
@@ -1479,6 +1488,7 @@ public class ClientDelegationControllerTest
     /// <summary>
     /// <see cref="ClientDelegationController.DeleteAgentAccessPackage(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
     /// </summary>
+    [IntegrationTest]
     public class DeleteAgentAccessPackageAndDelegation : IClassFixture<ApiFixture>
     {
         public DeleteAgentAccessPackageAndDelegation(ApiFixture fixture)
@@ -1743,6 +1753,7 @@ public class ClientDelegationControllerTest
     /// <summary>
     /// <see cref="ClientDelegationController.DeleteAgentAccessPackage(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
     /// </summary>
+    [IntegrationTest]
     public class DeleteAgentAccessPackage : IClassFixture<ApiFixture>
     {
         public DeleteAgentAccessPackage(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.AddAssignmentPackage.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.AddAssignmentPackage.cs
@@ -38,6 +38,7 @@ public partial class ConnectionsControllerTest
     /// - Jinx Arcane: MD of Kaos (can add packages to Kaos's rightholder connections)
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class AddAssignmentPackage : IClassFixture<ApiFixture>
     {
         public AddAssignmentPackage(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.AddInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.AddInstanceRights.cs
@@ -52,6 +52,7 @@ public partial class ConnectionsControllerTest
     /// - Malin Emilie: managing director of Dumbo Adventures (has DAGL role, can delegate)
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class AddInstanceRights : IClassFixture<ApiFixture>
     {
         private const string SiriusInstanceId = "urn:altinn:instance-id:50083510/c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.AddResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.AddResourceRights.cs
@@ -56,6 +56,7 @@ public partial class ConnectionsControllerTest
     /// that correct scopes are enforced, and that missing connections or invalid resources produce appropriate errors.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class AddResourceRights : IClassFixture<ApiFixture>
     {
         public AddResourceRights(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.AddRightholder.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.AddRightholder.cs
@@ -43,6 +43,7 @@ public partial class ConnectionsControllerTest
     /// Scope enforcement tests ensure only to-others write scope is accepted.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class AddRightholder : IClassFixture<ApiFixture>
     {
         public AddRightholder(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.CheckInstance.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.CheckInstance.cs
@@ -36,6 +36,7 @@ public partial class ConnectionsControllerTest
     /// for the sirius-skattemelding-v1 resource, and that scope and authorization enforcement works.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class CheckInstance : IClassFixture<ApiFixture>
     {
         private const string SiriusInstanceIdForCheck = "urn:altinn:instance-id:50083510/a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5f";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.CheckPackage.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.CheckPackage.cs
@@ -24,6 +24,7 @@ public partial class ConnectionsControllerTest
     /// <summary>
     /// Tests for <see cref="ConnectionsController.CheckPackage(Guid, IEnumerable{Guid}, IEnumerable{string}, CancellationToken)"/>.
     /// </summary>
+    [IntegrationTest]
     public class CheckPackage : IClassFixture<ApiFixture>
     {
         public CheckPackage(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.CheckResource.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.CheckResource.cs
@@ -49,6 +49,7 @@ public partial class ConnectionsControllerTest
     /// package-only access, partial access (some rights granted, some denied), and scope enforcement.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class CheckResource : IClassFixture<ApiFixture>
     {
         public CheckResource(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.DelegationCheckRoles.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.DelegationCheckRoles.cs
@@ -23,6 +23,7 @@ public partial class ConnectionsControllerTest
     /// <summary>
     /// Tests for <see cref="ConnectionsController.DelegationCheckRoles(Guid, CancellationToken)"/>.
     /// </summary>
+    [IntegrationTest]
     public class DelegationCheckRoles : IClassFixture<ApiFixture>
     {
         public DelegationCheckRoles(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetAvailableUsers.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetAvailableUsers.cs
@@ -49,6 +49,7 @@ public partial class ConnectionsControllerTest
     /// to the party and are eligible for new delegations, and that the correct write scope is required.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class GetAvailableUsers : IClassFixture<ApiFixture>
     {
         public GetAvailableUsers(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetConnections.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetConnections.cs
@@ -34,6 +34,7 @@ public partial class ConnectionsControllerTest
     /// that don't match from/to result in 403 Forbidden.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class GetConnections : IClassFixture<ApiFixture>
     {
         public GetConnections(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetInstanceRights.cs
@@ -40,6 +40,7 @@ public partial class ConnectionsControllerTest
     /// - Josephine Yvonnesdottir: rightholder for Kaos (views from her perspective, from-others)
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class GetInstanceRights : IClassFixture<ApiFixture>
     {
         private const string SiriusInstanceId = "urn:altinn:instance-id:50315678/b1a2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetInstanceUsers.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetInstanceUsers.cs
@@ -38,6 +38,7 @@ public partial class ConnectionsControllerTest
     /// - Jinx Arcane: MD of Kaos (queries who has access to Kaos's instances)
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class GetInstanceUsers : IClassFixture<ApiFixture>
     {
         private const string SiriusInstanceId = "urn:altinn:instance-id:50315678/b1a2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetInstances.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetInstances.cs
@@ -41,6 +41,7 @@ public partial class ConnectionsControllerTest
     /// result in HTTP 403 Forbidden.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class GetInstances : IClassFixture<ApiFixture>
     {
         public GetInstances(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetPackages.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetPackages.cs
@@ -35,6 +35,7 @@ public partial class ConnectionsControllerTest
     /// - Thea BFF: Rightholder at Dumbo, MD of Mille (from-others perspective, querying what she receives from Dumbo)
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class GetPackages : IClassFixture<ApiFixture>
     {
         public GetPackages(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetResourceRights.cs
@@ -44,6 +44,7 @@ public partial class ConnectionsControllerTest
     /// the direction of the query (to-others vs from-others). Mismatched scopes result in HTTP 403 Forbidden.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class GetResourceRights : IClassFixture<ApiFixture>
     {
         public GetResourceRights(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetResources.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetResources.cs
@@ -43,6 +43,7 @@ public partial class ConnectionsControllerTest
     /// result in HTTP 403 Forbidden.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class GetResources : IClassFixture<ApiFixture>
     {
         public GetResources(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetRoles.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.GetRoles.cs
@@ -37,6 +37,7 @@ public partial class ConnectionsControllerTest
     /// - Jinx Arcane: MD of Kaos (to-others perspective)
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class GetRoles : IClassFixture<ApiFixture>
     {
         public GetRoles(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemoveAssignment.Altinn2FeatureFlagDisabled.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemoveAssignment.Altinn2FeatureFlagDisabled.cs
@@ -31,6 +31,7 @@ public partial class ConnectionsControllerTest
     /// - Assignment: HanSoloEnterprise -> LukeSkyWalker (ReporterSender / Altinn2 role)
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class RemoveAssignmentAltinn2FeatureFlagDisabled : IClassFixture<ApiFixture>
     {
         public RemoveAssignmentAltinn2FeatureFlagDisabled(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemoveAssignment.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemoveAssignment.cs
@@ -48,6 +48,7 @@ public partial class ConnectionsControllerTest
     /// - Han Solo: MD of HanSoloEnterprise
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class RemoveAssignment : IClassFixture<ApiFixture>
     {
         public RemoveAssignment(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemoveInstance.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemoveInstance.cs
@@ -42,6 +42,7 @@ public partial class ConnectionsControllerTest
     /// - Jinx Arcane: MD of Kaos Magic Design and Arts (receiver, from-others perspective)
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class RemoveInstance : IClassFixture<ApiFixture>
     {
         private const string SiriusInstanceIdForRemove = "urn:altinn:instance-id:50083510/e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8091";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemovePackages.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemovePackages.cs
@@ -29,6 +29,7 @@ public partial class ConnectionsControllerTest
     /// <summary>
     /// Tests for <see cref="ConnectionsController.RemovePackages(Guid, Guid, Guid, Guid?, string, CancellationToken)"/>.
     /// </summary>
+    [IntegrationTest]
     public class RemovePackages : IClassFixture<ApiFixture>
     {
         public RemovePackages(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemoveResource.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemoveResource.cs
@@ -57,6 +57,7 @@ public partial class ConnectionsControllerTest
     /// that correct scopes are enforced, and that invalid resources produce appropriate errors.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class RemoveResource : IClassFixture<ApiFixture>
     {
         public RemoveResource(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemoveRole.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.RemoveRole.cs
@@ -28,6 +28,7 @@ public partial class ConnectionsControllerTest
     /// The endpoint is marked with [ApiExplorerSettings(IgnoreApi = true)] and returns NotFound()
     /// unconditionally. The tests verify this behavior and scope enforcement.
     /// </remarks>
+    [IntegrationTest]
     public class RemoveRole : IClassFixture<ApiFixture>
     {
         public RemoveRole(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.UpdateInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.UpdateInstanceRights.cs
@@ -44,6 +44,7 @@ public partial class ConnectionsControllerTest
     /// - Jinx Arcane: private person delegating instance rights from herself to Thea
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class UpdateInstanceRights : IClassFixture<ApiFixture>
     {
         private const string SiriusInstanceIdForUpdate = "urn:altinn:instance-id:50401001/d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.UpdateResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/ConnectionsControllerTest.UpdateResourceRights.cs
@@ -57,6 +57,7 @@ public partial class ConnectionsControllerTest
     /// that correct scopes are enforced, and that missing delegations or invalid resources produce appropriate errors.
     /// </para>
     /// </remarks>
+    [IntegrationTest]
     public class UpdateResourceRights : IClassFixture<ApiFixture>
     {
         public UpdateResourceRights(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/MaskinportenConsumersControllerIntegrationTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/MaskinportenConsumersControllerIntegrationTest.cs
@@ -22,6 +22,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Controllers;
 /// As in the suppliers integration tests, ApiFixture's permissive PDP means the access-based 403 is not reproduced
 /// here (covered by EndUserResourceAccessHandlerTest); the scope-based 403 is asserted.
 /// </summary>
+[IntegrationTest]
 public class MaskinportenConsumersControllerIntegrationTest : IClassFixture<ApiFixture>
 {
     private const string Route = "accessmanagement/api/v1/enduser/maskinportenconsumers";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/MaskinportenConsumersResourceFilterTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/MaskinportenConsumersResourceFilterTest.cs
@@ -25,6 +25,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Controllers;
 /// Without filters the endpoint returns both resources (A with two permissions). The tests assert
 /// that supplying <c>consumer</c> and/or <c>resource</c> narrows the result accordingly.
 /// </remarks>
+[IntegrationTest]
 public class MaskinportenConsumersResourceFilterTest : IClassFixture<ApiFixture>
 {
     private const string Route = "accessmanagement/api/v1/enduser/maskinportenconsumers";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/MaskinportenControllersTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/MaskinportenControllersTest.cs
@@ -14,6 +14,7 @@ using ValidationErrors = Altinn.AccessMgmt.Core.Utils.Models.ValidationErrors;
 namespace Altinn.AccessManagement.Enduser.Api.Tests.Controllers;
 
 #pragma warning disable SA1649 // file holds both Consumers/Suppliers controller tests
+[UnitTest]
 public class MaskinportenConsumersControllerTest
 {
     private static readonly Guid Party = Guid.NewGuid();
@@ -245,6 +246,7 @@ public class MaskinportenConsumersControllerTest
     #endregion
 }
 
+[UnitTest]
 public class MaskinportenSuppliersControllerTest
 {
     private static readonly Guid Party = Guid.NewGuid();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/MaskinportenSuppliersControllerIntegrationTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/MaskinportenSuppliersControllerIntegrationTest.cs
@@ -27,6 +27,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Controllers;
 /// Reuses the pre-seeded <see cref="TestEntities"/> organizations and seeds only the supplier
 /// assignments needed by the list/remove cases, using distinct pairs so the tests stay order-independent.
 /// </summary>
+[IntegrationTest]
 public class MaskinportenSuppliersControllerIntegrationTest : IClassFixture<ApiFixture>
 {
     private const string Route = "accessmanagement/api/v1/enduser/maskinportensuppliers";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/RequestControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/RequestControllerTest.cs
@@ -57,6 +57,7 @@ public class RequestControllerTest
 
     #region POST — Create resource request
 
+    [IntegrationTest]
     public class CreateResourceRequest : IClassFixture<ApiFixture>
     {
         private static readonly ResourceType TestResourceType = new()
@@ -147,6 +148,7 @@ public class RequestControllerTest
 
     #region POST — Create request forbidden (no connection)
 
+    [IntegrationTest]
     public class CreateRequestForbidden : IClassFixture<ApiFixture>
     {
         public CreateRequestForbidden(ApiFixture fixture)
@@ -192,6 +194,7 @@ public class RequestControllerTest
 
     #region GET /sent — Sender sees sent requests
 
+    [IntegrationTest]
     public class GetSentRequests : IClassFixture<ApiFixture>
     {
         private static readonly Guid PendingPackageRequestId = Guid.Parse("0196b002-0000-7000-8000-000000000001");
@@ -258,6 +261,7 @@ public class RequestControllerTest
 
     #region GET /received — Receiver sees resource requests
 
+    [IntegrationTest]
     public class GetReceivedResourceRequests : IClassFixture<ApiFixture>
     {
         private static readonly ResourceType TestResourceType = new()
@@ -344,6 +348,7 @@ public class RequestControllerTest
 
     #region PUT /received/reject — Reject resource request
 
+    [IntegrationTest]
     public class RejectResourceRequest : IClassFixture<ApiFixture>
     {
         private static readonly ResourceType TestResourceType = new()
@@ -418,6 +423,7 @@ public class RequestControllerTest
 
     #region PUT /sent/withdraw — Withdraw request
 
+    [IntegrationTest]
     public class WithdrawRequest : IClassFixture<ApiFixture>
     {
         private static readonly Guid PendingPackageRequestId = Guid.Parse("0196b007-0000-7000-8000-000000000001");
@@ -472,6 +478,7 @@ public class RequestControllerTest
 
     #region PUT /sent/confirm — Confirm draft request
 
+    [IntegrationTest]
     public class ConfirmDraftRequest : IClassFixture<ApiFixture>
     {
         private static readonly Guid DraftPackageRequestId = Guid.Parse("0196b008-0000-7000-8000-000000000001");
@@ -531,6 +538,7 @@ public class RequestControllerTest
 
     #region GET /?party=&id= — GetRequest
 
+    [IntegrationTest]
     public class GetRequestById : IClassFixture<ApiFixture>
     {
         private static readonly Guid PendingPackageRequestId = Guid.Parse("0196b00a-0000-7000-8000-000000000001");
@@ -619,6 +627,7 @@ public class RequestControllerTest
 
     #region GET /sent/count — GetSentRequestsCount
 
+    [IntegrationTest]
     public class GetSentRequestsCountTest : IClassFixture<ApiFixture>
     {
         private static readonly Guid PendingPackageRequestId = Guid.Parse("0196b00b-0000-7000-8000-000000000001");
@@ -671,6 +680,7 @@ public class RequestControllerTest
 
     #region PUT /received/approve — ApproveRequest
 
+    [IntegrationTest]
     public class ApprovePackageRequestTest : IClassFixture<ApiFixture>
     {
         private static readonly Guid PendingPackageRequestId = Guid.Parse("0196b00d-0000-7000-8000-000000000001");
@@ -753,6 +763,7 @@ public class RequestControllerTest
         }
     }
 
+    [IntegrationTest]
     public class ApproveResourceRequestTest : IClassFixture<ApiFixture>
     {
         private static readonly ResourceType TestResourceType = new()
@@ -831,6 +842,7 @@ public class RequestControllerTest
 
     #region GET /received/count — GetReceivedRequestsCount
 
+    [IntegrationTest]
     public class GetReceivedRequestsCountTest : IClassFixture<ApiFixture>
     {
         private static readonly Guid PendingPackageRequestId = Guid.Parse("0196b00c-0000-7000-8000-000000000001");

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/RightsInternalDelegateAndRevokeInstanceDelegation.RevokeInstance.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Controllers/RightsInternalDelegateAndRevokeInstanceDelegation.RevokeInstance.cs
@@ -29,6 +29,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Controllers;
 /// - Validation of input parameters
 /// - Database persistence of revocation operations
 /// </remarks>
+[IntegrationTest]
 public class RightsInternalDelegateAndRevokeInstanceDelegation : IClassFixture<ApiFixture>
 {
     private const string InstanceId = "fa0678ad-960d-4307-aba2-ba29c9804c9d";

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Utils/ToUuidResolverTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Utils/ToUuidResolverTest.cs
@@ -27,6 +27,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Utils;
 /// The class is <see langword="internal"/> and accessible via
 /// <c>InternalsVisibleTo</c> on the Api.Enduser project.
 /// </summary>
+[UnitTest]
 public class ToUuidResolverTest
 {
     private static readonly Guid PersonTypeId = EntityTypeConstants.Person.Id;

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Validation/ConnectionCombinationRulesTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Validation/ConnectionCombinationRulesTest.cs
@@ -12,6 +12,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Validation;
 /// exercised through controller integration tests. See
 /// <c>docs/testing/TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/Coverage_Enduser_Api.md</c> for the coverage rationale.
 /// </summary>
+[UnitTest]
 public class ConnectionCombinationRulesTest
 {
     private static readonly string PartyA = Guid.NewGuid().ToString();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Validation/ConnectionValidationTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Validation/ConnectionValidationTest.cs
@@ -12,6 +12,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Validation;
 /// (see <see cref="ConnectionCombinationRulesTest"/>). Here we exercise the
 /// happy path plus at least one failing path to cover the composition.
 /// </summary>
+[UnitTest]
 public class ConnectionValidationTest
 {
     private static readonly string PartyA = Guid.NewGuid().ToString();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Validation/ParameterValidationTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Validation/ParameterValidationTest.cs
@@ -16,6 +16,7 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Validation;
 /// Driven via <see cref="ValidationComposer"/> so we exercise exactly the same
 /// execution path as controller-level validation.
 /// </summary>
+[UnitTest]
 public class ParameterValidationTest
 {
     private static readonly string PartyA = Guid.NewGuid().ToString();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Controllers/RequestControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Controllers/RequestControllerTest.cs
@@ -69,6 +69,7 @@ public class RequestControllerTest
 
     #region GET _meta/urns/party
 
+    [IntegrationTest]
     public class GetValidUrnsTest : IClassFixture<ApiFixture>
     {
         public GetValidUrnsTest(ApiFixture fixture)
@@ -121,6 +122,7 @@ public class RequestControllerTest
 
     #region POST (create request with resource)
 
+    [IntegrationTest]
     public class CreateResourceRequestTest : IClassFixture<ApiFixture>
     {
         private static readonly ResourceType TestResourceType = new()
@@ -302,6 +304,7 @@ public class RequestControllerTest
 
     #region POST (create request with package)
 
+    [IntegrationTest]
     public class CreatePackageRequestTest : IClassFixture<ApiFixture>
     {
         public CreatePackageRequestTest(ApiFixture fixture)
@@ -510,6 +513,7 @@ public class RequestControllerTest
 
     #region End-to-end: GetValidUrns then Create Request
 
+    [IntegrationTest]
     public class GetValidUrnsThenCreateRequestTest : IClassFixture<ApiFixture>
     {
         private static readonly ResourceType TestResourceType = new()
@@ -625,6 +629,7 @@ public class RequestControllerTest
 
     #region GET {id}/status
 
+    [IntegrationTest]
     public class GetRequestStatusTest : IClassFixture<ApiFixture>
     {
         private static readonly ResourceType TestResourceType = new()
@@ -719,6 +724,7 @@ public class RequestControllerTest
 
     #region POST /resource (query-param overload)
 
+    [IntegrationTest]
     public class CreateResourceRequestByQueryTest : IClassFixture<ApiFixture>
     {
         private static readonly ResourceType TestResourceType = new()
@@ -803,6 +809,7 @@ public class RequestControllerTest
 
     #region POST /package (query-param overload)
 
+    [IntegrationTest]
     public class CreatePackageRequestByQueryTest : IClassFixture<ApiFixture>
     {
         public CreatePackageRequestByQueryTest(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Controllers/RequestControllerUnitTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Controllers/RequestControllerUnitTest.cs
@@ -22,6 +22,7 @@ namespace Altinn.AccessManagement.ServiceOwner.Api.Tests.Controllers;
 /// the ApiFixture (no Postgres / migrations), so they cover the branches even when
 /// the integration fixture is unavailable.
 /// </summary>
+[UnitTest]
 public class RequestControllerUnitTest
 {
     private static RequestController CreateController(

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Controllers/ServiceOwnerConnectionsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Controllers/ServiceOwnerConnectionsControllerTest.cs
@@ -28,6 +28,7 @@ public class ServiceOwnerConnectionsControllerTest
     /// <summary>
     /// Tests for <see cref="ConnectionsController.AddPackages(ServiceOwnerAccessPackageDelegation, CancellationToken)"/>
     /// </summary>
+    [IntegrationTest]
     public class AddRevokePackages : IClassFixture<ApiFixture>
     {
         public AddRevokePackages(ApiFixture fixture)
@@ -733,6 +734,7 @@ public class ServiceOwnerConnectionsControllerTest
     /// A separate fixture class is required because the host is sealed before test methods run,
     /// so the flag must be configured from the constructor.
     /// </summary>
+    [IntegrationTest]
     public class RevokePackages_Altinn2RoleFlagDisabled : IClassFixture<ApiFixture>
     {
         public RevokePackages_Altinn2RoleFlagDisabled(ApiFixture fixture)

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Authorization/ConditionalScopeTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Authorization/ConditionalScopeTest.cs
@@ -9,6 +9,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Authorization;
 /// by <c>ScopeConditionAuthorizationHandler</c> to decide whether a given access
 /// rule applies to the current request based on querystring inspection.
 /// </summary>
+[UnitTest]
 public class ConditionalScopeTest
 {
     private sealed class StubAccessor(HttpContext? context) : IHttpContextAccessor

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Authorization/DefaultAuthorizationScopeProviderTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Authorization/DefaultAuthorizationScopeProviderTest.cs
@@ -11,6 +11,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Authorization;
 /// `urn:altinn:scope` claims (one scope per claim) and top-level "scope" claims
 /// (space-separated values, split by the provider).
 /// </summary>
+[UnitTest]
 public class DefaultAuthorizationScopeProviderTest
 {
     private static AuthorizationHandlerContext MakeContext(ClaimsPrincipal user) =>

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Authorization/ScopeConditionAuthorizationHandlerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Authorization/ScopeConditionAuthorizationHandlerTest.cs
@@ -12,6 +12,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Authorization;
 /// matches the current request *and* the user has at least one of the rule's
 /// required scopes.
 /// </summary>
+[UnitTest]
 public class ScopeConditionAuthorizationHandlerTest
 {
     private sealed class StubAccessor(HttpContext? context) : IHttpContextAccessor

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Extensions/ControllerExtensionsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Extensions/ControllerExtensionsTest.cs
@@ -13,6 +13,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Extensions;
 /// fallback chain and the standalone Accept-Language parser used when
 /// TranslationMiddleware hasn't run.
 /// </summary>
+[UnitTest]
 public class ControllerExtensionsTest
 {
     private sealed class TestController : ControllerBase

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Extensions/DeepTranslationExtensionsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Extensions/DeepTranslationExtensionsTest.cs
@@ -17,6 +17,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Extensions;
 /// ProviderTypeDto, ResourceDto.Type as ResourceTypeDto) are translated
 /// via the singular <see cref="ITranslationService.TranslateAsync"/> only.
 /// </summary>
+[UnitTest]
 public class DeepTranslationExtensionsTest
 {
     private sealed class CountingTranslationService : ITranslationService

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Extensions/TranslationExtensionsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Extensions/TranslationExtensionsTest.cs
@@ -10,6 +10,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Extensions;
 /// null/default short-circuit behavior on every overload and the
 /// service-delegation contract for non-null inputs.
 /// </summary>
+[UnitTest]
 public class TranslationExtensionsTest
 {
     private sealed record Dto(string Name);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/HostedServices/Outbox/OutboxHandlerJobTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/HostedServices/Outbox/OutboxHandlerJobTest.cs
@@ -11,6 +11,7 @@ namespace Altinn.AccessMgmt.Core.Tests.HostedServices.Outbox;
 /// <summary>
 /// <see cref="OutboxHandlerJob"/>
 /// </summary>
+[IntegrationTest]
 public class OutboxHandlerJobTest : IClassFixture<ApiFixture>
 {
     public ApiFixture Fixture { get; }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/HostedServices/Outbox/OutboxReaperJobTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/HostedServices/Outbox/OutboxReaperJobTest.cs
@@ -10,6 +10,7 @@ namespace Altinn.AccessMgmt.Core.Tests.HostedServices.Outbox;
 /// <summary>
 /// <see cref="OutboxReaperJob"/>
 /// </summary>
+[IntegrationTest]
 public class OutboxReaperJobTest : IClassFixture<ApiFixture>
 {
     public ApiFixture Fixture { get; }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/HostedServices/Services/ResourceSyncServiceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/HostedServices/Services/ResourceSyncServiceTest.cs
@@ -20,6 +20,7 @@ namespace Altinn.AccessMgmt.Core.Tests.HostedServices.Services;
 /// <summary>
 /// <see cref="Altinn.AccessMgmt.Core.HostedServices.Services.ResourceSyncService"/>
 /// </summary>
+[IntegrationTest]
 public class ResourceSyncServiceTest : IClassFixture<ApiFixture>
 {
     private static readonly FakeResourceRegistry Registry = new();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/PersistenceCore/PersistenceCoreFuzzySearchTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/PersistenceCore/PersistenceCoreFuzzySearchTest.cs
@@ -2,6 +2,7 @@
 
 namespace Altinn.AccessMgmt.Core.Tests.PersistenceCore;
 
+[UnitTest]
 public class PersistenceCoreFuzzySearchTest
 {
     private record Item(string Name, string Description);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/PersistenceCore/SearchPropertyBuilderTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/PersistenceCore/SearchPropertyBuilderTest.cs
@@ -9,6 +9,7 @@ namespace Altinn.AccessMgmt.Core.Tests.PersistenceCore;
 /// produces are load-bearing: a wrong key silently misweights real search
 /// results.
 /// </summary>
+[UnitTest]
 public class SearchPropertyBuilderTest
 {
     // ── test models ──────────────────────────────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/DelegationCheckDtoMapperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/DelegationCheckDtoMapperTest.cs
@@ -6,6 +6,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Utils;
 /// <summary>
 /// Pure unit tests for <see cref="DtoMapper.Convert(IEnumerable{PackageDelegationCheck})"/>.
 /// </summary>
+[UnitTest]
 public class DelegationCheckDtoMapperTest
 {
     private static readonly DtoMapper Mapper = new();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/DelegationCheckHelperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/DelegationCheckHelperTest.cs
@@ -10,6 +10,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Utils;
 /// <summary>
 /// Pure unit tests for <see cref="DelegationCheckHelper"/>.
 /// </summary>
+[UnitTest]
 public class DelegationCheckHelperTest
 {
     // ── IsAccessListModeEnabledAndApplicable ─────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/FuzzySearchTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/FuzzySearchTest.cs
@@ -3,6 +3,7 @@ using Altinn.AccessMgmt.Core.Utils.Models;
 
 namespace Altinn.AccessMgmt.Core.Tests.Utils;
 
+[UnitTest]
 public class FuzzySearchTest
 {
     private record Item(string Name, string Description);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/IngestServiceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/IngestServiceTest.cs
@@ -12,6 +12,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Utils;
 /// <summary>
 /// <see cref="IngestService"/>
 /// </summary>
+[IntegrationTest]
 public class IngestServiceTest : IClassFixture<ApiFixture>
 {
     public ApiFixture Fixture { get; }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/Mappers/DtoMapperConnectionQueryTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/Mappers/DtoMapperConnectionQueryTest.cs
@@ -13,6 +13,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Utils.Mappers;
 /// <c>ConvertToAgentDto</c>, and all <c>Extract*</c> instance methods.
 /// No database or container required.
 /// </summary>
+[UnitTest]
 public class DtoMapperConnectionQueryTest
 {
     // ── known EntityTypeConstants / EntityVariantConstants ids ────────────────

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/Mappers/DtoMapperEntityVariantTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/Mappers/DtoMapperEntityVariantTest.cs
@@ -8,6 +8,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Utils.Mappers;
 /// Pure-logic unit tests for <see cref="DtoMapperEntityVariant"/>.
 /// No containers required.
 /// </summary>
+[UnitTest]
 public class DtoMapperEntityVariantTest
 {
     // Organization TypeId from EntityTypeConstants

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/Mappers/DtoMapperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/Mappers/DtoMapperTest.cs
@@ -18,6 +18,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Utils.Mappers;
 ///   DtoMapperRolePackage.cs, DtoMapperAccessPackageDto.cs,
 ///   DtoMapperAuthorizedPartyDto.cs, RequestMapper.cs
 /// </summary>
+[UnitTest]
 public class DtoMapperTest
 {
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/OrgUtilTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/OrgUtilTest.cs
@@ -3,6 +3,7 @@ using Altinn.AccessMgmt.Core.Utils;
 
 namespace Altinn.AccessMgmt.Core.Tests.Utils;
 
+[UnitTest]
 public class OrgUtilTest
 {
     // ── GetMaskinportenScopes ────────────────────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/QueryWrapperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/QueryWrapperTest.cs
@@ -6,6 +6,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Utils;
 /// <summary>
 /// Pure unit tests for <see cref="QueryWrapper.WrapQueryResponse{T}"/>.
 /// </summary>
+[UnitTest]
 public class QueryWrapperTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/TranslationMiddlewareTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Utils/TranslationMiddlewareTest.cs
@@ -12,6 +12,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Utils;
 /// X-Accept-Partial-Translation parsing, and the Content-Language
 /// response-header set behavior.
 /// </summary>
+[UnitTest]
 public class TranslationMiddlewareTest
 {
     private static async Task<HttpContext> Run(

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Validation/ResourceValidationTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Validation/ResourceValidationTest.cs
@@ -9,6 +9,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Validation;
 /// <summary>
 /// Direct unit tests for the internal validation-rule factory methods in <see cref="ResourceValidation"/>.
 /// </summary>
+[UnitTest]
 public class ResourceValidationTest
 {
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Validation/ValidationComposerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Validation/ValidationComposerTest.cs
@@ -4,6 +4,7 @@ using Altinn.Authorization.ProblemDetails;
 
 namespace Altinn.AccessMgmt.Core.Tests.Validation;
 
+[UnitTest]
 public class ValidationComposerTest
 {
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Validation/ValidationRuleClassesTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Validation/ValidationRuleClassesTest.cs
@@ -10,6 +10,7 @@ namespace Altinn.AccessMgmt.Core.Tests.Validation;
 /// <see cref="RoleValidation"/>, <see cref="AssignmentPackageValidation"/>,
 /// <see cref="DelegationValidation"/> and <see cref="PackageValidation"/>.
 /// </summary>
+[UnitTest]
 public class ValidationRuleClassesTest
 {
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/AreaConstantsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/AreaConstantsTest.cs
@@ -2,6 +2,7 @@ using Altinn.AccessMgmt.PersistenceEF.Constants;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Tests.Constants;
 
+[UnitTest]
 public class AreaConstantsTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/AreaGroupConstantsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/AreaGroupConstantsTest.cs
@@ -2,6 +2,7 @@ using Altinn.AccessMgmt.PersistenceEF.Constants;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Tests.Constants;
 
+[UnitTest]
 public class AreaGroupConstantsTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/EntityTypeConstantsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/EntityTypeConstantsTest.cs
@@ -2,6 +2,7 @@ using Altinn.AccessMgmt.PersistenceEF.Constants;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Tests.Constants;
 
+[UnitTest]
 public class EntityTypeConstantsTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/EntityVariantConstantsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/EntityVariantConstantsTest.cs
@@ -2,6 +2,7 @@ using Altinn.AccessMgmt.PersistenceEF.Constants;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Tests.Constants;
 
+[UnitTest]
 public class EntityVariantConstantsTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/PackageConstantsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/PackageConstantsTest.cs
@@ -2,6 +2,7 @@
 
 namespace Altinn.AccessMgmt.PersistenceEF.Tests.Constants;
 
+[UnitTest]
 public class PackageConstantsTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/ProviderConstantsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/ProviderConstantsTest.cs
@@ -2,6 +2,7 @@ using Altinn.AccessMgmt.PersistenceEF.Constants;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Tests.Constants;
 
+[UnitTest]
 public class ProviderConstantsTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/ProviderTypeConstantsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/ProviderTypeConstantsTest.cs
@@ -2,6 +2,7 @@ using Altinn.AccessMgmt.PersistenceEF.Constants;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Tests.Constants;
 
+[UnitTest]
 public class ProviderTypeConstantsTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/RoleConstantsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/RoleConstantsTest.cs
@@ -2,6 +2,7 @@ using Altinn.AccessMgmt.PersistenceEF.Constants;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Tests.Constants;
 
+[UnitTest]
 public class RoleConstantsTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/SystemEntityConstantsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Constants/SystemEntityConstantsTest.cs
@@ -2,6 +2,7 @@ using Altinn.AccessMgmt.PersistenceEF.Constants;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Tests.Constants;
 
+[UnitTest]
 public class SystemEntityConstantsTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Extensions/CustomMigrationsSqlGeneratorContractTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Extensions/CustomMigrationsSqlGeneratorContractTests.cs
@@ -32,6 +32,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Tests.Extensions;
 /// the generator around a replacement type, find a public-surface
 /// alternative, or pin the package version.
 /// </remarks>
+[UnitTest]
 public class CustomMigrationsSqlGeneratorContractTests
 {
     private const string InternalOptionsTypeFullName =

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AccessListAuthorizationControllerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AccessListAuthorizationControllerTest.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Altinn.Platform.Authorization.IntegrationTests;
 
+[IntegrationTest]
 public class AccessListAuthorizationControllerTest : IClassFixture<AuthorizationApiFixture>
 {
     private static readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AccessListAuthorizationTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AccessListAuthorizationTest.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace Altinn.Platform.Authorization.UnitTests;
 
+[UnitTest]
 public class AccessListAuthorizationTest
 {
     private static readonly Guid PartyUuid = Guid.NewGuid();

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AltinnApps_DecisionTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/AltinnApps_DecisionTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Altinn.Platform.Authorization.IntegrationTests
 {
+    [IntegrationTest]
     public class AltinnApps_DecisionTests : IClassFixture<AuthorizationApiFixture>
     {
         private readonly AuthorizationApiFixture _fixture;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ContextHandlerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ContextHandlerTest.cs
@@ -19,6 +19,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
     /// <summary>
     /// Test class for <see cref="ContextHandler"></see>
     /// </summary>
+    [UnitTest]
     public class ContextHandlerTest
     {
         private readonly ContextHandler _contextHandler;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ContextHandlerUnitTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ContextHandlerUnitTest.cs
@@ -24,6 +24,7 @@ namespace Altinn.Platform.Authorization.UnitTests;
 /// <summary>
 /// Unit tests for <see cref="ContextHandler"/> protected methods via a testable subclass.
 /// </summary>
+[UnitTest]
 public class ContextHandlerUnitTest : IDisposable
 {
     private readonly Mock<IInstanceMetadataRepository> _policyInfoRepoMock = new();

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/DelegationContextHandlerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/DelegationContextHandlerTest.cs
@@ -23,6 +23,7 @@ using Xunit;
 
 namespace Altinn.Platform.Authorization.UnitTests;
 
+[UnitTest]
 public class DelegationContextHandlerTest : IDisposable
 {
     private static readonly Uri StringDataType = new("http://www.w3.org/2001/XMLSchema#string");

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/DelegationHelperAdditionalTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/DelegationHelperAdditionalTest.cs
@@ -10,6 +10,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests;
 /// Additional unit tests for <see cref="DelegationHelper"/> methods not covered
 /// by the existing <see cref="Altinn.Platform.Authorization.IntegrationTests.DelegationHelperTest"/>.
 /// </summary>
+[UnitTest]
 public class DelegationHelperAdditionalTest
 {
     // --- TryGetCoveredByPartyIdFromMatch ---

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/DelegationHelperTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/DelegationHelperTest.cs
@@ -17,6 +17,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
     /// <summary>
     /// Test class for <see cref="ContextHandler"></see>
     /// </summary>
+    [UnitTest]
     public class DelegationHelperTest
     {
         private PolicyRetrievalPointMock _prpMock;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventLogHelperTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventLogHelperTest.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace Altinn.Platform.Authorization.Tests;
 
+[UnitTest]
 public class EventLogHelperTest
 {
     private static XacmlContextRequest CreateContextRequest(

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventLogServiceTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventLogServiceTest.cs
@@ -10,6 +10,7 @@ using Moq;
 
 namespace Altinn.Platform.Authorization.Tests;
 
+[UnitTest]
 public class EventLogServiceTest
 {
     private readonly Mock<IEventsQueueClient> _queueClientMock = new();

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventsQueueClientTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/EventsQueueClientTests.cs
@@ -10,6 +10,7 @@ using Moq;
 
 namespace Altinn.Authorization.Tests
 {
+    [UnitTest]
     public class EventsQueueClientTests
     {
         private EventsQueueClient CreateClient()

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExtensionTests/ClaimsPrincipalExtensionsTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExtensionTests/ClaimsPrincipalExtensionsTest.cs
@@ -4,6 +4,7 @@ using AltinnCore.Authentication.Constants;
 
 namespace Altinn.Platform.Authorization.Tests.ExtensionTests;
 
+[UnitTest]
 public class ClaimsPrincipalExtensionsTest
 {
     private static ClaimsPrincipal CreatePrincipal(params Claim[] claims)

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExtensionTests/DataReaderExtensionsTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExtensionTests/DataReaderExtensionsTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Altinn.Platform.Authorization.Tests.ExtensionTests
 {
+    [UnitTest]
     public class DataReaderExtensionsTests
     {
         private const string ColumnName = "Column";

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExtensionTests/HttpClientExtensionTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExtensionTests/HttpClientExtensionTest.cs
@@ -3,6 +3,7 @@ using Altinn.Platform.Authorization.Extensions;
 
 namespace Altinn.Platform.Authorization.Tests.ExtensionTests;
 
+[UnitTest]
 public class HttpClientExtensionTest
 {
     // --- PostAsync ---

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExtensionTests/StringExtensionsTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExtensionTests/StringExtensionsTest.cs
@@ -2,6 +2,7 @@
 
 namespace Altinn.Platform.Authorization.Tests.ExtensionTests;
 
+[UnitTest]
 public class StringExtensionsTest
 {
     [Fact]

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExternalDecisionTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ExternalDecisionTest.cs
@@ -18,6 +18,7 @@ using Xunit;
 
 namespace Altinn.Platform.Authorization.IntegrationTests
 {
+    [IntegrationTest]
     public class ExternalDecisionTest : IClassFixture<AuthorizationApiFixture>
     {
         private readonly AuthorizationApiFixture _fixture;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Health/HealthCheckTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Health/HealthCheckTests.cs
@@ -9,6 +9,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Health
     /// <summary>
     /// Health check 
     /// </summary>
+    [IntegrationTest]
     public class HealthCheckTests : IClassFixture<AuthorizationApiFixture>
     {
         private readonly HttpClient _client;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/OrganizationNumberTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/OrganizationNumberTest.cs
@@ -3,6 +3,7 @@ using Altinn.Authorization.Models.Register;
 
 namespace Altinn.Platform.Authorization.Tests;
 
+[UnitTest]
 public class OrganizationNumberTest
 {
     // --- Parse(string) ---

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PartiesControllerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PartiesControllerTest.cs
@@ -7,6 +7,7 @@ using Altinn.Platform.Register.Models;
 
 namespace Altinn.Platform.Authorization.IntegrationTests
 {
+    [IntegrationTest]
     public class PartiesControllerTest : IClassFixture<AuthorizationApiFixture>
     {
         private readonly HttpClient _client;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PdpDecisionTelemetryTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PdpDecisionTelemetryTests.cs
@@ -21,6 +21,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
     /// the request: <c>internal</c> for <c>authorization/api/v1/decision</c> and
     /// <c>external</c> for <c>authorization/api/v1/authorize</c>.
     /// </summary>
+    [IntegrationTest]
     public class PdpDecisionTelemetryTests : IClassFixture<AuthorizationApiFixture>
     {
         private const string ApiKindTag = "pdp.api.kind";

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PlatformHttpExceptionTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PlatformHttpExceptionTest.cs
@@ -3,6 +3,7 @@ using Altinn.Platform.Authorization.Exceptions;
 
 namespace Altinn.Platform.Authorization.Tests;
 
+[UnitTest]
 public class PlatformHttpExceptionTest
 {
     [Fact]

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyAdministrationPointTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyAdministrationPointTest.cs
@@ -27,6 +27,7 @@ using Xunit;
 namespace Altinn.Platform.Authorization.IntegrationTests
 {
     [Collection("PolicyAdministrationPointTest")]
+    [UnitTest]
     public class PolicyAdministrationPointTest
     {
         private readonly IPolicyAdministrationPoint _pap;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyControllerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyControllerTest.cs
@@ -20,6 +20,7 @@ using Xunit;
 namespace Altinn.Platform.Authorization.IntegrationTests
 {
     [Collection("Our Test Collection #1")]
+    [IntegrationTest]
     public class PolicyControllerTest : IClassFixture<AuthorizationApiFixture>
     {
         private readonly HttpClient _client;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyHelperTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyHelperTest.cs
@@ -6,6 +6,7 @@ using Altinn.Platform.Authorization.Models;
 
 namespace Altinn.Platform.Authorization.Tests;
 
+[UnitTest]
 public class PolicyHelperTest
 {
     // --- GetAltinnAppsPolicyPath ---

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyInformationPointTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyInformationPointTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace Altinn.Platform.Authorization.Tests;
 
+[UnitTest]
 public class PolicyInformationPointTest
 {
     private readonly Mock<IPolicyRetrievalPoint> _prpMock = new();

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyRetrievalPointTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyRetrievalPointTest.cs
@@ -23,6 +23,7 @@ using Xunit;
 namespace Altinn.Platform.Authorization.IntegrationTests
 {
     [Collection("Our Test Collection #1")]
+    [UnitTest]
     public class PolicyRetrievalPointTest
     {
         private const string ORG = "ttd";

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Repositories/DelegationMetadataRepositoryIntegrationTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Repositories/DelegationMetadataRepositoryIntegrationTests.cs
@@ -16,6 +16,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.Repositories;
 /// silently break inserts/reads, and that codepath is bypassed by the
 /// in-process test fixture which substitutes a mock repository.
 /// </summary>
+[IntegrationTest]
 public class DelegationMetadataRepositoryIntegrationTests : IClassFixture<AuthorizationDbFixture>
 {
     private readonly AuthorizationDbFixture _db;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ResourceRegistry_DecisionTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ResourceRegistry_DecisionTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Altinn.Platform.Authorization.IntegrationTests
 {
+    [IntegrationTest]
     public class ResourceRegistry_DecisionTests : IClassFixture<AuthorizationApiFixture>
     {
         private readonly AuthorizationApiFixture _fixture;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ServiceResourceHelperTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/ServiceResourceHelperTest.cs
@@ -2,6 +2,7 @@
 
 namespace Altinn.Platform.Authorization.Tests;
 
+[UnitTest]
 public class ServiceResourceHelperTest
 {
     [Theory]

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Xacml30ConformanceTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Xacml30ConformanceTests.cs
@@ -16,6 +16,7 @@ using Xunit;
 
 namespace Altinn.Platform.Authorization.IntegrationTests
 {
+    [IntegrationTest]
     public class Xacml30ConformanceTests : IClassFixture<WebApplicationFactory<DecisionController>>
     {
         private readonly WebApplicationFactory<DecisionController> _factory;

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/XacmlRequestApiModelBinderProviderTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/XacmlRequestApiModelBinderProviderTest.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 
 namespace Altinn.Platform.Authorization.Tests;
 
+[UnitTest]
 public class XacmlRequestApiModelBinderProviderTest
 {
     [Fact]

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/XacmlRequestApiModelBinderTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/XacmlRequestApiModelBinderTest.cs
@@ -7,6 +7,7 @@ using Moq;
 
 namespace Altinn.Platform.Authorization.Tests;
 
+[UnitTest]
 public class XacmlRequestApiModelBinderTest
 {
     [Fact]

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Lease.Tests/StorageAccount/StorageAccountLeaseTest.cs
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Lease.Tests/StorageAccount/StorageAccountLeaseTest.cs
@@ -10,6 +10,7 @@ namespace Altinn.Authorization.Host.Lease.Tests
     /// This class contains tests for acquiring leases on an Azure Storage Account using Altinn Lease.
     /// The tests validate the proper functionality of lease acquisition and management in a multithreaded environment.
     /// </summary>
+    [IntegrationTest]
     public class StorageAccountLeaseTest : FanoutTests
     {
         /// <summary>

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/PipelineMessageSmokeTest.cs
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/PipelineMessageSmokeTest.cs
@@ -9,6 +9,7 @@ namespace Altinn.Authorization.Host.Pipeline.Tests;
 /// recurrence of the empty-test-project problem (audit ID C1') that this Task
 /// just fixed for ABAC. Real Pipeline coverage tests follow under Phase D.1.
 /// </summary>
+[UnitTest]
 public class PipelineMessageSmokeTest
 {
     [Fact]

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/PipelineSinkServiceTest.cs
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/PipelineSinkServiceTest.cs
@@ -15,6 +15,7 @@ namespace Altinn.Authorization.Host.Pipeline.Tests;
 /// InvalidOperationException after exhaustion) and the outer-handler /
 /// finally-block contract in <c>Run</c>.
 /// </summary>
+[UnitTest]
 public class PipelineSinkServiceTest
 {
     private sealed class StubDescriptor(string? pipelineName) : IPipelineDescriptor

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/PipelineSourceServiceTest.cs
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/PipelineSourceServiceTest.cs
@@ -19,6 +19,7 @@ namespace Altinn.Authorization.Host.Pipeline.Tests;
 /// when a full pipeline runs in a host, so these tests pin behavior that would
 /// otherwise regress silently.
 /// </summary>
+[UnitTest]
 public class PipelineSourceServiceTest
 {
     private sealed class StubDescriptor(string? pipelineName) : IPipelineDescriptor

--- a/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/PaginatorStreamTest.cs
+++ b/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/PaginatorStreamTest.cs
@@ -10,6 +10,7 @@ namespace Altinn.Authorization.Integration.Tests;
 /// only exercised via live external Register / ResourceRegister calls, which
 /// <c>SkipIfMissingConfiguration</c> in CI without those env configs.
 /// </summary>
+[UnitTest]
 public class PaginatorStreamTest
 {
     private sealed record Item(string Name);

--- a/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/Register/PartiesStreamEndpointTest.cs
+++ b/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/Register/PartiesStreamEndpointTest.cs
@@ -4,6 +4,7 @@ using Altinn.Register.Contracts;
 
 namespace Altinn.Authorization.Integration.Tests.Register;
 
+[IntegrationTest]
 public class PartiesStreamEndpointTest : IClassFixture<PlatformFixture>
 {
     public PartiesStreamEndpointTest(PlatformFixture fixture)

--- a/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/Register/RoleStreamEndpointTest.cs
+++ b/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/Register/RoleStreamEndpointTest.cs
@@ -3,6 +3,7 @@ using Altinn.Authorization.Integration.Platform.Register;
 
 namespace Altinn.Authorization.Integration.Tests.Register;
 
+[IntegrationTest]
 public class RoleStreamEndpointTest : IClassFixture<PlatformFixture>
 {
     public RoleStreamEndpointTest(PlatformFixture fixture)

--- a/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/RequestComposerTest.cs
+++ b/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/RequestComposerTest.cs
@@ -7,6 +7,7 @@ namespace Altinn.Authorization.Integration.Tests;
 /// <summary>
 /// Pure-unit tests for <see cref="RequestComposer"/> (no external dependencies).
 /// </summary>
+[UnitTest]
 public class RequestComposerTest
 {
     // ── New ──────────────────────────────────────────────────────────────────

--- a/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/ResourceRegister/ResourceGetEndpointTest.cs
+++ b/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/ResourceRegister/ResourceGetEndpointTest.cs
@@ -6,6 +6,7 @@ namespace Altinn.Authorization.Integration.Tests.ResourceRegistry;
 /// <summary>
 /// Contains test cases for the ResourceGetEndpoint.
 /// </summary>
+[IntegrationTest]
 public class ResourceGetEndpointTest : IClassFixture<PlatformFixture>
 {
     public ResourceGetEndpointTest(PlatformFixture fixture)

--- a/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/ResourceRegister/ResourceUpdatedEndpointTest.cs
+++ b/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/ResourceRegister/ResourceUpdatedEndpointTest.cs
@@ -7,6 +7,7 @@ namespace Altinn.Authorization.Integration.Tests.ResourceRegistry;
 /// Tests for the ResourceUpdatedEndpoint.
 /// </summary>
 /// <param name="fixture">The platform fixture to provide necessary services.</param>
+[IntegrationTest]
 public class ResourceUpdatedEndpointTest : IClassFixture<PlatformFixture>
 {
     public ResourceUpdatedEndpointTest(PlatformFixture fixture)

--- a/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/ResourceRegister/ServiceOwnersEndpointsTest.cs
+++ b/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/ResourceRegister/ServiceOwnersEndpointsTest.cs
@@ -7,6 +7,7 @@ namespace Altinn.Authorization.Integration.Tests.ResourceRegistry;
 /// Tests for the ResourceUpdatedEndpoint.
 /// </summary>
 /// <param name="fixture">The platform fixture to provide necessary services.</param>
+[IntegrationTest]
 public class ServiceOwnersEndpointsTest : IClassFixture<PlatformFixture>
 {
     public ServiceOwnersEndpointsTest(PlatformFixture fixture)

--- a/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/ResponseComposerTest.cs
+++ b/src/libs/Altinn.Authorization.Integration/test/Altinn.Authorization.Integration.Tests/ResponseComposerTest.cs
@@ -8,6 +8,7 @@ namespace Altinn.Authorization.Integration.Tests;
 /// <summary>
 /// Pure-unit tests for <see cref="ResponseComposer"/> (no external dependencies).
 /// </summary>
+[UnitTest]
 public class ResponseComposerTest
 {
     // ── Handle ────────────────────────────────────────────────────────────────

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/AppAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/AppAccessHandlerTest.cs
@@ -15,6 +15,7 @@ using Moq;
 
 namespace Altinn.Authorization.PEP.Tests
 {
+    [UnitTest]
     public class AppAccessHandlerTest
     {
         private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock;

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ClaimAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ClaimAccessHandlerTest.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Altinn.Authorization.PEP.Tests
 {
+    [UnitTest]
     public class ClaimAccessHandlerTest
     {
         private readonly ClaimAccessHandler _handler;

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/DecisionHelperTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/DecisionHelperTest.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Altinn.Authorization.PEP.Tests
 {
+    [UnitTest]
     public class DecisionHelperTest
     {
         private const string Org = "Altinn";

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/IDFormatDeterminatorTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/IDFormatDeterminatorTest.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Altinn.Authorization.PEP.Tests
 {
+    [UnitTest]
     public class IDFormatDeterminatorTest
     {
         [Fact]

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/PDPAppSITest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/PDPAppSITest.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Altinn.Authorization.PEP.Tests
 {
+    [UnitTest]
     public class PDPAppSITest
     {
         [Fact]

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ResourceAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ResourceAccessHandlerTest.cs
@@ -19,6 +19,7 @@ using Xunit;
 
 namespace Altinn.Authorization.PEP.Tests
 {
+    [UnitTest]
     public class ResourceAccessHandlerTest
     {
         private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock;

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ScopeAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ScopeAccessHandlerTest.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Altinn.Authorization.PEP.Tests
 {
+    [UnitTest]
     public class ScopeAccessHandlerTest
     {
         private readonly ScopeAccessHandler _sah;

--- a/src/testing/TestCategories.cs
+++ b/src/testing/TestCategories.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using Xunit.v3;
+
+namespace Altinn.Authorization.Testing;
+
+/// <summary>
+/// Test category names used by the <c>Category</c> trait. Filter a run with
+/// <c>dotnet test -- --filter-trait "Category=Unit"</c> (MTP) or
+/// <c>--filter-query "/*/*/*/*[Category=Unit]"</c>.
+/// </summary>
+public static class TestCategories
+{
+    /// <summary>Fast, in-process tests with no external dependencies.</summary>
+    public const string Unit = "Unit";
+
+    /// <summary>Tests that exercise the real pipeline / a database / external services.</summary>
+    public const string Integration = "Integration";
+
+    /// <summary>The trait name both categories are published under.</summary>
+    public const string Category = "Category";
+}
+
+/// <summary>
+/// Marks a test class or method as a fast, in-process unit test
+/// (publishes the trait <c>Category=Unit</c>).
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public sealed class UnitTestAttribute : Attribute, ITraitAttribute
+{
+    /// <inheritdoc />
+    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits() =>
+        new[] { new KeyValuePair<string, string>(TestCategories.Category, TestCategories.Unit) };
+}
+
+/// <summary>
+/// Marks a test class or method as an integration test that needs the real
+/// pipeline, a database, or external services (publishes the trait
+/// <c>Category=Integration</c>).
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public sealed class IntegrationTestAttribute : Attribute, ITraitAttribute
+{
+    /// <inheritdoc />
+    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits() =>
+        new[] { new KeyValuePair<string, string>(TestCategories.Category, TestCategories.Integration) };
+}

--- a/src/testing/TestCategories.cs
+++ b/src/testing/TestCategories.cs
@@ -28,9 +28,11 @@ public static class TestCategories
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
 public sealed class UnitTestAttribute : Attribute, ITraitAttribute
 {
-    /// <inheritdoc />
-    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits() =>
+    private static readonly IReadOnlyCollection<KeyValuePair<string, string>> Traits =
         new[] { new KeyValuePair<string, string>(TestCategories.Category, TestCategories.Unit) };
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits() => Traits;
 }
 
 /// <summary>
@@ -41,7 +43,9 @@ public sealed class UnitTestAttribute : Attribute, ITraitAttribute
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
 public sealed class IntegrationTestAttribute : Attribute, ITraitAttribute
 {
-    /// <inheritdoc />
-    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits() =>
+    private static readonly IReadOnlyCollection<KeyValuePair<string, string>> Traits =
         new[] { new KeyValuePair<string, string>(TestCategories.Category, TestCategories.Integration) };
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits() => Traits;
 }


### PR DESCRIPTION
## What

Tag every test class with a `Category` trait so a run can be filtered and grouped by type (the basis for splitting CI into fast unit and slower integration lanes later).

- New shared `[UnitTest]` / `[IntegrationTest]` marker attributes (xUnit v3 `ITraitAttribute`) emitting `Category=Unit` / `Category=Integration`. Defined once in `src/testing/TestCategories.cs` and compiled into every xUnit v3 test assembly via `Directory.Build.targets` (linked source + a global `using`) - no per-file imports, no project reference.
- Applied to every concrete test class across all 11 test projects: **115 Unit / 111 Integration**, classified by actual fixture usage (WebApplicationFactory / Testcontainers / real DB / live platform -> Integration; pure logic / Moq -> Unit). Nested classes tagged individually; partial classes carry exactly one marker.

## Why

A full run was one undifferentiated list with no way to select unit vs integration. With the trait in place:

```
dotnet test -- --filter-trait "Category=Unit"
dotnet test -- --filter-query "/*/*/*/*[Category=Unit]"
```

## Verified

- Full solution builds (0 errors).
- Unit lane runs green with no container: PEP 92, Core 372, Authorization 267 - each selecting only its unit tests.

## Note

The `CollectionDefinition` formalization originally listed for this phase is moved to #3362 (Phase 3), where namespace normalization gives those consts a stable home - doing it here would churn namespaces twice.

Closes #3361
Related to #3359
