### PR TITLE
refactor(test): shared PostgresTestEngine — dedup the Testcontainers Postgres harness

### DIFF
--- a/docs/testing/FIXTURES.md
+++ b/docs/testing/FIXTURES.md
@@ -118,7 +118,10 @@ consumers get rewritten on EF seed data over time and the fixture is retired.
 ## `EFPostgresFactory` — how the DB is provisioned
 
 Under the hood, `ApiFixture` delegates database provisioning to
-`EFPostgresFactory`. The strategy:
+`EFPostgresFactory`, a thin wrapper over the shared
+[`PostgresTestEngine`](../../src/testing/PostgresTestEngine.cs) (linked into test
+assemblies that set `IncludePostgresTestEngine`, the same mechanism as the
+`[UnitTest]`/`[IntegrationTest]` markers). The strategy:
 
 1. A **single** PostgreSQL container is shared across every fixture in the
    test run (reference counted).
@@ -137,16 +140,22 @@ PostgreSQL container is needed.
 
 ### Graceful skip when no container runtime is available
 
-`EFPostgresFactory` detects the absence of a Docker / Podman socket and calls
-`Assert.Skip(...)` so the suite doesn't fail on developer machines without a
-runtime.
+When no Docker / Podman socket is reachable, `PostgresTestEngine` records a
+`SkipReason` instead of throwing — a skip raised from a fixture's
+`InitializeAsync` surfaces as a fixture-init *failure*, not a skip, in xUnit v3.
+Fixtures convert that reason to a per-test skip: `AuthorizationDbFixture` exposes
+`SkipReason` and its tests call `Assert.SkipWhen(...)`. `ApiFixture` /
+`EFPostgresFactory` still surface a missing runtime as a failure (converting its
+many test classes to the per-test-skip pattern is tracked separately); in CI a
+runtime is always present.
 
 ## Other fixtures
 
-- **`AuthorizationDbFixture`** (`Altinn.Authorization.Tests`) — a Testcontainers
-  PostgreSQL fixture used directly by the Authorization delegation-metadata
-  repository tests. (`AuthorizationApiFixture` itself is mock-backed and needs
-  no container.)
+- **`AuthorizationDbFixture`** (`Altinn.Authorization.Tests`) — provides a
+  PostgreSQL database with the Authorization Yuniql schema for the
+  delegation-metadata repository tests. Backed by the shared `PostgresTestEngine`
+  (the Yuniql scripts are replayed once into a template; each test class gets a
+  clone). (`AuthorizationApiFixture` itself is mock-backed and needs no container.)
 - **`PlatformFixture`** (`Altinn.Authorization.Integration.Tests`) — wires up the
   platform-integration clients against the **live** platform; its tests
   `Assert.Skip(...)` when credentials/config are missing, so they don't run in a

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -52,6 +52,18 @@
                 <Using Include="Altinn.Authorization.Testing" />
             </ItemGroup>
 
+            <!-- Shared PostgreSQL test engine (template-clone provisioning + the
+                 correct xUnit v3 Docker-skip). Opt-in because it pulls Testcontainers
+                 + Npgsql: set <IncludePostgresTestEngine>true</IncludePostgresTestEngine>
+                 in projects that provision a real PostgreSQL for tests (they must
+                 already reference Testcontainers.PostgreSql and Npgsql). Linked
+                 source, like the category markers above — no project reference. -->
+            <ItemGroup Condition=" '$(IncludePostgresTestEngine)' == 'true' ">
+                <Compile Include="$(MSBuildThisFileDirectory)testing\PostgresTestEngine.cs">
+                    <Link>Properties\PostgresTestEngine.cs</Link>
+                </Compile>
+            </ItemGroup>
+
             <ItemGroup Condition=" '$(IsTestLibrary)' == 'true' ">
                 <PackageReference Include="xunit.assert" Condition=" '$(XUnitVersion)' == 'v2' " />
                 <PackageReference Include="xunit.extensibility.core" Condition=" '$(XUnitVersion)' == 'v2' " />

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Altinn.AccessManagement.TestUtils.csproj
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Altinn.AccessManagement.TestUtils.csproj
@@ -8,6 +8,8 @@
              discovered). -->
         <IsTestProject>false</IsTestProject>
         <IsTestLibrary>true</IsTestLibrary>
+        <!-- Link the shared PostgreSQL test engine (src/testing/PostgresTestEngine.cs). -->
+        <IncludePostgresTestEngine>true</IncludePostgresTestEngine>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Factories/EFPostgresFactory.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Factories/EFPostgresFactory.cs
@@ -41,6 +41,8 @@ public static class EFPostgresFactory
         ApplicationUser = DbUserName,
         AdminUser = DbAdminName,
         Password = DbPassword,
+        // AccessManagement's test app role has always been a superuser; keep it.
+        ApplicationUserIsSuperuser = true,
         BuildTemplateAsync = BuildTemplateAsync,
     });
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Factories/EFPostgresFactory.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Factories/EFPostgresFactory.cs
@@ -1,37 +1,26 @@
-﻿using Altinn.AccessManagement.Persistence.Configuration;
+using Altinn.AccessManagement.Persistence.Configuration;
 using Altinn.AccessMgmt.PersistenceEF.Audit;
 using Altinn.AccessMgmt.PersistenceEF.Constants;
 using Altinn.AccessMgmt.PersistenceEF.Contexts;
 using Altinn.AccessMgmt.PersistenceEF.Extensions;
 using Altinn.Authorization.Host.Database;
+using Altinn.Authorization.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Npgsql;
-using Testcontainers.PostgreSql;
-using Xunit.Sdk;
+using Xunit;
 
 namespace Altinn.AccessManagement.TestUtils.Factories;
 
 /// <summary>
-/// Test helper that provisions a PostgreSQL container and provides per-test
-/// databases. On first use the factory starts a PostgreSQL container, creates
-/// a migrated and seeded template database, and thereafter returns cloned
-/// databases based on that template to provide isolation between tests.
+/// Test helper that provisions per-test databases backed by the shared
+/// <see cref="PostgresTestEngine"/>: on first use it starts a PostgreSQL
+/// container, builds a migrated and seeded template database, and thereafter
+/// returns fast clones of that template.
 /// </summary>
 public static class EFPostgresFactory
 {
-    private static PostgreSqlContainer Server { get; } = new PostgreSqlBuilder()
-        .WithCleanUp(true)
-        .WithImage("docker.io/postgres:16.1-alpine")
-        .Build();
-
-    private static readonly SemaphoreSlim _semaphore = new(1, 1);
-
-    private static bool _isInitialized = false;
-
-    private static int _databaseInstance = 0;
-
     /// <summary>
     /// Password used for the test database users.
     /// </summary>
@@ -47,95 +36,51 @@ public static class EFPostgresFactory
     /// </summary>
     public static readonly string DbAdminName = "platform_authorization_admin";
 
+    private static readonly PostgresTestEngine _engine = new(new PostgresTestEngineOptions
+    {
+        ApplicationUser = DbUserName,
+        AdminUser = DbAdminName,
+        Password = DbPassword,
+        BuildTemplateAsync = BuildTemplateAsync,
+    });
+
     /// <summary>
-    /// Creates and returns a new database instance for a test. The first call
-    /// initializes the container, sets up roles and a migrated template database
-    /// named <c>test_primary</c>, and seeds it with test data. Subsequent calls
-    /// create cloned databases using <c>CREATE DATABASE ... WITH TEMPLATE test_primary</c>.
+    /// Creates and returns a new database instance for a test, cloned from the
+    /// shared migrated + seeded template. The first call starts the container and
+    /// builds the template; subsequent calls only clone.
     /// </summary>
     /// <returns>A <see cref="PostgresDatabase"/> describing the newly created database.</returns>
-    /// <exception cref="XunitException">Thrown when bootstrapping the primary database or roles fails.</exception>
     public static async Task<PostgresDatabase> Create()
     {
-        await _semaphore.WaitAsync();
-        try
+        var database = await _engine.CreateDatabaseAsync();
+        if (database is null)
         {
-            if (!_isInitialized)
+            // No container runtime. The engine records the reason rather than
+            // throwing; surface it as a skip here (note: a skip thrown from a
+            // fixture's InitializeAsync still reports as a fixture-init failure in
+            // xUnit v3 — converting ApiFixture to a per-test skip is tracked
+            // separately).
+            Assert.Skip(_engine.SkipReason ?? "Docker/Testcontainers unavailable");
+            return null!;
+        }
+
+        return new PostgresDatabase(database.Name, database.Admin.ToString());
+    }
+
+    private static async Task BuildTemplateAsync(PostgresTestDatabase template)
+    {
+        using var sp = new ServiceCollection()
+            .AddAccessManagementDatabase(opts =>
             {
-                try
-                {
-                    await Server.StartAsync();
-                }
-                catch (Exception ex)
-                {
-                    // On Linux CI runners a Docker daemon outage or image-pull
-                    // failure (rate limiting, network) would otherwise surface
-                    // as an opaque Testcontainers timeout. Convert to a clear
-                    // xUnit v3 skip so all-skipped verticals exit 8, which the
-                    // `Test` workflow step already tolerates via
-                    // `--ignore-exit-code 8`.
-                    Assert.Skip($"Docker/Testcontainers unavailable: {ex.GetBaseException().Message}");
-                }
+                opts.MigrationConnectionString = template.Admin.ToString();
+                opts.Source = SourceType.Migration;
+                opts.EnableEFPooling = false;
+            }).BuildServiceProvider();
 
-                const string templateDb = "test_primary";
-
-                var roleResult = await Server.ExecScriptAsync($@"
-                DO $$
-                    BEGIN
-                    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{DbUserName}') THEN
-                        CREATE ROLE {DbUserName} LOGIN PASSWORD '{DbPassword}' SUPERUSER INHERIT;
-                    END IF;
-                    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{DbAdminName}') THEN
-                        CREATE ROLE {DbAdminName} LOGIN PASSWORD '{DbPassword}' SUPERUSER INHERIT;
-                    END IF;
-                END $$;
-                ");
-
-                if (roleResult.ExitCode != 0 || !string.IsNullOrEmpty(roleResult.Stderr))
-                {
-                    throw new XunitException($"Role init failed. Exitcode {roleResult.ExitCode}, Error {roleResult.Stderr}");
-                }
-
-                var createDbResult = await Server.ExecScriptAsync($@"CREATE DATABASE {templateDb};");
-                if (createDbResult.ExitCode != 0 || !string.IsNullOrEmpty(createDbResult.Stderr))
-                {
-                    throw new XunitException($"Create Db failed. Exitcode {createDbResult.ExitCode}, Error {createDbResult.Stderr}");
-                }
-
-                var connString = new PostgresDatabase(templateDb, Server.GetConnectionString());
-
-                using var sp = new ServiceCollection()
-                    .AddAccessManagementDatabase(opts =>
-                    {
-                        opts.MigrationConnectionString = connString.Admin.ToString();
-                        opts.Source = SourceType.Migration;
-                        opts.EnableEFPooling = false;
-                    }).BuildServiceProvider();
-
-                var audit = new AuditValues(SystemEntityConstants.StaticDataIngest);
-                using var db = sp.CreateEFScope(audit).ServiceProvider.GetRequiredService<AppDbContext>();
-                await db.Database.MigrateAsync();
-                await TestDataSeeds.Exec(db);
-                NpgsqlConnection.ClearAllPools();
-                _isInitialized = true;
-            }
-        }
-        finally
-        {
-            _semaphore.Release();
-        }
-
-        var dbInstance = Interlocked.Increment(ref _databaseInstance);
-        var dbName = $"test_{dbInstance}";
-
-        var cloneResult = await Server.ExecScriptAsync($"CREATE DATABASE {dbName} WITH TEMPLATE test_primary OWNER {DbUserName};");
-
-        if (cloneResult.ExitCode != 0 || !string.IsNullOrEmpty(cloneResult.Stderr))
-        {
-            throw new XunitException($"create database with template failed. Exitcode {cloneResult.ExitCode}, Error {cloneResult.Stderr}");
-        }
-
-        return new PostgresDatabase(dbName, Server.GetConnectionString());
+        var audit = new AuditValues(SystemEntityConstants.StaticDataIngest);
+        using var db = sp.CreateEFScope(audit).ServiceProvider.GetRequiredService<AppDbContext>();
+        await db.Database.MigrateAsync();
+        await TestDataSeeds.Exec(db);
     }
 }
 

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Altinn.Authorization.Tests.csproj
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Altinn.Authorization.Tests.csproj
@@ -5,6 +5,8 @@
              dotnet test routes to the Microsoft Testing Platform (required for xUnit v3). -->
         <TargetFramework></TargetFramework>
         <TargetFrameworks>net10.0</TargetFrameworks>
+        <!-- Link the shared PostgreSQL test engine (src/testing/PostgresTestEngine.cs). -->
+        <IncludePostgresTestEngine>true</IncludePostgresTestEngine>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationDbFixture.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationDbFixture.cs
@@ -34,6 +34,9 @@ public sealed class AuthorizationDbFixture : IAsyncLifetime
 {
     private static readonly PostgresTestEngine Engine = new(new PostgresTestEngineOptions
     {
+        // The application role stays a normal (non-superuser) login role — the
+        // engine default — matching production and this fixture's prior behaviour,
+        // so missing GRANTs surface instead of being masked.
         BuildTemplateAsync = ApplyMigrationsAsync,
     });
 

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationDbFixture.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationDbFixture.cs
@@ -1,138 +1,98 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Npgsql;
-using Testcontainers.PostgreSql;
 using Xunit;
 
 namespace Altinn.Authorization.Tests.Fixtures;
 
 /// <summary>
-/// Provisions a PostgreSQL container, bootstraps the AuthorizationDB roles +
-/// schema, and replays the Yuniql migration scripts shipped with
-/// <c>Altinn.Authorization</c>. Tests can pull <see cref="ApplicationConnectionString"/>
-/// to exercise <c>DelegationMetadataRepository</c> against a real database.
+/// Provides a PostgreSQL database carrying the AuthorizationDB schema (the Yuniql
+/// migration scripts shipped with <c>Altinn.Authorization</c>) so tests can
+/// exercise <c>DelegationMetadataRepository</c> against a real database via
+/// <see cref="ApplicationConnectionString"/>.
 /// </summary>
 /// <remarks>
+/// <para>
+/// Backed by the shared <see cref="PostgresTestEngine"/>: the migration scripts are
+/// replayed once into a template database, and each test class gets a fast
+/// <c>CREATE DATABASE ... WITH TEMPLATE</c> clone — instead of starting a container
+/// and re-running every script per fixture.
+/// </para>
+/// <para>
 /// On hosts where Docker / Testcontainers is unavailable, <see cref="SkipReason"/>
-/// is populated and <see cref="ApplicationConnectionString"/> is left empty.
-/// Tests should call <c>Assert.SkipWhen(fixture.SkipReason is not null, fixture.SkipReason!)</c>
-/// at the top of their body — <c>Assert.Skip</c> raised from
-/// <see cref="IAsyncLifetime.InitializeAsync"/> propagates as a fixture-init
-/// failure rather than a test skip in xUnit v3, so the check has to live on the
-/// per-test path.
+/// is populated and <see cref="ApplicationConnectionString"/> is left empty. Tests
+/// must call <c>Assert.SkipWhen(fixture.SkipReason is not null, fixture.SkipReason!)</c>
+/// at the top of their body — a skip thrown from <c>InitializeAsync</c> surfaces as
+/// a fixture-init failure, not a skip, in xUnit v3, so the engine records the reason
+/// instead of throwing and the check has to live on the per-test path.
+/// </para>
 /// </remarks>
 public sealed class AuthorizationDbFixture : IAsyncLifetime
 {
-    private const string AppUser = "platform_authorization";
-    private const string AdminUser = "platform_authorization_admin";
-    private const string Password = "Password";
-    private const string DatabaseName = "authorizationdb";
-
-    private PostgreSqlContainer? _container;
+    private static readonly PostgresTestEngine Engine = new(new PostgresTestEngineOptions
+    {
+        BuildTemplateAsync = ApplyMigrationsAsync,
+    });
 
     /// <summary>
-    /// Connection string for the application-level <c>platform_authorization</c>
-    /// user, scoped to the bootstrapped <c>authorizationdb</c> database.
-    /// Empty when <see cref="SkipReason"/> is set.
+    /// Connection string for the application-level user, scoped to a clone of the
+    /// migrated template. Empty when <see cref="SkipReason"/> is set.
     /// </summary>
     public string ApplicationConnectionString { get; private set; } = string.Empty;
 
     /// <summary>
-    /// Set when the fixture cannot provision a real PostgreSQL container
-    /// (typically: Docker daemon not running). Tests that depend on the
-    /// fixture should call <c>Assert.SkipWhen</c> on this value before doing
-    /// any work that requires <see cref="ApplicationConnectionString"/>.
+    /// Set when no container runtime is available. Tests should call
+    /// <c>Assert.SkipWhen</c> on this before using <see cref="ApplicationConnectionString"/>.
     /// </summary>
     public string? SkipReason { get; private set; }
 
     /// <inheritdoc />
     public async ValueTask InitializeAsync()
     {
-        try
+        var database = await Engine.CreateDatabaseAsync();
+        if (database is null)
         {
-            // Both the builder's `.Build()` and `StartAsync` reach for the Docker
-            // daemon, so the construction has to live inside the try/catch — running
-            // it as a field initializer would surface a fixture-construction
-            // failure that no test-level skip can intercept.
-            _container = new PostgreSqlBuilder()
-                .WithImage("docker.io/postgres:16.1-alpine")
-                .WithCleanUp(true)
-                .Build();
-            await _container.StartAsync();
-        }
-        catch (Exception ex)
-        {
-            // Throwing — including via Assert.Skip — from IAsyncLifetime.InitializeAsync
-            // surfaces as a fixture-init failure (every dependent test is reported
-            // failed with "Class fixture type ... threw"), not as a skip. Stash the
-            // reason and let each test convert it to a skip via Assert.SkipWhen.
-            SkipReason = $"Docker/Testcontainers unavailable: {ex.GetBaseException().Message}";
+            SkipReason = Engine.SkipReason;
             return;
         }
 
-        var bootstrap = await _container.ExecScriptAsync($@"
-            CREATE ROLE {AppUser} LOGIN PASSWORD '{Password}';
-            CREATE ROLE {AdminUser} LOGIN PASSWORD '{Password}' SUPERUSER;
-            CREATE DATABASE {DatabaseName} OWNER {AdminUser};
-        ");
-        if (bootstrap.ExitCode != 0)
-        {
-            throw new InvalidOperationException($"Bootstrap failed (exit {bootstrap.ExitCode}): {bootstrap.Stderr}");
-        }
-
-        var adminConnection = new NpgsqlConnectionStringBuilder(_container.GetConnectionString())
-        {
-            Database = DatabaseName,
-            Username = AdminUser,
-            Password = Password,
-        }.ToString();
-
-        await using (var conn = new NpgsqlConnection(adminConnection))
-        {
-            await conn.OpenAsync();
-
-            // Authorization migrations assume the delegation schema already exists; in
-            // production this is provisioned outside Yuniql.
-            await using (var cmd = new NpgsqlCommand("CREATE SCHEMA IF NOT EXISTS delegation;", conn))
-            {
-                await cmd.ExecuteNonQueryAsync();
-            }
-
-            foreach (var sqlFile in EnumerateMigrationFiles())
-            {
-                var sql = await File.ReadAllTextAsync(sqlFile);
-                await using var cmd = new NpgsqlCommand(sql, conn);
-                try
-                {
-                    await cmd.ExecuteNonQueryAsync();
-                }
-                catch (Exception ex)
-                {
-                    throw new InvalidOperationException($"Migration '{sqlFile}' failed: {ex.Message}", ex);
-                }
-            }
-        }
-
-        ApplicationConnectionString = new NpgsqlConnectionStringBuilder(_container.GetConnectionString())
-        {
-            Database = DatabaseName,
-            Username = AppUser,
-            Password = Password,
-        }.ToString();
+        ApplicationConnectionString = database.User.ToString();
     }
 
     /// <inheritdoc />
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static async Task ApplyMigrationsAsync(PostgresTestDatabase template)
     {
-        if (_container is not null)
+        await using var conn = new NpgsqlConnection(template.Admin.ToString());
+        await conn.OpenAsync();
+
+        // Authorization migrations assume the delegation schema already exists; in
+        // production this is provisioned outside Yuniql.
+        await using (var cmd = new NpgsqlCommand("CREATE SCHEMA IF NOT EXISTS delegation;", conn))
         {
-            await _container.DisposeAsync();
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        foreach (var sqlFile in EnumerateMigrationFiles())
+        {
+            var sql = await File.ReadAllTextAsync(sqlFile);
+            await using var cmd = new NpgsqlCommand(sql, conn);
+            try
+            {
+                await cmd.ExecuteNonQueryAsync();
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Migration '{sqlFile}' failed: {ex.Message}", ex);
+            }
         }
     }
 
-    private static System.Collections.Generic.IEnumerable<string> EnumerateMigrationFiles()
+    private static IEnumerable<string> EnumerateMigrationFiles()
     {
         var migrationDir = Path.Combine(AppContext.BaseDirectory, "Migration");
         if (!Directory.Exists(migrationDir))

--- a/src/testing/PostgresTestEngine.cs
+++ b/src/testing/PostgresTestEngine.cs
@@ -1,0 +1,220 @@
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Altinn.Authorization.Testing;
+
+/// <summary>
+/// Shared PostgreSQL provisioning engine for integration tests. Starts one
+/// Testcontainers PostgreSQL server, bootstraps the application + admin roles,
+/// builds a migrated/seeded <em>template</em> database once, and then hands out
+/// fast per-test clones via <c>CREATE DATABASE ... WITH TEMPLATE</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine is vertical-agnostic: callers supply how the template is built
+/// (EF migrations + seed, Yuniql SQL, …) through
+/// <see cref="PostgresTestEngineOptions.BuildTemplateAsync"/>. It is shared into
+/// test assemblies as linked source (see <c>src/Directory.Build.targets</c>), so
+/// each assembly gets its own static instance and container — no cross-vertical
+/// project reference.
+/// </para>
+/// <para>
+/// <strong>Docker-skip:</strong> when no container runtime is available the engine
+/// does <em>not</em> throw — it records <see cref="SkipReason"/> and returns
+/// <c>null</c> from <see cref="CreateDatabaseAsync"/>. Throwing (including
+/// <c>Assert.Skip</c>) from a fixture's <c>InitializeAsync</c> surfaces as a
+/// fixture-init failure, not a skip, in xUnit v3 — so the engine leaves the skip
+/// decision to the caller, which should stash the reason and have each test call
+/// <c>Assert.SkipWhen(fixture.SkipReason is not null, fixture.SkipReason!)</c>.
+/// </para>
+/// </remarks>
+public sealed class PostgresTestEngine
+{
+    private readonly PostgresTestEngineOptions _options;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private PostgreSqlContainer? _server;
+    private bool _templateReady;
+    private int _databaseInstance;
+
+    /// <summary>
+    /// Creates an engine with the supplied options. Construct one per test
+    /// assembly (typically a <c>static readonly</c> field on a factory/fixture).
+    /// </summary>
+    public PostgresTestEngine(PostgresTestEngineOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(options.BuildTemplateAsync);
+        _options = options;
+    }
+
+    /// <summary>
+    /// Set when the engine could not provision a container (typically: Docker /
+    /// Podman not running). While set, <see cref="CreateDatabaseAsync"/> returns
+    /// <c>null</c>. Callers should convert this to a per-test skip.
+    /// </summary>
+    public string? SkipReason { get; private set; }
+
+    /// <summary>
+    /// Returns a fresh database cloned from the shared template, or <c>null</c>
+    /// when no container runtime is available (see <see cref="SkipReason"/>). The
+    /// first call starts the container and builds the template under a lock;
+    /// subsequent calls only clone.
+    /// </summary>
+    public async Task<PostgresTestDatabase?> CreateDatabaseAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (SkipReason is not null)
+            {
+                return null;
+            }
+
+            if (!_templateReady)
+            {
+                if (!await EnsureServerStartedAsync(cancellationToken))
+                {
+                    return null;
+                }
+
+                await BootstrapRolesAsync(cancellationToken);
+                await ExecAsync($"CREATE DATABASE {_options.TemplateDatabaseName};", cancellationToken);
+                var template = NewDatabase(_options.TemplateDatabaseName);
+                await _options.BuildTemplateAsync(template);
+                NpgsqlConnection.ClearAllPools();
+                _templateReady = true;
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        var name = $"test_{Interlocked.Increment(ref _databaseInstance)}";
+        await ExecAsync(
+            $"CREATE DATABASE {name} WITH TEMPLATE {_options.TemplateDatabaseName} OWNER {_options.ApplicationUser};",
+            cancellationToken);
+        return NewDatabase(name);
+    }
+
+    private async Task<bool> EnsureServerStartedAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Both `.Build()` and `StartAsync` reach for the Docker daemon, so they
+            // must be inside the try — a field initializer would surface as an
+            // unrecoverable fixture-construction failure instead of a skip.
+            _server = new PostgreSqlBuilder()
+                .WithImage(_options.Image)
+                .WithCleanUp(true)
+                .Build();
+            await _server.StartAsync(cancellationToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            SkipReason = $"Docker/Testcontainers unavailable: {ex.GetBaseException().Message}";
+            return false;
+        }
+    }
+
+    private async Task BootstrapRolesAsync(CancellationToken cancellationToken)
+    {
+        // Idempotent: a shared container builds roles once, but keep IF NOT EXISTS
+        // so the script is safe to re-run.
+        await ExecAsync(
+            $@"
+            DO $$
+            BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{_options.ApplicationUser}') THEN
+                    CREATE ROLE {_options.ApplicationUser} LOGIN PASSWORD '{_options.Password}' SUPERUSER INHERIT;
+                END IF;
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{_options.AdminUser}') THEN
+                    CREATE ROLE {_options.AdminUser} LOGIN PASSWORD '{_options.Password}' SUPERUSER INHERIT;
+                END IF;
+            END $$;
+            ",
+            cancellationToken);
+    }
+
+    private async Task ExecAsync(string sql, CancellationToken cancellationToken)
+    {
+        var result = await _server!.ExecScriptAsync(sql, cancellationToken);
+        if (result.ExitCode != 0 || !string.IsNullOrEmpty(result.Stderr))
+        {
+            throw new InvalidOperationException(
+                $"PostgreSQL test setup failed (exit {result.ExitCode}): {result.Stderr}");
+        }
+    }
+
+    private PostgresTestDatabase NewDatabase(string databaseName) =>
+        new(databaseName, _server!.GetConnectionString(), _options);
+}
+
+/// <summary>
+/// Configuration for a <see cref="PostgresTestEngine"/>. Roles, password, and
+/// image default to the values both verticals already use; the one required
+/// member is <see cref="BuildTemplateAsync"/>.
+/// </summary>
+public sealed class PostgresTestEngineOptions
+{
+    /// <summary>Container image. Defaults to <c>postgres:16.1-alpine</c>.</summary>
+    public string Image { get; init; } = "docker.io/postgres:16.1-alpine";
+
+    /// <summary>Application-level (non-admin) login role.</summary>
+    public string ApplicationUser { get; init; } = "platform_authorization";
+
+    /// <summary>Administrative login role used for migrations and template/clone creation.</summary>
+    public string AdminUser { get; init; } = "platform_authorization_admin";
+
+    /// <summary>Password for both roles.</summary>
+    public string Password { get; init; } = "Password";
+
+    /// <summary>Name of the template database that clones are created from.</summary>
+    public string TemplateDatabaseName { get; init; } = "test_primary";
+
+    /// <summary>
+    /// Applies schema + seed data to the template database. Runs exactly once,
+    /// before any clone is created. Receives the template's connection builders.
+    /// </summary>
+    public required Func<PostgresTestDatabase, Task> BuildTemplateAsync { get; init; }
+}
+
+/// <summary>
+/// A provisioned test database, with admin and application connection-string
+/// builders. Returned by <see cref="PostgresTestEngine.CreateDatabaseAsync"/>.
+/// </summary>
+public sealed class PostgresTestDatabase
+{
+    internal PostgresTestDatabase(string name, string baseConnectionString, PostgresTestEngineOptions options)
+    {
+        Name = name;
+        Admin = BuildConnection(baseConnectionString, options.AdminUser, options.Password, name);
+        User = BuildConnection(baseConnectionString, options.ApplicationUser, options.Password, name);
+    }
+
+    /// <summary>Physical database name.</summary>
+    public string Name { get; }
+
+    /// <summary>Connection builder for the admin role (migrations, DDL).</summary>
+    public NpgsqlConnectionStringBuilder Admin { get; }
+
+    /// <summary>Connection builder for the application role.</summary>
+    public NpgsqlConnectionStringBuilder User { get; }
+
+    private static NpgsqlConnectionStringBuilder BuildConnection(string baseConnectionString, string user, string password, string database) =>
+        new(baseConnectionString)
+        {
+            Database = database,
+            Username = user,
+            Password = password,
+            IncludeErrorDetail = true,
+            Timeout = 3,
+            Pooling = true,
+            MinPoolSize = 0,
+            MaxPoolSize = 50,
+            ConnectionIdleLifetime = 30,
+            ConnectionPruningInterval = 15,
+        };
+}

--- a/src/testing/PostgresTestEngine.cs
+++ b/src/testing/PostgresTestEngine.cs
@@ -122,13 +122,15 @@ public sealed class PostgresTestEngine
     private async Task BootstrapRolesAsync(CancellationToken cancellationToken)
     {
         // Idempotent: a shared container builds roles once, but keep IF NOT EXISTS
-        // so the script is safe to re-run.
+        // so the script is safe to re-run. The application role is superuser only
+        // when opted in; the admin role is always superuser.
+        var applicationSuperuser = _options.ApplicationUserIsSuperuser ? "SUPERUSER " : string.Empty;
         await ExecAsync(
             $@"
             DO $$
             BEGIN
                 IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{_options.ApplicationUser}') THEN
-                    CREATE ROLE {_options.ApplicationUser} LOGIN PASSWORD '{_options.Password}' SUPERUSER INHERIT;
+                    CREATE ROLE {_options.ApplicationUser} LOGIN PASSWORD '{_options.Password}' {applicationSuperuser}INHERIT;
                 END IF;
                 IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{_options.AdminUser}') THEN
                     CREATE ROLE {_options.AdminUser} LOGIN PASSWORD '{_options.Password}' SUPERUSER INHERIT;
@@ -170,6 +172,14 @@ public sealed class PostgresTestEngineOptions
 
     /// <summary>Password for both roles.</summary>
     public string Password { get; init; } = "Password";
+
+    /// <summary>
+    /// Whether the application role is created as a superuser. Defaults to
+    /// <c>false</c> — a normal login role, mirroring production, so missing GRANTs
+    /// surface in integration tests instead of being masked. The admin role is
+    /// always a superuser.
+    /// </summary>
+    public bool ApplicationUserIsSuperuser { get; init; }
 
     /// <summary>Name of the template database that clones are created from.</summary>
     public string TemplateDatabaseName { get; init; } = "test_primary";


### PR DESCRIPTION
## What

The two verticals each reimplemented the same Testcontainers PostgreSQL harness, and had diverged:

- `EFPostgresFactory` (AccessManagement): migrated + seeded **template**, `CREATE DATABASE ... WITH TEMPLATE` clone per class (fast).
- `AuthorizationDbFixture` (Authorization): one database, **re-ran every Yuniql script per fixture** — no template, no clone.

Identical container image and role bootstrap in both; a third copy of the skip logic. This extracts one shared engine and puts both on it.

## Changes

- **`src/testing/PostgresTestEngine.cs`** — a vertical-agnostic provider: container lifecycle, role bootstrap, build-template-once, clone-per-test, and a correct Docker-skip. Callers supply *how* the template is built (EF migrate + seed, Yuniql SQL, …) via a delegate. Shared as **linked source** through `Directory.Build.targets` (opt-in `IncludePostgresTestEngine`) — the same mechanism as `TestCategories.cs`, so no cross-vertical project reference.
- **`EFPostgresFactory`** now delegates to the engine, keeping its public `Create()` / `PostgresDatabase` surface (behaviour-preserving).
- **`AuthorizationDbFixture`** now delegates to the engine, so it **gains the template-clone speedup** (was re-running all Yuniql per fixture). Public surface (`ApplicationConnectionString`, `SkipReason`) unchanged.

## The Docker-skip

A skip thrown from a fixture's `InitializeAsync` surfaces as a fixture-init **failure**, not a skip, in xUnit v3 (verified with a probe). The engine therefore records a `SkipReason` instead of throwing. `AuthorizationDbFixture` converts it to a per-test `Assert.SkipWhen` (as before). `ApiFixture`/`EFPostgresFactory` still surface a missing runtime as a failure — converting its many test classes to the per-test-skip pattern is a separate follow-up; CI always has a runtime.

## Validation

Built green (both verticals). Ran locally through the engine:
- AccessManagement: `Integration.Services` 586, `ConsentControllerTestEnterprise` 45 — pass (covers the `EfDatabaseFixture` and `ApiFixture`/`LegacyApiFixture` paths).
- Authorization: `DelegationMetadataRepositoryIntegrationTests` 3/3 — pass (Yuniql template-build + clone).

Closes #3424
