### PR TITLE
fix: serialize StaticDataIngest with an advisory lock to stop pk_entity races

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/StaticDataIngest.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/StaticDataIngest.cs
@@ -15,8 +15,37 @@ public static partial class StaticDataIngest
 {
     private static AuditValues AuditValues { get; set; } = new(SystemEntityConstants.StaticDataIngest, SystemEntityConstants.StaticDataIngest, Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
 
+    /// <summary>
+    /// Fixed key for the transaction-scoped advisory lock that serializes
+    /// <see cref="IngestAll"/> against a single database (ASCII "ACMINGST").
+    /// </summary>
+    private const long IngestAdvisoryLockKey = 0x4143_4D49_4E47_5354;
+
     public static async Task IngestAll(AppDbContext dbContext, CancellationToken cancellationToken = default)
     {
+        // Each AutoIngest below is read-existing-ids-then-insert-missing. That is
+        // idempotent when run sequentially, but races under concurrency: two
+        // callers can both observe a row as absent and both INSERT it, violating
+        // its primary key (e.g. pk_entity). IngestAll is reachable from several
+        // paths against the same database — the EF UseAsyncSeeding hook on every
+        // MigrateAsync, the explicit startup call in Program.Init, and the
+        // integration-test fixtures — so those paths can overlap.
+        //
+        // Take a transaction-scoped Postgres advisory lock so concurrent ingests
+        // serialize: the second waits for the first to commit, then sees the rows
+        // as present and updates instead of inserting. The lock auto-releases when
+        // the transaction commits or rolls back. If a transaction is already
+        // active (e.g. a caller wrapped the ingest), reuse it rather than nesting;
+        // disposing the owned transaction without committing rolls it back.
+        var ownsTransaction = dbContext.Database.CurrentTransaction is null;
+        await using var transaction = ownsTransaction
+            ? await dbContext.Database.BeginTransactionAsync(cancellationToken)
+            : null;
+
+        await dbContext.Database.ExecuteSqlAsync(
+            $"SELECT pg_advisory_xact_lock({IngestAdvisoryLockKey})",
+            cancellationToken);
+
         /* ProviderType */
         await AutoIngest(
             dbContext,
@@ -152,6 +181,11 @@ public static partial class StaticDataIngest
         await IngestRoleMap(dbContext, cancellationToken);
         await IngestRolePackage(dbContext, cancellationToken);
         await IngestEntityVariantRole(dbContext, cancellationToken);
+
+        if (ownsTransaction)
+        {
+            await transaction!.CommitAsync(cancellationToken);
+        }
     }
 
     internal static async Task AutoIngest<T>(

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/StaticDataIngest.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/StaticDataIngest.cs
@@ -32,10 +32,10 @@ public static partial class StaticDataIngest
         // paths can overlap.
         //
         // Take a transaction-scoped Postgres advisory lock so concurrent ingests
-        // serialize: the second waits for the first to commit, then sees the rows
-        // as present and updates instead of inserting. The lock auto-releases on
-        // commit/rollback. Transaction handling mirrors AppDbContext.SaveChangesAsync:
-        // only own (and commit/rollback) the transaction when one isn't already active.
+        // serialize: the second waits for the first to finish, then sees the rows
+        // as present and updates instead of inserting. The lock is released when the
+        // transaction ends. The transaction is owned here only when one is not
+        // already active, matching how AppDbContext handles its own writes.
         var currentTransaction = dbContext.Database.CurrentTransaction is not null;
         using var transaction = currentTransaction ? null : await dbContext.Database.BeginTransactionAsync(cancellationToken);
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/StaticDataIngest.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/StaticDataIngest.cs
@@ -23,29 +23,48 @@ public static partial class StaticDataIngest
 
     public static async Task IngestAll(AppDbContext dbContext, CancellationToken cancellationToken = default)
     {
-        // Each AutoIngest below is read-existing-ids-then-insert-missing. That is
-        // idempotent when run sequentially, but races under concurrency: two
-        // callers can both observe a row as absent and both INSERT it, violating
-        // its primary key (e.g. pk_entity). IngestAll is reachable from several
-        // paths against the same database — the EF UseAsyncSeeding hook on every
-        // MigrateAsync, the explicit startup call in Program.Init, and the
-        // integration-test fixtures — so those paths can overlap.
+        // AutoIngest is read-existing-ids-then-insert-missing: idempotent when run
+        // sequentially, but it races under concurrency — two callers can both
+        // observe a row as absent and both INSERT it, violating its primary key
+        // (e.g. pk_entity). IngestAll is reachable from several paths against the
+        // same database (the EF UseAsyncSeeding hook on every MigrateAsync, the
+        // explicit Program.Init call, and the integration-test fixtures), so those
+        // paths can overlap.
         //
         // Take a transaction-scoped Postgres advisory lock so concurrent ingests
         // serialize: the second waits for the first to commit, then sees the rows
-        // as present and updates instead of inserting. The lock auto-releases when
-        // the transaction commits or rolls back. If a transaction is already
-        // active (e.g. a caller wrapped the ingest), reuse it rather than nesting;
-        // disposing the owned transaction without committing rolls it back.
-        var ownsTransaction = dbContext.Database.CurrentTransaction is null;
-        await using var transaction = ownsTransaction
-            ? await dbContext.Database.BeginTransactionAsync(cancellationToken)
-            : null;
+        // as present and updates instead of inserting. The lock auto-releases on
+        // commit/rollback. Transaction handling mirrors AppDbContext.SaveChangesAsync:
+        // only own (and commit/rollback) the transaction when one isn't already active.
+        var currentTransaction = dbContext.Database.CurrentTransaction is not null;
+        using var transaction = currentTransaction ? null : await dbContext.Database.BeginTransactionAsync(cancellationToken);
 
-        await dbContext.Database.ExecuteSqlAsync(
-            $"SELECT pg_advisory_xact_lock({IngestAdvisoryLockKey})",
-            cancellationToken);
+        try
+        {
+            await dbContext.Database.ExecuteSqlAsync(
+                $"SELECT pg_advisory_xact_lock({IngestAdvisoryLockKey})",
+                cancellationToken);
 
+            await IngestStaticData(dbContext, cancellationToken);
+
+            if (transaction is { })
+            {
+                await transaction.CommitAsync(cancellationToken);
+            }
+        }
+        catch
+        {
+            if (transaction is { })
+            {
+                await transaction.RollbackAsync(cancellationToken);
+            }
+
+            throw;
+        }
+    }
+
+    private static async Task IngestStaticData(AppDbContext dbContext, CancellationToken cancellationToken)
+    {
         /* ProviderType */
         await AutoIngest(
             dbContext,
@@ -181,11 +200,6 @@ public static partial class StaticDataIngest
         await IngestRoleMap(dbContext, cancellationToken);
         await IngestRolePackage(dbContext, cancellationToken);
         await IngestEntityVariantRole(dbContext, cancellationToken);
-
-        if (ownsTransaction)
-        {
-            await transaction!.CommitAsync(cancellationToken);
-        }
     }
 
     internal static async Task AutoIngest<T>(

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/StaticDataIngest.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/StaticDataIngest.cs
@@ -16,10 +16,12 @@ public static partial class StaticDataIngest
     private static AuditValues AuditValues { get; set; } = new(SystemEntityConstants.StaticDataIngest, SystemEntityConstants.StaticDataIngest, Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
 
     /// <summary>
-    /// Fixed key for the transaction-scoped advisory lock that serializes
-    /// <see cref="IngestAll"/> against a single database (ASCII "ACMINGST").
+    /// Namespace component of the transaction-scoped advisory lock that serializes
+    /// <see cref="IngestAll"/> (ASCII "ACMI"). Paired with the current database's
+    /// oid so the lock is scoped per database — Postgres advisory locks are
+    /// otherwise global to the whole server instance.
     /// </summary>
-    private const long IngestAdvisoryLockKey = 0x4143_4D49_4E47_5354;
+    private const int IngestAdvisoryLockKey = 0x4143_4D49;
 
     public static async Task IngestAll(AppDbContext dbContext, CancellationToken cancellationToken = default)
     {
@@ -34,15 +36,18 @@ public static partial class StaticDataIngest
         // Take a transaction-scoped Postgres advisory lock so concurrent ingests
         // serialize: the second waits for the first to finish, then sees the rows
         // as present and updates instead of inserting. The lock is released when the
-        // transaction ends. The transaction is owned here only when one is not
-        // already active, matching how AppDbContext handles its own writes.
+        // transaction ends. Advisory locks are global to the Postgres instance, so
+        // the key is paired with the current database's oid to scope it per database,
+        // letting different test databases on one server still ingest concurrently.
+        // The transaction is owned here only when one is not already active, matching
+        // how AppDbContext handles its own writes.
         var currentTransaction = dbContext.Database.CurrentTransaction is not null;
         using var transaction = currentTransaction ? null : await dbContext.Database.BeginTransactionAsync(cancellationToken);
 
         try
         {
             await dbContext.Database.ExecuteSqlAsync(
-                $"SELECT pg_advisory_xact_lock({IngestAdvisoryLockKey})",
+                $"SELECT pg_advisory_xact_lock({IngestAdvisoryLockKey}, (SELECT oid FROM pg_database WHERE datname = current_database())::int)",
                 cancellationToken);
 
             await IngestStaticData(dbContext, cancellationToken);


### PR DESCRIPTION
## Problem

`AccessMgmt.Tests` intermittently fails CI with `Npgsql.PostgresException 23505: duplicate key value violates unique constraint "pk_entity"` — a single failure among ~1331 tests, with the offending entity varying run to run. That signature is a read-then-write race, not a bug in any one test.

## Root cause

`StaticDataIngest.AutoIngest` is read-existing-ids-then-insert-missing: it `SELECT`s which seed ids already exist, then `Add()`s the rest and `SaveChanges`. Idempotent when run sequentially, but **not atomic** — two concurrent runs against the same database both observe a row as absent and both `INSERT` it, violating the primary key.

`IngestAll` is reachable from several paths against the same database, which overlap in the integration suite:
- the EF `UseAsyncSeeding` hook, which fires on every `MigrateAsync`;
- the explicit call in `Program.Init` (host startup when `RunIntegrationTests=true`, i.e. `LegacyApiFixture`);
- the test fixtures (`LegacyApiFixture` host startup, `PostgresFixture.InitializeAsync`).

Production guards startup init with a distributed lease, but the seeding hook runs the ingest outside it, so the race is latent on a cold production boot too.

## Fix

Wrap the ingest in a transaction-scoped Postgres advisory lock (`pg_advisory_xact_lock`). Concurrent ingests now serialize: the second waits for the first to commit, then sees the rows as present and updates instead of inserting. An already-active transaction is reused rather than nested, and the lock auto-releases on commit/rollback. Side benefit: the ingest is now atomic.

No test logic changed; the production code path is unchanged in behaviour aside from being concurrency-safe and atomic.

## Validation

- Build green.
- Ran the `LegacyApiFixture` smoke test (exercises the template-build seeding hook + the host-startup double-ingest) — passes.
- Ran the `Integration.Services` namespace (586 tests across several ingest-heavy hosts in parallel) — all pass, no deadlock.
- CI's AccessManagement integration lane is the real stress test for the race and runs on this PR.

Fixes #3376
