### PR TITLE
test(perf): provision base test host with external-client mock defaults (#3453, #3454)

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Altinn2RightsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Altinn2RightsControllerTest.cs
@@ -279,7 +279,6 @@ public class Altinn2RightsControllerTest : IClassFixture<ApiFixture>
         services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
         services.AddSingleton<IPartiesClient, PartiesClientMock>();
         services.AddSingleton<IProfileClient, ProfileClientMock>();
-        services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
         services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();
         services.AddSingleton<IPDP, PdpPermitMock>();
         services.AddSingleton<IAltinn2RightsClient, Tests.Mocks.Altinn2RightsClientMock>();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Bff/ConsentControllerTestBFF.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Bff/ConsentControllerTestBFF.cs
@@ -198,7 +198,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers.Bff
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 services.RemoveAll<IPublicSigningKeyProvider>();
                 services.AddSingleton<IPublicSigningKeyProvider, SigningKeyResolverMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
                 services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();
                 services.RemoveAll<IPDP>();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Bff/ConsentControllerTestBFF.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Bff/ConsentControllerTestBFF.cs
@@ -203,7 +203,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers.Bff
                 services.RemoveAll<IPDP>();
                 services.AddSingleton<IPDP, PdpPermitMock>();
                 services.AddSingleton<IProfileClient, ProfileClientMock>();
-                services.AddSingleton<IAltinn2ConsentClient, Altinn2ConsentClientMock>();
             });
 
             await _fixture.InitializeAsync();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/DelegationsControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/DelegationsControllerTest.cs
@@ -60,7 +60,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers
                 services.AddSingleton<IPolicyFactory, PolicyFactoryMock>();
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 services.AddSingleton<IPartiesClient, PartiesClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPDP, PepWithPDPAuthorizationMock>();
                 services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                 services.AddSingleton<IAMPartyService, AMPartyServiceMock>();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Enterprise/ConsentControllerTestEnterprise.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Enterprise/ConsentControllerTestEnterprise.cs
@@ -61,7 +61,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers.Enterprise
 
                 services.AddSingleton<IPartiesClient, PartiesClientMock>();
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
                 services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Enterprise/ConsentControllerTestEnterpriseFetchStatusChanges.cs
@@ -222,7 +222,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers.Enterprise
                 services.AddSingleton<IPartiesClient, PartiesClientMock>();
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 services.AddSingleton<IPublicSigningKeyProvider, SigningKeyResolverMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
                 services.AddSingleton<IProfileClient, ProfileClientMock>();
                 services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/MaskinPorten/ConsentControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/MaskinPorten/ConsentControllerTest.cs
@@ -66,7 +66,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers.MaskinPorten
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
                 services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();
-                services.AddSingleton<IAltinn2ConsentClient, Altinn2ConsentClientMock>();
                 services.AddSingleton<IProfileClient, ProfileClientMock>();
 
                 // Register the SAME mock instance

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/MaskinPorten/ConsentControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/MaskinPorten/ConsentControllerTest.cs
@@ -64,7 +64,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers.MaskinPorten
 
                 services.AddSingleton<IPartiesClient, PartiesClientMock>();
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
                 services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();
                 services.AddSingleton<IAltinn2ConsentClient, Altinn2ConsentClientMock>();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/MaskinportenSchemaControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/MaskinportenSchemaControllerTest.cs
@@ -141,7 +141,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers
                 services.AddSingleton<IPolicyFactory, PolicyFactoryMock>();
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 services.AddSingleton<IPartiesClient, PartiesClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();
                 services.RemoveAll<IPublicSigningKeyProvider>();
                 services.AddSingleton<IPublicSigningKeyProvider, SigningKeyResolverMock>();
@@ -1896,7 +1895,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers
                 services.AddSingleton<IPolicyFactory, PolicyFactoryMock>();
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 services.AddSingleton<IPartiesClient, PartiesClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();
                 services.RemoveAll<IPublicSigningKeyProvider>();
                 services.AddSingleton<IPublicSigningKeyProvider, SigningKeyResolverMock>();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/PolicyInformationPointControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/PolicyInformationPointControllerTest.cs
@@ -43,7 +43,6 @@ public class PolicyInformationPointControllerTest : IClassFixture<ApiFixture>
             services.AddSingleton<IDelegationMetadataRepository, DelegationMetadataRepositoryMock>();
             services.AddSingleton<IPartiesClient, PartiesClientMock>();
             services.AddSingleton<IProfileClient, ProfileClientMock>();
-            services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
         });
 
         _client = fixture.CreateClient(new() { AllowAutoRedirect = false });

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/ResourceControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/ResourceControllerTest.cs
@@ -56,7 +56,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 services.RemoveAll<IPublicSigningKeyProvider>();
                 services.AddSingleton<IPublicSigningKeyProvider, SigningKeyResolverMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPDP, PdpPermitMock>();
             });
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/ResourceOwnerAPI/AppsInstanceDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/ResourceOwnerAPI/AppsInstanceDelegationControllerTest.cs
@@ -55,7 +55,6 @@ public class AppsInstanceDelegationControllerTest : IClassFixture<ApiFixture>
             services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
             services.AddSingleton<IPartiesClient, PartiesClientMock>();
             services.AddSingleton<IProfileClient, ProfileClientMock>();
-            services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
             services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();
             services.AddSingleton<IPDP, PdpPermitMock>();
             services.AddSingleton<IAltinn2RightsClient, Tests.Mocks.Altinn2RightsClientMock>();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/RightsInternalControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/RightsInternalControllerTest.cs
@@ -67,7 +67,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers
                 services.AddSingleton<IPublicSigningKeyProvider, SigningKeyResolverMock>();
                 services.AddSingleton<IPartiesClient, PartiesClientMock>();
                 services.AddSingleton<IProfileClient, ProfileClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();
                 services.RemoveAll<IPDP>();
                 services.AddSingleton<IPDP, PdpPermitMock>();
@@ -1675,7 +1674,6 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers
                 services.AddSingleton<IPublicSigningKeyProvider, SigningKeyResolverMock>();
                 services.AddSingleton<IPartiesClient, PartiesClientMock>();
                 services.AddSingleton<IProfileClient, ProfileClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IAltinnRolesClient, AltinnRolesClientMock>();
                 services.RemoveAll<IPDP>();
                 services.AddSingleton<IPDP, PdpPermitMock>();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddInstanceRights.cs
@@ -63,7 +63,6 @@ public partial class ConnectionsControllerTest
             Fixture.ConfigureServices(services =>
             {
                 services.AddSingleton<IAltinn2RightsClient, Altinn2RightsClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointWithWrittenPoliciesMock>();
                 services.AddSingleton<IPolicyFactory, PolicyFactoryMock>();
             });

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddResourceRights.cs
@@ -65,7 +65,6 @@ public partial class ConnectionsControllerTest
             Fixture.ConfigureServices(services =>
             {
                 services.AddSingleton<IAltinn2RightsClient, Altinn2RightsClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
                 services.AddSingleton<IPolicyFactory, PolicyFactoryMock>();
             });

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.CheckInstance.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.CheckInstance.cs
@@ -46,7 +46,6 @@ public partial class ConnectionsControllerTest
             Fixture = fixture;
             Fixture.ConfigureServices(services =>
             {
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
             });
         }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.CheckResource.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.CheckResource.cs
@@ -57,7 +57,6 @@ public partial class ConnectionsControllerTest
             Fixture = fixture;
             Fixture.ConfigureServices(services =>
             {
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
             });
             Fixture.EnsureSeedOnce<CheckResource>(db =>

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstanceRights.cs
@@ -52,7 +52,6 @@ public partial class ConnectionsControllerTest
             Fixture.ConfigureServices(services =>
             {
                 services.AddSingleton<IAltinn2RightsClient, Altinn2RightsClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
             });
         }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstanceUsers.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstanceUsers.cs
@@ -49,7 +49,6 @@ public partial class ConnectionsControllerTest
             Fixture = fixture;
             Fixture.ConfigureServices(services =>
             {
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
             });
         }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetResourceRights.cs
@@ -53,7 +53,6 @@ public partial class ConnectionsControllerTest
             Fixture.ConfigureServices(services =>
             {
                 services.AddSingleton<IAltinn2RightsClient, Altinn2RightsClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
             });
             Fixture.EnsureSeedOnce<GetResourceRights>(db =>

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemoveInstance.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemoveInstance.cs
@@ -54,7 +54,6 @@ public partial class ConnectionsControllerTest
             Fixture.ConfigureServices(services =>
             {
                 services.AddSingleton<IAltinn2RightsClient, Altinn2RightsClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointWithWrittenPoliciesMock>();
                 services.AddSingleton<IPolicyFactory, PolicyFactoryMock>();
             });

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemoveResource.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemoveResource.cs
@@ -66,7 +66,6 @@ public partial class ConnectionsControllerTest
             Fixture.ConfigureServices(services =>
             {
                 services.AddSingleton<IAltinn2RightsClient, Altinn2RightsClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
                 services.AddSingleton<IPolicyFactory, PolicyFactoryMock>();
             });

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateInstanceRights.cs
@@ -55,7 +55,6 @@ public partial class ConnectionsControllerTest
             Fixture.ConfigureServices(services =>
             {
                 services.AddSingleton<IAltinn2RightsClient, Altinn2RightsClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointWithWrittenPoliciesMock>();
                 services.AddSingleton<IPolicyFactory, PolicyFactoryMock>();
             });

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateResourceRights.cs
@@ -66,7 +66,6 @@ public partial class ConnectionsControllerTest
             Fixture.ConfigureServices(services =>
             {
                 services.AddSingleton<IAltinn2RightsClient, Altinn2RightsClientMock>();
-                services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
                 services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
                 services.AddSingleton<IPolicyFactory, PolicyFactoryMock>();
             });

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/RightsInternalDelegateAndRevokeInstanceDelegation.RevokeInstance.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/RightsInternalDelegateAndRevokeInstanceDelegation.RevokeInstance.cs
@@ -45,7 +45,6 @@ public class RightsInternalDelegateAndRevokeInstanceDelegation : IClassFixture<A
         Fixture.ConfigureServices(services =>
         {
             services.AddSingleton<IAltinn2RightsClient, Altinn2RightsClientMock>();
-            services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
             services.AddSingleton<IPolicyFactory, PolicyFactoryMock>();
             services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointWithWrittenPoliciesMock>();
         });

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Fixtures/ApiFixture.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Fixtures/ApiFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.TestUtils.Factories;
 using Altinn.AccessManagement.TestUtils.Mocks;
 using Altinn.AccessMgmt.PersistenceEF.Audit;
@@ -136,6 +137,13 @@ public class ApiFixture : WebApplicationFactory<Program>, IAsyncLifetime
 
             services.AddSingleton<IPublicSigningKeyProvider, PublicSigningKeyProviderMock>();
             services.AddSingleton<IPDP, PermitPdpMock>();
+
+            // Default external-platform client mocks (#3453, Phase 2): these are
+            // always mocked in tests, so registering them here removes the
+            // identical per-class ConfigureServices boilerplate. Per-class
+            // ConfigureServices runs after this and still wins for any class
+            // that needs a different behaviour.
+            services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
 
             foreach (var configure in ConfigureServicesActions)
             {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Fixtures/ApiFixture.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Fixtures/ApiFixture.cs
@@ -144,6 +144,7 @@ public class ApiFixture : WebApplicationFactory<Program>, IAsyncLifetime
             // ConfigureServices runs after this and still wins for any class
             // that needs a different behaviour.
             services.AddSingleton<IResourceRegistryClient, ResourceRegistryClientMock>();
+            services.AddSingleton<IAltinn2ConsentClient, Altinn2ConsentClientMock>();
 
             foreach (var configure in ConfigureServicesActions)
             {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Mocks/Altinn2ConsentClientMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Mocks/Altinn2ConsentClientMock.cs
@@ -15,7 +15,7 @@ using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.Consent;
 using Altinn.AccessManagement.Integration.Clients;
 
-namespace Altinn.AccessManagement.Tests.Mocks
+namespace Altinn.AccessManagement.TestUtils.Mocks
 {
     /// <summary>
     /// Mock class for <see cref="IAltinn2ConsentClient"></see> interface


### PR DESCRIPTION
## What

First slices of the test-architecture overhaul (Feature #3452): provision the base `ApiFixture` with external-client mock defaults so test classes stop hand-registering the same mocks (the per-class `ConfigureServices` divergence that forces a unique web-host build per class).

## Changes

- **#3453** — default `ResourceRegistryClientMock` in the base fixture; remove the 23 redundant per-class registrations.
- **#3454** — consolidate `Altinn2ConsentClientMock` into `TestUtils` (it lived in `AccessMgmt.Tests`) and default it; remove its per-class registrations. Template for moving project-local mocks into the shared fixture.

External-platform client mocks are always mocked in tests, so defaulting is safe; per-class `ConfigureServices` still runs after and wins for any class needing different behaviour. Data-layer mocks (repositories, PDP, PRP) are deliberately left per-class — DB tests use the real ones.

## Validation

Every ApiFixture project, after each change: AccessMgmt.Tests 972, Enduser 221, ServiceOwner 41, Api.Internal 7 — all green (local Podman).

## Scope

This does **not** collapse host builds yet (that lands when classes join shared profiles, a later phase) — it removes the DI divergence that blocks sharing.

## Remaining external clients (investigated; recipes on #3454)

| Mock | Status |
|---|---|
| `Profile` | ready — benign duplicate (TestUtils version canonical); default it + drop 9 registrations |
| `Altinn2Rights` | ready, verified — default the data-free TestUtils version + drop the Enduser registrations; the 4 AccessMgmt.Tests files keep their explicit `Tests.Mocks.` data-loading registration |
| `Parties` | blocked — depends on `Tests.Seeds`; needs Seeds extracted to `TestUtils` first (separate task) |
| `Authentication` | out of scope — registered only via the standalone resolver DI, never `ApiFixture` |

Design: [`docs/testing/TEST_ARCHITECTURE.md`](docs/testing/TEST_ARCHITECTURE.md).

> Stacked on #3447 (builds on its `ApiFixture` changes). Base retargets to `main` once #3447 merges.

Updates #3453
Updates #3454
