### PR TITLE
ci(sonar): disable SonarCloud for verticals without a real project

### DIFF
--- a/src/libs/Altinn.Authorization.Host/conf.json
+++ b/src/libs/Altinn.Authorization.Host/conf.json
@@ -1,0 +1,3 @@
+{
+  "sonarcloud": false
+}

--- a/src/libs/Altinn.Authorization.Integration/conf.json
+++ b/src/libs/Altinn.Authorization.Integration/conf.json
@@ -1,0 +1,3 @@
+{
+  "sonarcloud": false
+}

--- a/src/pkgs/Altinn.Authorization.ABAC/conf.json
+++ b/src/pkgs/Altinn.Authorization.ABAC/conf.json
@@ -1,0 +1,3 @@
+{
+  "sonarcloud": false
+}

--- a/src/pkgs/Altinn.Authorization.PEP/conf.json
+++ b/src/pkgs/Altinn.Authorization.PEP/conf.json
@@ -1,6 +1,7 @@
 {
   "deps": [
       "pkg:Altinn.Authorization.ABAC"
-    ]
+    ],
+  "sonarcloud": false
 }  
 

--- a/src/pkgs/Altinn.Authorization.PEP/conf.json
+++ b/src/pkgs/Altinn.Authorization.PEP/conf.json
@@ -1,7 +1,6 @@
 {
   "deps": [
-      "pkg:Altinn.Authorization.ABAC"
-    ],
+    "pkg:Altinn.Authorization.ABAC"
+  ],
   "sonarcloud": false
-}  
-
+}

--- a/src/tools/Altinn.Authorization.Cli/conf.json
+++ b/src/tools/Altinn.Authorization.Cli/conf.json
@@ -1,0 +1,3 @@
+{
+  "sonarcloud": false
+}


### PR DESCRIPTION
## What

Sets `"sonarcloud": false` for the five verticals that have no real SonarCloud project: PEP, ABAC, Host, Integration, Cli.

## Why

`_meta.mts` defaults `sonarcloud` to `{ enabled: true }` with a derived `projectKey: authorization-<slug>` when none is configured. So these five ran the full SonarCloud `begin`/`end` against keys that don't exist on SonarCloud (all return "Project not found") — producing no dashboard while still spending the Sonar steps (~78s each) on every scan. Only `AccessManagement` and `Authorization` have real projects (`Authorization_AccessManagement` / `Authorization_Authorization`).

This surfaced when the nightly scan (#3436) ran all seven enabled verticals. Disabling the five aligns the scanned set with the two real projects — matching the docs and README dashboard — and drops ~6 min/night of wasted runner time.

## Changes

- `pkgs/Altinn.Authorization.PEP/conf.json` — add `"sonarcloud": false`.
- New minimal `{ "sonarcloud": false }` conf.json for `pkgs/Altinn.Authorization.ABAC`, `libs/Altinn.Authorization.Host`, `libs/Altinn.Authorization.Integration`, `tools/Altinn.Authorization.Cli` (previously no conf.json → pure defaults).

Build and test for these verticals are unaffected — only the Sonar steps are gated off (same mechanism Register and Contracts already use).

Closes #3438
