### PR TITLE
chore: add authentication as valid platform token app to create seln-assignments

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Controllers/InternalConnectionsController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Internal/Controllers/InternalConnectionsController.cs
@@ -242,6 +242,7 @@ public class InternalConnectionsController(IConnectionService connectionService)
             return appClaimValue switch
             {
                 "register" => true,
+                "authentication" => true,
                 _ => false,
             };
         }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Internal.Tests/Controllers/InternalConnectionsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Internal.Tests/Controllers/InternalConnectionsControllerTest.cs
@@ -112,6 +112,23 @@ public class InternalConnectionsControllerTest
         }
 
         [Fact]
+        public async Task PostSelfIdentifiedUser_SameGuidFromAndTo_Edu_PlatformIssuerWithAuthenticationAppClaim_ReturnsOk()
+        {
+            var client = CreateClientWithPlatformToken("authentication");
+
+            var entityId = TestEntities.EduUserHermioneGranger.Id;
+            var response = await client.PostAsync($"{Route}/selfidentifiedusers?from={entityId}&to={entityId}", null, TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<AssignmentDto>(data);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(entityId, result.FromId);
+            Assert.Equal(entityId, result.ToId);
+            Assert.Equal(RoleConstants.SelfRegisteredUser, result.RoleId);
+        }
+
+        [Fact]
         public async Task PostSelfIdentifiedUser_SameGuidFromAndTo_PlatformIssuerWithRegisterAppClaim_ReturnsProblem()
         {
             var client = CreateClientWithPlatformToken("register");


### PR DESCRIPTION
- needed as authentication is to take the responsibility to call accmgmt when connecting email and a2-legacy si-users

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #2985

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
