### PR TITLE
Split per-vertical CI tests into unit and integration lanes

### DIFF
--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -167,31 +167,54 @@ jobs:
         # `--no-incremental` keeps the output deterministic between this run
         # and any local rebuild — important when the SonarCloud scanner is
         # wrapping the build, which is sensitive to stale analyzer outputs.
+        id: build
         run: dotnet build -c Release --no-incremental -bl:binlog/build.binlog
         working-directory: ${{ inputs.path }}
 
-      - name: Test (with coverage)
-        # ONE test execution per CI run. dotnet-coverage collects in the
-        # native `.coverage` binary format; the two Convert steps below
-        # produce cobertura (for the threshold check) and VSCoverage XML
-        # (for Sonar) without re-running the tests. xUnit v3 routes through
-        # Microsoft Testing Platform (MTP); arguments after `--` are
-        # forwarded to each per-project MTP runner:
-        #   --results-directory   write per-project artifacts under TestResults/
-        #   --report-xunit-trx    emit .trx files (consumed by Sonar via
-        #                         sonar.cs.vstest.reportsPaths)
-        #   --ignore-exit-code 8  treat "all tests [Skip]ped" as success
-        #                         (e.g. Host.Lease without Azurite)
-        # `dotnet-coverage collect -- dotnet test` propagates the test exit
-        # code, so a real test failure (exit 2) fails this step.
-        id: test
+      # Tests run in two lanes off the single build above (#3363): a fast unit
+      # lane first, then the slower integration lane. xUnit v3 routes through
+      # Microsoft Testing Platform (MTP); arguments after `--` go to each
+      # per-project MTP runner:
+      #   --filter-trait        select the lane by the Category trait
+      #   --results-directory   per-lane subdir so the two lanes' .trx / .log
+      #                         files don't overwrite each other
+      #   --report-xunit-trx    emit .trx (consumed by Sonar via
+      #                         sonar.cs.vstest.reportsPaths = **/*.trx)
+      #   --ignore-exit-code 8  treat "no tests ran" as success — covers both
+      #                         all-[Skip]ped (e.g. Host.Lease without Azurite)
+      #                         AND a lane that selects 0 tests in a
+      #                         single-type vertical (e.g. PEP has no
+      #                         integration tests). Verified: an empty filtered
+      #                         run exits 8, which this flag maps to success.
+      # Each lane writes its own .coverage file; the Convert steps below merge
+      # TestResults/*.coverage into one report, so the threshold gate and Sonar
+      # still see whole-suite coverage. `dotnet-coverage collect -- dotnet test`
+      # propagates the test exit code, so a real failure (exit 2) fails the step.
+      - name: Test - unit lane (with coverage)
+        id: test_unit
         shell: bash
         working-directory: ${{ inputs.path }}
         run: |
           dotnet-coverage collect --nologo \
-            --output TestResults/coverage.coverage --output-format coverage \
-            -- dotnet test -c Release --no-build -bl:binlog/test.binlog \
-              -- --results-directory TestResults/ --report-xunit-trx --ignore-exit-code 8
+            --output TestResults/coverage.unit.coverage --output-format coverage \
+            -- dotnet test -c Release --no-build -bl:binlog/test-unit.binlog \
+              -- --results-directory TestResults/unit --report-xunit-trx \
+                 --filter-trait "Category=Unit" --ignore-exit-code 8
+
+      - name: Test - integration lane (with coverage)
+        # Runs even when the unit lane failed (but not when the build failed),
+        # so coverage spans the whole suite and the threshold gate is never
+        # computed on unit-only data.
+        id: test_integration
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        shell: bash
+        working-directory: ${{ inputs.path }}
+        run: |
+          dotnet-coverage collect --nologo \
+            --output TestResults/coverage.integration.coverage --output-format coverage \
+            -- dotnet test -c Release --no-build -bl:binlog/test-integration.binlog \
+              -- --results-directory TestResults/integration --report-xunit-trx \
+                 --filter-trait "Category=Integration" --ignore-exit-code 8
 
       - name: Report failed tests
         # When the Test step fails, surface the specific failing test names
@@ -203,19 +226,19 @@ jobs:
         # the step below; we mirror the failures into the log (and as
         # ::error:: annotations for the PR checks summary) so reviewers don't
         # need to download the artifact for the most common case.
-        if: failure() && steps.test.conclusion == 'failure'
+        if: failure() && (steps.test_unit.conclusion == 'failure' || steps.test_integration.conclusion == 'failure')
         shell: pwsh
         working-directory: ${{ inputs.path }}
         run: |
-          # The Test step passes `--results-directory TestResults/` to MTP,
-          # so the per-project logs land in `<vertical>/TestResults/` (and,
-          # for some configurations, in the per-project `bin/.../TestResults/`).
-          # Match either layout — the `Directory.Name -eq 'TestResults'`
-          # filter still keeps us off arbitrary `*.log` files elsewhere in
-          # the working tree, while the `*_net10.0_x64.log` filename pattern
-          # already constrains to MTP-shaped per-project logs.
+          # Each lane passes `--results-directory TestResults/<lane>` to MTP,
+          # so the per-project logs land under `<vertical>/TestResults/unit/`
+          # and `.../integration/` (and, for some configurations, in the
+          # per-project `bin/.../TestResults/`). Matching any path that
+          # contains a `TestResults/` segment covers all of these while the
+          # `*_net10.0_x64.log` filename pattern keeps us on MTP-shaped
+          # per-project logs.
           $logs = Get-ChildItem -Path . -Recurse -Filter '*_net10.0_x64.log' -ErrorAction SilentlyContinue |
-                  Where-Object { $_.Directory.Name -eq 'TestResults' }
+                  Where-Object { ($_.FullName -replace '\\','/') -match '/TestResults/' }
 
           if (-not $logs) {
               Write-Host "No MTP per-project logs found in any TestResults/ directory under $(Get-Location)." -ForegroundColor Yellow
@@ -263,30 +286,31 @@ jobs:
           Write-Host "Total failing tests: $total"
 
       - name: Convert coverage to cobertura
-        # Reads the native .coverage binary written by the Test step and
-        # emits cobertura — the format the PowerShell threshold check below
-        # parses. Runs even on test failure so a coverage regression isn't
-        # masked by a separate test failure.
-        if: always() && hashFiles(format('{0}/TestResults/coverage.coverage', inputs.path)) != ''
+        # Merges the per-lane .coverage binaries (unit + integration) written
+        # by the Test steps and emits cobertura — the format the PowerShell
+        # threshold check below parses. Runs even on test failure so a coverage
+        # regression isn't masked by a separate test failure. The glob tolerates
+        # a vertical that produced only one lane's file.
+        if: always() && hashFiles(format('{0}/TestResults/*.coverage', inputs.path)) != ''
         shell: bash
         working-directory: ${{ inputs.path }}
         run: |
           dotnet-coverage merge --nologo \
             --output TestResults/coverage.cobertura.xml --output-format cobertura \
-            TestResults/coverage.coverage
+            TestResults/*.coverage
 
       - name: Convert coverage to VSCoverage XML
         # Sonar's C# scanner does not accept cobertura — it reads VSCoverage
         # XML via sonar.cs.vscoveragexml.reportsPaths (configured in the
         # repo-root SonarQube.Analysis.xml). Skip when Sonar is off for this
         # vertical (no consumer).
-        if: always() && steps.sonar-begin.outcome == 'success' && hashFiles(format('{0}/TestResults/coverage.coverage', inputs.path)) != ''
+        if: always() && steps.sonar-begin.outcome == 'success' && hashFiles(format('{0}/TestResults/*.coverage', inputs.path)) != ''
         shell: bash
         working-directory: ${{ inputs.path }}
         run: |
           dotnet-coverage merge --nologo \
             --output TestResults/coverage.xml --output-format xml \
-            TestResults/coverage.coverage
+            TestResults/*.coverage
 
       - name: SonarCloud end
         # Uploads analysis to SonarCloud. Runs on test failure too — issues
@@ -340,8 +364,8 @@ jobs:
         with:
           name: ${{ inputs.slug }}-test-results
           path: |
-            ${{ inputs.path }}/**/TestResults/*.log
-            ${{ inputs.path }}/**/TestResults/*.trx
+            ${{ inputs.path }}/**/TestResults/**/*.log
+            ${{ inputs.path }}/**/TestResults/**/*.trx
           if-no-files-found: ignore
           retention-days: 3
 

--- a/docs/testing/CI.md
+++ b/docs/testing/CI.md
@@ -14,7 +14,7 @@ For each vertical the pipeline runs:
 3. **Test + coverage (two lanes off one build)** — tests run in two
    sequential lanes selected by the `Category` trait: a fast **unit** lane
    (`--filter-trait "Category=Unit"`) then a slower **integration** lane
-   (`Category=Integration`). Both reuse the single build (`--no-build`) and
+   (`--filter-trait "Category=Integration"`). Both reuse the single build (`--no-build`) and
    each is wrapped by `dotnet-coverage collect` into its own `.coverage`
    binary (`coverage.unit.coverage` / `coverage.integration.coverage`) and
    writes TRX into a per-lane `TestResults/<lane>/` subdir. The integration

--- a/docs/testing/CI.md
+++ b/docs/testing/CI.md
@@ -11,7 +11,19 @@ For each vertical the pipeline runs:
 
 1. **SonarCloud begin** *(verticals that opt in via `conf.json`)* — `dotnet-sonarscanner begin` wraps the build/test that follow so the scanner can hook MSBuild's analyzers.
 2. **Restore + build** — `dotnet build -c Release --no-incremental`. The build inside Sonar's begin/end window is what gives the scanner its data.
-3. **Test + coverage (single pass)** — `dotnet-coverage collect` wraps `dotnet test` once, writing TRX reports plus a native `.coverage` binary. See
+3. **Test + coverage (two lanes off one build)** — tests run in two
+   sequential lanes selected by the `Category` trait: a fast **unit** lane
+   (`--filter-trait "Category=Unit"`) then a slower **integration** lane
+   (`Category=Integration`). Both reuse the single build (`--no-build`) and
+   each is wrapped by `dotnet-coverage collect` into its own `.coverage`
+   binary (`coverage.unit.coverage` / `coverage.integration.coverage`) and
+   writes TRX into a per-lane `TestResults/<lane>/` subdir. The integration
+   lane runs even if the unit lane failed (but not if the build failed) so
+   coverage spans the whole suite. The Convert steps below merge
+   `TestResults/*.coverage` into one report, so the threshold gate and Sonar
+   still see whole-suite coverage. A lane that selects 0 tests in a
+   single-type vertical (e.g. `pkg: PEP` has no integration tests) exits 8,
+   which `--ignore-exit-code 8` treats as success. See
    [`TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/41_CI_Coverage_Single_Run.md`](TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/41_CI_Coverage_Single_Run.md).
 4. **Convert coverage** — two `dotnet-coverage merge` calls turn the binary into cobertura (for the threshold check) and VSCoverage XML (for Sonar). No re-running tests.
 5. **SonarCloud end** *(verticals that opt in)* — uploads the analysis. Runs even if tests failed so issues found by the scanner are still posted. See [../SONARCLOUD.md](../SONARCLOUD.md).
@@ -32,7 +44,8 @@ xUnit v3 is self-hosted on MTP. A few things the pipeline relies on:
   [`TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/37_CI_MTP_Routing_TargetFramework_Clear.md`](TESTING_INFRASTRUCTURE_OVERHAUL/STEPS_PART_1/37_CI_MTP_Routing_TargetFramework_Clear.md).
 - MTP exit codes:
   - `0` — all tests passed
-  - `8` — all tests were `[Skip]`ped (treated as success via
+  - `8` — no tests ran: either all were `[Skip]`ped, or a `--filter-trait`
+    lane selected 0 tests in a single-type vertical (treated as success via
     `--ignore-exit-code 8`)
   - non-zero — failures
 


### PR DESCRIPTION
## What

Run each vertical's tests in two lanes off the single shared build, selected by the `Category` trait added in #3361:

- **unit lane** (`--filter-trait "Category=Unit"`) runs first, then the
- **integration lane** (`Category=Integration`).

Each lane is wrapped by its own `dotnet-coverage collect`; the Convert steps merge `TestResults/*.coverage` into one report, so the per-assembly threshold gate and Sonar still see whole-suite coverage. Per-lane `--results-directory` keeps the two lanes' `.trx`/`.log` apart.

## Why

Unit failures now surface before the slower integration tests run, and the run is grouped by type. The integration lane runs even if the unit lane failed (but not if the build failed), so coverage always spans the whole suite and the threshold gate is never computed on unit-only data.

## Scope note

This keeps the single build and is a within-job split: it improves signal ordering/grouping, not wall-clock time (the two lanes still run sequentially after one build). Genuine parallel speedup would need a larger build-once/fan-out restructure, deliberately out of scope here.

## Behaviour for single-type verticals

A lane that selects 0 tests (e.g. `pkg: PEP` has no integration tests; `app: Register` has none) exits 8, which the existing `--ignore-exit-code 8` treats as success.

## Validation

Ran the exact lane + coverage-merge sequence locally on the PEP vertical: unit lane 92/92 pass, empty integration lane exits 0, `dotnet-coverage merge TestResults/*.coverage` produces cobertura, and per-lane `.trx` land under `TestResults/<lane>/`. Mixed-vertical real+real coverage merges are exercised by this PR's own CI run.

Closes #3363
Related to #3359
