### PR TITLE
fix: add Expired to the consent-request-status API contract enum

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Extensions/ConsentExtensionsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Extensions/ConsentExtensionsTest.cs
@@ -23,6 +23,22 @@ public class ConsentExtensionsTest
         dto.Value.Should().Be("ttd-some-app");
     }
 
+    // ── ConsentRequestStatusType contract sync ───────────────────────────────
+    [Fact]
+    public void ConsentRequestStatusType_EveryCoreValue_HasAContractCounterpart()
+    {
+        // The enterprise mapper casts the core status straight to the contract enum
+        // (ConsentRequestDetailsExtensions.ToConsentRequestDetailsExternal), so every
+        // core value must have a defined contract counterpart or it serializes as a
+        // bare number. Guards against future drift between the two enums.
+        foreach (Altinn.AccessManagement.Core.Models.Consent.ConsentRequestStatusType core
+            in Enum.GetValues<Altinn.AccessManagement.Core.Models.Consent.ConsentRequestStatusType>())
+        {
+            Enum.IsDefined(typeof(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestStatusType), (int)core)
+                .Should().BeTrue($"core ConsentRequestStatusType.{core} ({(int)core}) must map to a defined contract value");
+        }
+    }
+
     // ── ConsentRightExtensions ───────────────────────────────────────────────
     [Fact]
     public void ToConsentRightExternal_EmptyResourceList_MapsToEmptyList()

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Consent/ConsentRequestStatusType.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Consent/ConsentRequestStatusType.cs
@@ -22,6 +22,9 @@ namespace Altinn.Authorization.Api.Contracts.Consent
         Revoked = 3,
 
         [EnumMember(Value = "deleted")]
-        Deleted = 4
+        Deleted = 4,
+
+        [EnumMember(Value = "expired")]
+        Expired = 5
     }
 }


### PR DESCRIPTION
Fixes a contract enum drift. `Altinn.AccessMgmt.Core`'s `ConsentRequestStatusType` has `Expired = 5`, but the public `Altinn.Authorization.Api.Contracts` enum stopped at `Deleted = 4`. The enterprise consent mapper (`ConsentRequestDetailsExtensions.ToConsentRequestDetailsExternal`) casts core → contract directly, so an `Expired` consent serialized as the undefined value `5` instead of `"expired"`, breaking the API contract for clients reading an expired consent.

## Fix
Add `Expired = 5` (`[EnumMember(Value = "expired")]`) to the contract enum — a backward-compatible addition; the cast now resolves and serializes as `"expired"`.

## Pin
A test asserts every core `ConsentRequestStatusType` value has a defined contract counterpart (guards future drift too). Verified failing against the pre-fix enum (1/23), green with the fix (23/23).

Closes #3473
