### PR TITLE
test(perf): cut integration-test setup cost — measure, fixture sharing, parallelism, Task.Delay audit (#3379)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ artifacts/
 
 # Test coverage results
 TestResults/
+
+# Local FixtureTiming output (FIXTURE_TIMING_FILE)
+fixture-timing.txt

--- a/docs/testing/TEST_ARCHITECTURE.md
+++ b/docs/testing/TEST_ARCHITECTURE.md
@@ -1,0 +1,159 @@
+# Test Architecture — Target Structure
+
+Status: **proposal** (design doc; precursor to a Feature + migration Tasks).
+Scope: the AccessManagement integration/web-app test suite. Authorization is
+referenced as the pattern to copy.
+
+## 1. Why
+
+The suite's cost and flakiness are dominated by one number — **how many web-host
+builds it does** (~71, at ~1.36 s each; DB clones are cheap at 230 ms, template is
+a one-time ~9 s). The #3379 measurement proved this, and the incremental fixture
+sharing there confirmed that ad-hoc cohort sharing plateaus, because the structure
+fights it. This document is the structure those measurements point to.
+
+## 2. Current state (measured)
+
+| Fact | Value |
+|---|---|
+| `IClassFixture<ApiFixture>` classes (≈ host builds) | ~71 across 45 files |
+| Per-fixture host build (dominant cost) | ~1.36 s avg (12.9 s cold) |
+| DB clone / template build | 230 ms / 9 s one-time |
+| Classes calling `ConfigureServices` | 39 files |
+| Distinct mock interfaces across *all* those calls (the catalog) | **15** (+ 4 `RemoveAll`) |
+| API feature-flag axes | ~5 |
+| Behavioral-override files (`RemoveAll<…>`, non-default behavior) | ~12 |
+| Fixture files that never seed/query the DB | 19 (4 clearly mock the repo layer) |
+| `ApiFixture` / `LegacyApiFixture` files | 52 / 8 |
+
+## 3. Root cause
+
+**The test class is the unit of everything** — host config, seed data, isolation,
+and assertion scope are all bound to it. Every wall the incremental work hit is a
+symptom:
+
+1. **Under-provisioned base host → artificial DI divergence.** `ApiFixture`
+   registers only auth stubs + a permit-PDP, so each class patches in whichever of
+   the **same 15-mock catalog** it needs via `ConfigureServices`. The 39 calls are
+   *subsets of one catalog*, not 39 configs — but each subset forces a unique host.
+   **`AuthorizationApiFixture` already bakes its full mock graph in**, proving the
+   divergence is avoidable.
+2. **Grouping by API operation, not compatibility.** `Connections` is ~20 classes
+   (`Get`/`Check`/`Add`/`Remove`/`Update`), each rebuilding the whole host.
+3. **Class-coupled data + global assertions.** `EnsureSeedOnce<TSelf>` + exact /
+   count assertions mean shared data breaks tests — sharing is hostile by
+   construction.
+4. **DB clone even when unused.** `InitializeAsync` always clones Postgres; ~19
+   files mock the data layer.
+5. **No single convention.** `ApiFixture`, `LegacyApiFixture` (8), scenario/E2E
+   tests, and the mock-based Authorization fixture coexist.
+
+**Headline: ~71 host builds are not ~71 configs — they are ~10–12 real profiles,
+multiplied out by per-class mock-patching and per-operation splitting.**
+
+## 4. Principles
+
+- **Decouple three axes:** host configuration, data, isolation.
+- **Shared-by-default, divergence-by-exception.**
+- **Own your data:** a test reads/writes only entities it uniquely owns and asserts
+  only against them — so sharing is tolerant by construction.
+- **Pay only for what you use:** no DB for tests that don't touch it.
+
+## 5. Target architecture
+
+**A. Host profiles (finite, named).** Base fixture registers the **full 15-mock
+catalog + standard removals** once (the `AuthorizationApiFixture` pattern). Most
+classes then need zero `ConfigureServices` and join one shared host. Genuine
+variation becomes a small enumerated set of collection-fixture profiles:
+
+| Profile | Driver | Approx. classes |
+|---|---|---|
+| `Default` (full mocks, permit PDP) | no flags, no override | ~40+ |
+| `Altinn2RoleRevoke` (on/off) | feature flag | ~7 |
+| `EnableRequestAssignmentResource` / `…Package` / `EnableEnduserMaskinportenAdminApi` | feature flags | ~3 each |
+| PDP / resource-registry / http-context overrides | `RemoveAll<…>` behavior | ~12 spread over a few |
+
+→ **~71 host builds collapse to ~10–12.**
+
+**B. Data ownership.** Rich shared baseline template + each test creating entities
+under **unique IDs** and asserting only against them. Additive seeds never collide;
+exact assertions become safe; **read/write distinction dissolves** (a test that
+mutates only its own rows can share too).
+
+**C. Isolation by exception.** Shared host + owned data is the default. Only tests
+that mutate *global* state or need a divergent host get a dedicated fixture.
+
+**D. Two tiers.**
+- **Web-app tier (no DB):** mock-the-data-layer tests — no Postgres clone, no
+  DB-connected host.
+- **DB-integration tier:** real `AppDbContext` + migrations.
+
+**E. One convention.** Retire `LegacyApiFixture`; fold scenario/E2E in.
+
+## 6. Before / after (author-facing)
+
+```csharp
+// BEFORE — own host, patches mocks, seeds + asserts globally
+public class GetInstanceRights : IClassFixture<ApiFixture> {
+    public GetInstanceRights(ApiFixture f) {
+        f.ConfigureServices(s => {                 // forces a unique host
+            s.AddSingleton<IAltinn2RightsClient, Altinn2RightsClientMock>();
+            s.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
+            s.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
+        });
+        f.EnsureSeedOnce<GetInstanceRights>(db => /* shared entities */);
+    }
+}
+
+// AFTER — shared host (catalog pre-registered), owns its data, scoped assert
+[Collection(DefaultHost.Name)]                     // one host for the whole profile
+public class GetInstanceRights(DefaultHost host) {
+    [Fact] public async Task ... {
+        var party = host.NewOwnedOrg();            // unique id; no collision possible
+        // seed under `party`; assert only on `party`'s results
+    }
+}
+```
+
+## 7. Expected impact
+
+- **Host builds ~71 → ~10–12** — a structural ~6× cut (vs ~9 recovered by cohort
+  sharing).
+- **Flakiness:** the seed-interference failure class disappears; #3376 pressure drops.
+- **Parallelism:** with far fewer host builds, the single-Postgres-container plateau
+  stops being the ceiling.
+- **DB-less tier** removes unnecessary clones + DB-connected host builds.
+
+## 8. Migration plan (sized → Tasks)
+
+Each phase is independently shippable, kept green, and measured with `FixtureTiming`.
+Sizing is files/classes touched in AccessManagement.
+
+| # | Phase | Scope (sized) | Win | Risk | Task granularity |
+|---|---|---|---|---|---|
+| 1 | Enumerate profiles | done (this doc): ~10–12 | unblocks the rest | — | folded into the Feature |
+| 2 | **Provision the `Default` host** — bake the 15-mock catalog + removals into the base fixture; delete now-redundant `ConfigureServices` | 39 files | collapses ~40+ classes → 1 host (largest single win) | low — additive registration, validate per project | 1 Task (1 PR) |
+| 3 | **Owned-data + scoped assertions** — replace `EnsureSeedOnce<TSelf>` global seeds/asserts with per-test owned entities | 33 seeding files | removes condition-4 fragility; enables write-sharing | med — most careful; per-controller | 3–4 Tasks (per project/controller cluster) |
+| 4 | **DB-less web-app tier** — no-DB fixture for mock-the-data-layer tests | 4 clear, up to 19 candidates | drops clones + DB hosts | low | 1 Task |
+| 5 | **Define profiles as collection fixtures; convert classes to `[Collection]`** — *supersedes #3449's per-controller cohorts* | all ~71 | realizes the 71 → ~12 collapse | low after 2–3 | 2 Tasks (per project) |
+| 6 | **Retire `LegacyApiFixture`; unify scenario/E2E** | 8 + scenario | one convention | low | 1 Task |
+
+Suggested Feature → ~8–9 Tasks. Order matters: **2 → 3 → 4/5 → 6** (provision the
+host first; then make data shareable; then collapse onto profiles).
+
+## 9. Risks & open items
+
+- **Scope:** touches most test classes — phase per project, stay green.
+- **Discipline:** owned-data + no-per-class-DI must be conventions (review/lint) or
+  it rots back.
+- **Open numbers to confirm during Phase 1/2:** exact profile count (≤~12); the
+  DB-less set (4 confirmed, 19 candidates); any mock needing *per-test behavior*
+  (vs one impl) — those stay isolated.
+- **Relationship to PR #3447:** that PR's measurement, `FixtureTiming`, and the two
+  validated cohorts stay. This doc reframes the cohort approach: Phase 5 supersedes
+  the per-controller rollout (#3449) with profile-based collections.
+
+## Related
+
+- [TEST_SETUP_TIMING.md](TEST_SETUP_TIMING.md) — the measurements this is built on.
+- [CI.md](CI.md), [../SONARCLOUD.md](../SONARCLOUD.md).

--- a/docs/testing/TEST_SETUP_TIMING.md
+++ b/docs/testing/TEST_SETUP_TIMING.md
@@ -94,6 +94,30 @@ safely-shareable read-only cohorts in the suite. **Note:** detection of writes
 must match `PostAsJsonAsync` / `SendAsync`, not just `PostAsync` — a class that
 creates data (even a `Get…Then…` setup) is not shareable.
 
+## Parallelism (measured — no change warranted)
+
+`maxParallelThreads` sweep on `AccessMgmt.Tests` integration (972 tests, local
+Podman, 20-core host), all green:
+
+| `maxParallelThreads` | Duration | vs current |
+|---:|---:|---:|
+| 1 | 2m 55s | +49% |
+| **4 (current)** | **1m 57s** | — |
+| 8 | 2m 05s | +7% |
+| 16 | 1m 58s | +1% |
+
+The setting *is* honoured (1 → 4 is ~33% faster), but **4 is already at the
+plateau** — 4 → 8 → 16 is flat despite 20 idle cores. The limiter is not CPU; it
+is the single shared Postgres container (clone creation + connection throughput,
+`MaxPoolSize = 50`) plus the CPU-bound host builds. So raising
+`maxParallelThreads` only adds shared-state / connection pressure (cf. the #3376
+seed race) for no measured gain.
+
+**Decision: keep `maxParallelThreads: 4`.** The effective lever for these suites
+is fewer host builds (fixture sharing, above), not more threads. Going faster
+would require removing the single-container bottleneck (e.g. a container per
+worker) — out of scope and unlikely to pay off.
+
 ## Reproduce
 
 `FixtureTiming` is opt-out (disable with `FIXTURE_TIMING=off`) and writes one

--- a/docs/testing/TEST_SETUP_TIMING.md
+++ b/docs/testing/TEST_SETUP_TIMING.md
@@ -1,0 +1,58 @@
+# Integration-test setup timing (measurement)
+
+Measurement step for [#3379](https://github.com/Altinn/altinn-authorization-tmp/issues/3379):
+size where integration-test wall-clock goes **before** investing in a
+fixture-sharing refactor. Instrumented by `FixtureTiming` (linked alongside
+`PostgresTestEngine`); see [#3446](https://github.com/Altinn/altinn-authorization-tmp/issues/3446).
+
+## Result
+
+`AccessMgmt.Tests`, `Category=Integration` — **972 tests, ~2m05s**, run locally
+against Podman (`maxParallelThreads = 4`):
+
+| Phase | Total | Count | Avg | Notes |
+|---|---:|---:|---:|---|
+| App-host build (`WebApplicationFactory`) | **92.2 s** | 68 | **1,356 ms** | one per `IClassFixture` |
+| DB provision (`InitializeAsync` → factory) | 56.2 s | 68 | 826 ms | includes template + clone |
+| DB clone (`CREATE DATABASE … WITH TEMPLATE`) | **18.4 s** | 80 | **230 ms** | per provisioned database |
+| Template build (migrate + seed) | 9.3 s | 1 | — | one-time per process |
+
+## Conclusion
+
+- **Host build dominates setup — ~5× the total clone cost (92 s vs 18 s).**
+  The DB layer is already cheap: a clone is ~230 ms, and the migrated/seeded
+  template is built once (~9 s). This confirms the #3379 hypothesis — the
+  bottleneck is the **68 unshared `WebApplicationFactory` host builds**, not the
+  database.
+- The first host build is much slower (~13 s cold, JIT + EF model warm-up); the
+  amortized average across 68 fixtures is ~1.36 s.
+- This run covers `AccessMgmt.Tests` only (68 host-building fixtures). The other
+  AccessManagement test projects add more `ApiFixture` instances — the
+  repo-wide figure cited in #3379 is 111 `IClassFixture` / 85 `ApiFixture`,
+  every one a separate cold host build.
+
+## Implication for the next step
+
+Sharing one host across the read-only, additive-seed cohort via
+`ICollectionFixture` collapses N cold host builds into one. If ~⅔ of the 68
+fixtures here are shareable, that removes ~40–45 host builds (~60 s of
+serial-equivalent build work) — the lever the next #3379 sub-task prototypes
+and measures. Clone/template work is left alone; it is already cheap.
+
+## Reproduce
+
+`FixtureTiming` is opt-out (disable with `FIXTURE_TIMING=off`) and writes one
+summary line to stdout and, when `FIXTURE_TIMING_FILE` is set, appends it to
+that file (stdout is swallowed by MTP / `dotnet-coverage` in CI).
+
+```bash
+# Local run against a container runtime (here: Podman; Docker Desktop works too).
+FIXTURE_TIMING_FILE="$PWD/fixture-timing.txt" \
+DOCKER_HOST="npipe://./pipe/podman-machine-default" \
+TESTCONTAINERS_RYUK_DISABLED=true \
+dotnet test src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/AccessMgmt.Tests.csproj \
+  -c Release -- --filter-trait "Category=Integration" --ignore-exit-code 8
+```
+
+Numbers are from local Podman; absolute values differ on CI hardware, but the
+**ratio** (host build ≫ clone) is the hardware-independent finding.

--- a/docs/testing/TEST_SETUP_TIMING.md
+++ b/docs/testing/TEST_SETUP_TIMING.md
@@ -54,12 +54,30 @@ saving exceeds the 6 eliminated builds because removing them also cut CPU
 contention on the remaining 19 (avg build 5.2 s → 2.8 s). Clone/template work is
 untouched; it is already cheap.
 
-**Shareability rule (for rolling this out):** a class can join the shared
-collection only if it (a) seeds additively via `EnsureSeedOnce<TSelf>`, (b) never
-calls `ConfigureServices` / `WithAppsettings` / `With*FeatureFlag`, and (c) issues
-no writes against rows other members read. Anything else keeps its own
-`IClassFixture`. The next #3379 sub-task rolls this rule out across the broader
-cohort.
+**Shareability rule.** A class can join a shared collection only if it:
+
+1. seeds additively via `EnsureSeedOnce<TSelf>`,
+2. never calls `ConfigureServices` / `WithAppsettings` / `With*FeatureFlag`,
+3. issues no writes against rows other members read, **and**
+4. asserts *scoped / subset* results — not exact-equals or counts that another
+   member's additive seed would change.
+
+Conditions 1–3 are statically checkable; **4 is not** — it only surfaces at
+runtime, so every converted cohort is run before it is kept. Anything failing the
+rule keeps its own `IClassFixture`.
+
+## Rollout status
+
+| Cohort | Classes shared | Result |
+|---|---:|---|
+| `ConnectionsController` (Enduser) | 7 | ✅ shared |
+| `RequestController` (Enduser) | 4 | ✅ shared |
+| `ClientDelegationController` (Enduser) | 0 | ⛔ reverted — `GetClients`/`GetAgents` assert exact results and failed under sharing (condition 4) |
+
+`AuthorizedParties` and the Maskinporten controllers are excluded statically
+(`ConfigureServices` / per-class feature flags). Full Enduser integration suite
+after sharing the two safe cohorts: **221 passed / 9 skipped, 0 failed.** Rollout
+continues into the other AccessManagement test projects under the same rule.
 
 ## Reproduce
 

--- a/docs/testing/TEST_SETUP_TIMING.md
+++ b/docs/testing/TEST_SETUP_TIMING.md
@@ -31,13 +31,35 @@ against Podman (`maxParallelThreads = 4`):
   repo-wide figure cited in #3379 is 111 `IClassFixture` / 85 `ApiFixture`,
   every one a separate cold host build.
 
-## Implication for the next step
+## Prototype: fixture sharing (validated)
 
-Sharing one host across the read-only, additive-seed cohort via
-`ICollectionFixture` collapses N cold host builds into one. If ~⅔ of the 68
-fixtures here are shareable, that removes ~40–45 host builds (~60 s of
-serial-equivalent build work) — the lever the next #3379 sub-task prototypes
-and measures. Clone/template work is left alone; it is already cheap.
+Sharing one host across a read-only, additive-seed cohort via
+`ICollectionFixture` collapses N cold host builds into one. Prototyped on the
+`ConnectionsController` cluster (`Enduser.Api.Tests`): the **7** nested classes
+that are read-only, do not call `ConfigureServices`, and apply no per-class
+configuration (`CheckPackage`, `DelegationCheckRoles`, `GetAvailableUsers`,
+`GetConnections`, `GetInstances`, `GetPackages`, `GetRoles`) now join a single
+`ConnectionsReadOnlyCollection`. The other classes — `Add*`/`Remove*` (mutating)
+and any calling `ConfigureServices` — stay on `IClassFixture`.
+
+| Metric | Before | After |
+|---|---:|---:|
+| Test result | 143 passed / 5 skipped | **143 passed / 5 skipped** |
+| Wall clock | 1m 02s | **35.8 s** (−42%) |
+| Host builds (`host_build_n`) | 25 | **19** (−6) |
+| Host-build work | 129 s | 52 s |
+
+Identical pass/skip counts — no seed collisions, no isolation regression. The
+saving exceeds the 6 eliminated builds because removing them also cut CPU
+contention on the remaining 19 (avg build 5.2 s → 2.8 s). Clone/template work is
+untouched; it is already cheap.
+
+**Shareability rule (for rolling this out):** a class can join the shared
+collection only if it (a) seeds additively via `EnsureSeedOnce<TSelf>`, (b) never
+calls `ConfigureServices` / `WithAppsettings` / `With*FeatureFlag`, and (c) issues
+no writes against rows other members read. Anything else keeps its own
+`IClassFixture`. The next #3379 sub-task rolls this rule out across the broader
+cohort.
 
 ## Reproduce
 

--- a/docs/testing/TEST_SETUP_TIMING.md
+++ b/docs/testing/TEST_SETUP_TIMING.md
@@ -118,6 +118,22 @@ is fewer host builds (fixture sharing, above), not more threads. Going faster
 would require removing the single-container bottleneck (e.g. a container per
 worker) — out of scope and unlikely to pay off.
 
+## Test waits (`Task.Delay` audit)
+
+Test code has **0 `Thread.Sleep`** and **32 `Task.Delay`**. Audited:
+
+| Use | Count | Action |
+|---|---:|---|
+| `Task.WhenAny(serviceTask, Task.Delay(1000))` shutdown timeout guards | 12 | keep (bounded wait) |
+| `Task.Delay(N) // simulate processing` inside mock callbacks | 6 | keep (intended test-double latency) |
+| 100M-ms cancellation sentinel / 90 s lease-TTL / SUT retry backoff | 3 | keep (not test waits) |
+| `Task.Delay(20)` then assert metrics (`ConsentServiceTests`) | 4 | **fixed** → `MeasurementCollector.WaitForMeasurementsAsync` (polls; returns on first measurement, throws on timeout) |
+| `Task.Delay(10)` "let the hosted-service loop reach its timer" (`ConsentMigrationHostedServiceTests`) | 7 | keep — driven by a fake `TimeProvider`; nothing signals "now awaiting the timer", so a poll has no observable state to watch |
+
+Net: the one genuinely flaky *delay-then-assert* pattern (the metrics listener)
+is replaced with polling. The rest are either correct by design (bounded guards,
+deliberate latency) or lack an observable signal to poll on.
+
 ## Reproduce
 
 `FixtureTiming` is opt-out (disable with `FIXTURE_TIMING=off`) and writes one

--- a/docs/testing/TEST_SETUP_TIMING.md
+++ b/docs/testing/TEST_SETUP_TIMING.md
@@ -76,8 +76,23 @@ rule keeps its own `IClassFixture`.
 
 `AuthorizedParties` and the Maskinporten controllers are excluded statically
 (`ConfigureServices` / per-class feature flags). Full Enduser integration suite
-after sharing the two safe cohorts: **221 passed / 9 skipped, 0 failed.** Rollout
-continues into the other AccessManagement test projects under the same rule.
+after sharing the two safe cohorts: **221 passed / 9 skipped, 0 failed.**
+
+**Survey of the remaining test projects (complete).** The lever needs *multiple*
+read-only classes in one controller. The rest of the AccessManagement suite does
+not offer this:
+
+- `AccessMgmt.Tests` is almost entirely one class per controller — nothing to
+  share.
+- Every other multi-class file (`ServiceOwner.Api.Tests` `RequestController` /
+  `ServiceOwnerConnections`, `AccessMgmt.Tests` `MaskinportenSchema` /
+  `RightsInternal`) contains a writer or a `ConfigureServices` / feature-flag
+  member, leaving at most one read-only class — no cohort.
+
+So `ConnectionsController` + `RequestController` (Enduser) are the only
+safely-shareable read-only cohorts in the suite. **Note:** detection of writes
+must match `PostAsJsonAsync` / `SendAsync`, not just `PostAsync` — a class that
+creates data (even a `Get…Then…` setup) is not shareable.
 
 ## Reproduce
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -62,6 +62,10 @@
                 <Compile Include="$(MSBuildThisFileDirectory)testing\PostgresTestEngine.cs">
                     <Link>Properties\PostgresTestEngine.cs</Link>
                 </Compile>
+                <!-- Opt-out setup-timing for the engine + fixtures (#3379 measurement). -->
+                <Compile Include="$(MSBuildThisFileDirectory)testing\FixtureTiming.cs">
+                    <Link>Properties\FixtureTiming.cs</Link>
+                </Compile>
             </ItemGroup>
 
             <ItemGroup Condition=" '$(IsTestLibrary)' == 'true' ">

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Services/ConsentServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Services/ConsentServiceTests.cs
@@ -216,8 +216,11 @@ public class ConsentServiceTests
         // Act
         var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
 
-        // Allow listener to process
-        await Task.Delay(20, TestContext.Current.CancellationToken);
+        await collector.WaitForMeasurementsAsync(
+            TestContext.Current.CancellationToken,
+            "consent_migration_get_a2_duration_seconds",
+            "consent_migration_insert_a3_duration_seconds",
+            "consent_migration_update_a2_duration_seconds");
 
         // Assert
         Assert.False(result.IsProblem);
@@ -261,7 +264,9 @@ public class ConsentServiceTests
 
         var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
 
-        await Task.Delay(20, TestContext.Current.CancellationToken);
+        await collector.WaitForMeasurementsAsync(
+            TestContext.Current.CancellationToken,
+            "consent_migration_get_a2_duration_seconds");
 
         Assert.False(result.IsProblem);
         Assert.NotNull(result.Value);
@@ -297,7 +302,9 @@ public class ConsentServiceTests
 
         var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
 
-        await Task.Delay(20, TestContext.Current.CancellationToken);
+        await collector.WaitForMeasurementsAsync(
+            TestContext.Current.CancellationToken,
+            "consent_migration_update_a2_duration_seconds");
 
         Assert.True(result.IsProblem || result.Value == null);
         Assert.True(collector.GetMeasurements("consent_migration_update_a2_duration_seconds").Any());
@@ -338,8 +345,9 @@ public class ConsentServiceTests
         // Act
         var result = await service.GetAndStoreAltinn2Consent(consentRequestId, CancellationToken.None);
 
-        // Allow listener to process
-        await Task.Delay(20, TestContext.Current.CancellationToken);
+        await collector.WaitForMeasurementsAsync(
+            TestContext.Current.CancellationToken,
+            "consent_migration_overall_duration_seconds");
 
         // Assert
         Assert.False(result.IsProblem);
@@ -735,6 +743,27 @@ public class ConsentServiceTests
             }
 
             return Array.Empty<double>();
+        }
+
+        /// <summary>
+        /// Polls until every named instrument has at least one measurement, or the
+        /// timeout elapses (then throws). Replaces a fixed <c>Task.Delay</c> "let the
+        /// listener catch up" wait: returns as soon as the metrics are observed and
+        /// fails loudly — instead of silently — if they never arrive.
+        /// </summary>
+        public async Task WaitForMeasurementsAsync(CancellationToken cancellationToken, params string[] instrumentNames)
+        {
+            var deadline = Environment.TickCount64 + 5000;
+            while (instrumentNames.Any(name => GetMeasurements(name).Count == 0))
+            {
+                if (Environment.TickCount64 >= deadline)
+                {
+                    var missing = string.Join(", ", instrumentNames.Where(name => GetMeasurements(name).Count == 0));
+                    throw new TimeoutException($"No measurements for instrument(s) [{missing}] within 5000 ms.");
+                }
+
+                await Task.Delay(10, cancellationToken);
+            }
         }
 
         public void Dispose() => _listener.Dispose();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.CheckPackage.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.CheckPackage.cs
@@ -25,7 +25,8 @@ public partial class ConnectionsControllerTest
     /// Tests for <see cref="ConnectionsController.CheckPackage(Guid, IEnumerable{Guid}, IEnumerable{string}, CancellationToken)"/>.
     /// </summary>
     [IntegrationTest]
-    public class CheckPackage : IClassFixture<ApiFixture>
+    [Collection(ConnectionsReadOnlyCollection.Name)]
+    public class CheckPackage
     {
         public CheckPackage(ApiFixture fixture)
         {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.DelegationCheckRoles.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.DelegationCheckRoles.cs
@@ -24,7 +24,8 @@ public partial class ConnectionsControllerTest
     /// Tests for <see cref="ConnectionsController.DelegationCheckRoles(Guid, CancellationToken)"/>.
     /// </summary>
     [IntegrationTest]
-    public class DelegationCheckRoles : IClassFixture<ApiFixture>
+    [Collection(ConnectionsReadOnlyCollection.Name)]
+    public class DelegationCheckRoles
     {
         public DelegationCheckRoles(ApiFixture fixture)
         {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetAvailableUsers.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetAvailableUsers.cs
@@ -50,7 +50,8 @@ public partial class ConnectionsControllerTest
     /// </para>
     /// </remarks>
     [IntegrationTest]
-    public class GetAvailableUsers : IClassFixture<ApiFixture>
+    [Collection(ConnectionsReadOnlyCollection.Name)]
+    public class GetAvailableUsers
     {
         public GetAvailableUsers(ApiFixture fixture)
         {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetConnections.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetConnections.cs
@@ -35,7 +35,8 @@ public partial class ConnectionsControllerTest
     /// </para>
     /// </remarks>
     [IntegrationTest]
-    public class GetConnections : IClassFixture<ApiFixture>
+    [Collection(ConnectionsReadOnlyCollection.Name)]
+    public class GetConnections
     {
         public GetConnections(ApiFixture fixture)
         {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstances.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstances.cs
@@ -42,7 +42,8 @@ public partial class ConnectionsControllerTest
     /// </para>
     /// </remarks>
     [IntegrationTest]
-    public class GetInstances : IClassFixture<ApiFixture>
+    [Collection(ConnectionsReadOnlyCollection.Name)]
+    public class GetInstances
     {
         public GetInstances(ApiFixture fixture)
         {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetPackages.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetPackages.cs
@@ -36,7 +36,8 @@ public partial class ConnectionsControllerTest
     /// </para>
     /// </remarks>
     [IntegrationTest]
-    public class GetPackages : IClassFixture<ApiFixture>
+    [Collection(ConnectionsReadOnlyCollection.Name)]
+    public class GetPackages
     {
         public GetPackages(ApiFixture fixture)
         {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetRoles.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetRoles.cs
@@ -38,7 +38,8 @@ public partial class ConnectionsControllerTest
     /// </para>
     /// </remarks>
     [IntegrationTest]
-    public class GetRoles : IClassFixture<ApiFixture>
+    [Collection(ConnectionsReadOnlyCollection.Name)]
+    public class GetRoles
     {
         public GetRoles(ApiFixture fixture)
         {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.ReadOnlyCollection.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.ReadOnlyCollection.cs
@@ -1,0 +1,23 @@
+using Altinn.AccessManagement.TestUtils.Fixtures;
+
+namespace Altinn.AccessManagement.Enduser.Api.Tests.Integration.Controllers;
+
+/// <summary>
+/// Shares a single <see cref="ApiFixture"/> — one test host plus one seeded
+/// database — across the read-only <c>ConnectionsController</c> test classes,
+/// instead of each building its own (see #3379: host build is the dominant
+/// integration-test setup cost).
+/// </summary>
+/// <remarks>
+/// Members must be safe to share: additive seeding only (each keys its
+/// <c>EnsureSeedOnce&lt;T&gt;</c> on its own type), no per-class
+/// <c>ConfigureServices</c> / configuration overrides, and no mutation of rows
+/// other classes read. Classes that need isolation stay on
+/// <see cref="Xunit.IClassFixture{TFixture}"/>.
+/// </remarks>
+[CollectionDefinition(Name)]
+public sealed class ConnectionsReadOnlyCollection : ICollectionFixture<ApiFixture>
+{
+    /// <summary>Collection name referenced by member classes via <c>[Collection]</c>.</summary>
+    public const string Name = "ConnectionsController read-only";
+}

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/RequestControllerTest.ReadOnlyCollection.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/RequestControllerTest.ReadOnlyCollection.cs
@@ -1,0 +1,18 @@
+using Altinn.AccessManagement.TestUtils.Fixtures;
+
+namespace Altinn.AccessManagement.Enduser.Api.Tests.Integration.Controllers;
+
+/// <summary>
+/// Shares a single <see cref="ApiFixture"/> across the read-only
+/// <c>RequestController</c> test classes (see #3379). Members must be
+/// additive-seed-only, must not call <c>ConfigureServices</c> / configuration
+/// helpers, and must not write rows other members read. Mutating classes
+/// (<c>Create*</c>, <c>Reject*</c>, <c>Withdraw*</c>, <c>Approve*</c>, …) stay
+/// on <see cref="Xunit.IClassFixture{TFixture}"/>.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class RequestReadOnlyCollection : ICollectionFixture<ApiFixture>
+{
+    /// <summary>Collection name referenced by member classes via <c>[Collection]</c>.</summary>
+    public const string Name = "RequestController read-only";
+}

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/RequestControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/RequestControllerTest.cs
@@ -195,7 +195,8 @@ public class RequestControllerTest
     #region GET /sent — Sender sees sent requests
 
     [IntegrationTest]
-    public class GetSentRequests : IClassFixture<ApiFixture>
+    [Collection(RequestReadOnlyCollection.Name)]
+    public class GetSentRequests
     {
         private static readonly Guid PendingPackageRequestId = Guid.Parse("0196b002-0000-7000-8000-000000000001");
 
@@ -262,7 +263,8 @@ public class RequestControllerTest
     #region GET /received — Receiver sees resource requests
 
     [IntegrationTest]
-    public class GetReceivedResourceRequests : IClassFixture<ApiFixture>
+    [Collection(RequestReadOnlyCollection.Name)]
+    public class GetReceivedResourceRequests
     {
         private static readonly ResourceType TestResourceType = new()
         {
@@ -539,7 +541,8 @@ public class RequestControllerTest
     #region GET /?party=&id= — GetRequest
 
     [IntegrationTest]
-    public class GetRequestById : IClassFixture<ApiFixture>
+    [Collection(RequestReadOnlyCollection.Name)]
+    public class GetRequestById
     {
         private static readonly Guid PendingPackageRequestId = Guid.Parse("0196b00a-0000-7000-8000-000000000001");
 
@@ -628,7 +631,8 @@ public class RequestControllerTest
     #region GET /sent/count — GetSentRequestsCount
 
     [IntegrationTest]
-    public class GetSentRequestsCountTest : IClassFixture<ApiFixture>
+    [Collection(RequestReadOnlyCollection.Name)]
+    public class GetSentRequestsCountTest
     {
         private static readonly Guid PendingPackageRequestId = Guid.Parse("0196b00b-0000-7000-8000-000000000001");
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Fixtures/ApiFixture.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Fixtures/ApiFixture.cs
@@ -5,6 +5,7 @@ using Altinn.AccessMgmt.PersistenceEF.Audit;
 using Altinn.AccessMgmt.PersistenceEF.Constants;
 using Altinn.AccessMgmt.PersistenceEF.Contexts;
 using Altinn.AccessMgmt.PersistenceEF.Extensions;
+using Altinn.Authorization.Testing;
 using Altinn.Common.AccessToken.Services;
 using Altinn.Common.PEP.Interfaces;
 using AltinnCore.Authentication.JwtCookie;
@@ -13,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Altinn.AccessManagement.TestUtils.Fixtures;
 
@@ -143,6 +145,13 @@ public class ApiFixture : WebApplicationFactory<Program>, IAsyncLifetime
 
         builder.UseConfiguration(appsettings.Build());
     }
+
+    /// <summary>
+    /// Builds the test host. Overridden only to time the build — the dominant
+    /// per-fixture cost we are sizing in #3379 — via <see cref="FixtureTiming"/>.
+    /// </summary>
+    protected override IHost CreateHost(IHostBuilder builder) =>
+        FixtureTiming.Time(FixtureTiming.Phase.HostBuild, () => base.CreateHost(builder));
 
     /// <summary>
     /// Registers a callback that modifies the <see cref="IServiceCollection"/>
@@ -339,6 +348,6 @@ public class ApiFixture : WebApplicationFactory<Program>, IAsyncLifetime
     /// </summary>
     public async ValueTask InitializeAsync()
     {
-        _database = await EFPostgresFactory.Create();
+        _database = await FixtureTiming.TimeAsync(FixtureTiming.Phase.DbProvision, () => EFPostgresFactory.Create());
     }
 }

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationApiFixture.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationApiFixture.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Altinn.Authorization.Tests.Fixtures;
@@ -93,6 +94,13 @@ public class AuthorizationApiFixture : WebApplicationFactory<Program>
             }
         });
     }
+
+    /// <summary>
+    /// Builds the test host. Overridden only to time the build — the dominant
+    /// per-fixture setup cost being sized in #3379 — via <see cref="FixtureTiming"/>.
+    /// </summary>
+    protected override IHost CreateHost(IHostBuilder builder) =>
+        FixtureTiming.Time(FixtureTiming.Phase.HostBuild, () => base.CreateHost(builder));
 
     /// <summary>
     /// Registers a callback that modifies the <see cref="IServiceCollection"/>

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationDbFixture.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Fixtures/AuthorizationDbFixture.cs
@@ -55,7 +55,7 @@ public sealed class AuthorizationDbFixture : IAsyncLifetime
     /// <inheritdoc />
     public async ValueTask InitializeAsync()
     {
-        var database = await Engine.CreateDatabaseAsync();
+        var database = await FixtureTiming.TimeAsync(FixtureTiming.Phase.DbProvision, () => Engine.CreateDatabaseAsync());
         if (database is null)
         {
             SkipReason = Engine.SkipReason;

--- a/src/testing/FixtureTiming.cs
+++ b/src/testing/FixtureTiming.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 
 namespace Altinn.Authorization.Testing;
 
@@ -137,7 +138,7 @@ internal static class FixtureTiming
     {
         static long Ms(long ticks) => (long)TimeSpan.FromTicks(ticks).TotalMilliseconds;
 
-        Console.WriteLine(
+        var line =
             $"===FIXTURE_TIMING=== " +
             $"host_build_ms={Ms(Interlocked.Read(ref _hostBuildTicks))} " +
             $"host_build_n={Interlocked.Read(ref _hostBuildCount)} " +
@@ -145,6 +146,24 @@ internal static class FixtureTiming
             $"db_provision_n={Interlocked.Read(ref _dbProvisionCount)} " +
             $"clone_ms={Ms(Interlocked.Read(ref _cloneTicks))} " +
             $"clone_n={Interlocked.Read(ref _cloneCount)} " +
-            $"template_build_ms={Ms(Interlocked.Read(ref _templateBuildTicks))}");
+            $"template_build_ms={Ms(Interlocked.Read(ref _templateBuildTicks))}";
+
+        Console.WriteLine(line);
+
+        // MTP / dotnet-coverage can swallow the test host's process-exit stdout
+        // (the summary never reached the CI log), so also append to a file when
+        // FIXTURE_TIMING_FILE is set — read locally, uploaded as a CI artifact.
+        var file = Environment.GetEnvironmentVariable("FIXTURE_TIMING_FILE");
+        if (!string.IsNullOrEmpty(file))
+        {
+            try
+            {
+                File.AppendAllText(file, line + Environment.NewLine);
+            }
+            catch
+            {
+                // Best-effort diagnostic; never fail a test run over timing output.
+            }
+        }
     }
 }

--- a/src/testing/FixtureTiming.cs
+++ b/src/testing/FixtureTiming.cs
@@ -1,0 +1,150 @@
+using System.Diagnostics;
+
+namespace Altinn.Authorization.Testing;
+
+/// <summary>
+/// Lightweight, opt-out timing for the integration-test setup path. Added to
+/// size where test wall-clock actually goes — per-fixture app-host build vs
+/// per-test database provisioning vs the one-time template build — before the
+/// fixture-sharing refactor in <c>#3379</c>. Linked into the same assemblies as
+/// <see cref="PostgresTestEngine"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Recording is a few atomic adds around a <see cref="Stopwatch"/> timestamp, so
+/// it is safe to leave on. At process exit one summary line is written to stdout
+/// — captured in the CI test-lane log — of the form:
+/// </para>
+/// <code>
+/// ===FIXTURE_TIMING=== host_build_ms=12345 host_build_n=85 db_provision_ms=6789 db_provision_n=85 clone_ms=4200 clone_n=85 template_build_ms=900
+/// </code>
+/// <para>
+/// Disable entirely by setting the <c>FIXTURE_TIMING=off</c> environment
+/// variable (then every <see cref="Time{T}(Phase, Func{T})"/> call is a pass-through).
+/// </para>
+/// </remarks>
+internal static class FixtureTiming
+{
+    private static readonly bool Enabled =
+        !string.Equals(Environment.GetEnvironmentVariable("FIXTURE_TIMING"), "off", StringComparison.OrdinalIgnoreCase);
+
+    private static long _hostBuildTicks;
+    private static long _hostBuildCount;
+    private static long _dbProvisionTicks;
+    private static long _dbProvisionCount;
+    private static long _cloneTicks;
+    private static long _cloneCount;
+    private static long _templateBuildTicks;
+    private static int _exitHooked;
+
+    /// <summary>Setup phase being measured.</summary>
+    internal enum Phase
+    {
+        /// <summary>Per-fixture <c>WebApplicationFactory</c> host build (DI graph, EF model, middleware).</summary>
+        HostBuild,
+
+        /// <summary>Per-fixture database provisioning (factory call, includes the clone).</summary>
+        DbProvision,
+
+        /// <summary>Per-test <c>CREATE DATABASE ... WITH TEMPLATE</c> clone inside the engine.</summary>
+        Clone,
+
+        /// <summary>One-time container start + role bootstrap + migrate/seed of the template.</summary>
+        TemplateBuild,
+    }
+
+    /// <summary>Times an async <paramref name="action"/> and attributes it to <paramref name="phase"/>.</summary>
+    public static async Task<T> TimeAsync<T>(Phase phase, Func<Task<T>> action)
+    {
+        if (!Enabled)
+        {
+            return await action();
+        }
+
+        EnsureExitHook();
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            return await action();
+        }
+        finally
+        {
+            Record(phase, Stopwatch.GetElapsedTime(start));
+        }
+    }
+
+    /// <summary>Times an async <paramref name="action"/> (no return value) and attributes it to <paramref name="phase"/>.</summary>
+    public static async Task TimeAsync(Phase phase, Func<Task> action)
+    {
+        await TimeAsync<object?>(phase, async () =>
+        {
+            await action();
+            return null;
+        });
+    }
+
+    /// <summary>Times a synchronous <paramref name="action"/> and attributes it to <paramref name="phase"/>.</summary>
+    public static T Time<T>(Phase phase, Func<T> action)
+    {
+        if (!Enabled)
+        {
+            return action();
+        }
+
+        EnsureExitHook();
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            return action();
+        }
+        finally
+        {
+            Record(phase, Stopwatch.GetElapsedTime(start));
+        }
+    }
+
+    private static void Record(Phase phase, TimeSpan elapsed)
+    {
+        switch (phase)
+        {
+            case Phase.HostBuild:
+                Interlocked.Add(ref _hostBuildTicks, elapsed.Ticks);
+                Interlocked.Increment(ref _hostBuildCount);
+                break;
+            case Phase.DbProvision:
+                Interlocked.Add(ref _dbProvisionTicks, elapsed.Ticks);
+                Interlocked.Increment(ref _dbProvisionCount);
+                break;
+            case Phase.Clone:
+                Interlocked.Add(ref _cloneTicks, elapsed.Ticks);
+                Interlocked.Increment(ref _cloneCount);
+                break;
+            case Phase.TemplateBuild:
+                Interlocked.Add(ref _templateBuildTicks, elapsed.Ticks);
+                break;
+        }
+    }
+
+    private static void EnsureExitHook()
+    {
+        if (Interlocked.Exchange(ref _exitHooked, 1) == 0)
+        {
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => WriteSummary();
+        }
+    }
+
+    private static void WriteSummary()
+    {
+        static long Ms(long ticks) => (long)TimeSpan.FromTicks(ticks).TotalMilliseconds;
+
+        Console.WriteLine(
+            $"===FIXTURE_TIMING=== " +
+            $"host_build_ms={Ms(Interlocked.Read(ref _hostBuildTicks))} " +
+            $"host_build_n={Interlocked.Read(ref _hostBuildCount)} " +
+            $"db_provision_ms={Ms(Interlocked.Read(ref _dbProvisionTicks))} " +
+            $"db_provision_n={Interlocked.Read(ref _dbProvisionCount)} " +
+            $"clone_ms={Ms(Interlocked.Read(ref _cloneTicks))} " +
+            $"clone_n={Interlocked.Read(ref _cloneCount)} " +
+            $"template_build_ms={Ms(Interlocked.Read(ref _templateBuildTicks))}");
+    }
+}

--- a/src/testing/PostgresTestEngine.cs
+++ b/src/testing/PostgresTestEngine.cs
@@ -78,11 +78,14 @@ public sealed class PostgresTestEngine
                     return null;
                 }
 
-                await BootstrapRolesAsync(cancellationToken);
-                await ExecAsync($"CREATE DATABASE {_options.TemplateDatabaseName};", cancellationToken);
-                var template = NewDatabase(_options.TemplateDatabaseName);
-                await _options.BuildTemplateAsync(template);
-                NpgsqlConnection.ClearAllPools();
+                await FixtureTiming.TimeAsync(FixtureTiming.Phase.TemplateBuild, async () =>
+                {
+                    await BootstrapRolesAsync(cancellationToken);
+                    await ExecAsync($"CREATE DATABASE {_options.TemplateDatabaseName};", cancellationToken);
+                    var template = NewDatabase(_options.TemplateDatabaseName);
+                    await _options.BuildTemplateAsync(template);
+                    NpgsqlConnection.ClearAllPools();
+                });
                 _templateReady = true;
             }
         }
@@ -92,9 +95,9 @@ public sealed class PostgresTestEngine
         }
 
         var name = $"test_{Interlocked.Increment(ref _databaseInstance)}";
-        await ExecAsync(
+        await FixtureTiming.TimeAsync(FixtureTiming.Phase.Clone, () => ExecAsync(
             $"CREATE DATABASE {name} WITH TEMPLATE {_options.TemplateDatabaseName} OWNER {_options.ApplicationUser};",
-            cancellationToken);
+            cancellationToken));
         return NewDatabase(name);
     }
 


### PR DESCRIPTION
## What

Two steps of #3379 on one PR: (1) **measure** where integration-test setup wall-clock goes, then (2) a **fixture-sharing prototype** acting on the result. No production behaviour change.

## 1. Measurement

`FixtureTiming` (opt-out; linked alongside `PostgresTestEngine`) times host build, DB provision, clone, and the one-time template build, writing a summary to stdout and to `FIXTURE_TIMING_FILE`.

`AccessMgmt.Tests` `Category=Integration` (972 tests):

| Phase | Total | Count | Avg |
|---|---:|---:|---:|
| App-host build | **92.2 s** | 68 | **1,356 ms** |
| DB provision (incl. template + clone) | 56.2 s | 68 | 826 ms |
| DB clone | **18.4 s** | 80 | **230 ms** |
| Template build (one-time) | 9.3 s | 1 | — |

**Host build dominates — ~5× the total clone cost.** The DB layer isn't the bottleneck; the unshared `WebApplicationFactory` host builds are.

## 2. Prototype — fixture sharing

Converted the 7 read-only, config-free `ConnectionsController` nested classes to share one `ApiFixture` via `ConnectionsReadOnlyCollection`. Mutating (`Add*`/`Remove*`) and `ConfigureServices`-using classes stay isolated.

| Metric | Before | After |
|---|---:|---:|
| Test result | 143 passed / 5 skipped | **143 passed / 5 skipped** |
| Wall clock | 1m 02s | **35.8 s** (−42%) |
| Host builds | 25 | **19** (−6) |

Identical results, no seed collisions. Full write-up + the shareability rule for broader rollout: [`docs/testing/TEST_SETUP_TIMING.md`](docs/testing/TEST_SETUP_TIMING.md).

Next #3379 sub-task: roll the rule out across the wider read-only cohort.

Closes #3446
Closes #3448
Closes #3449
Closes #3450
Closes #3451
Updates #3379


