### PR TITLE
fix: guard SystemUserId index access in AuthenticationHelper (pure-logic test batch)

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/AuthenticationHelper.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/AuthenticationHelper.cs
@@ -72,7 +72,7 @@ namespace Altinn.AccessManagement.Core.Helpers
             }
 
             AuthorizationDetails authDetails = JsonSerializer.Deserialize<AuthorizationDetails>(claim.Value);
-            if (authDetails != null && authDetails.Type == "urn:altinn:systemuser")
+            if (authDetails != null && authDetails.Type == "urn:altinn:systemuser" && authDetails.SystemUserId is { Length: > 0 })
             {
                 return authDetails.SystemUserId[0];
             }
@@ -108,7 +108,7 @@ namespace Altinn.AccessManagement.Core.Helpers
             }
 
             AuthorizationDetails authDetails = JsonSerializer.Deserialize<AuthorizationDetails>(claim.Value);
-            if (authDetails != null && authDetails.Type == "urn:altinn:systemuser")
+            if (authDetails != null && authDetails.Type == "urn:altinn:systemuser" && authDetails.SystemUserId is { Length: > 0 })
             {
                 return Guid.Parse(authDetails.SystemUserId[0]);
             }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Utilities/IdentifierUtil.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Utilities/IdentifierUtil.cs
@@ -37,6 +37,11 @@ public static class IdentifierUtil
     /// </remarks>
     public static bool IsValidOrganizationNumber(string orgNo)
     {
+        if (string.IsNullOrEmpty(orgNo))
+        {
+            return false;
+        }
+
         int[] weight = { 3, 2, 7, 6, 5, 4, 3, 2 };
 
         // Validation only done for 8 and 9 digit numbers

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Helpers/AuthenticationHelperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Helpers/AuthenticationHelperTest.cs
@@ -135,6 +135,22 @@ public class AuthenticationHelperTest
         AuthenticationHelper.GetSystemUserUuidString(CtxWith()).Should().BeEmpty();
     }
 
+    [Fact]
+    public void GetSystemUserUuid_SystemUserTypeWithEmptyIdArray_ReturnsEmpty()
+    {
+        var json = """{"type":"urn:altinn:systemuser","systemuser_id":[]}""";
+
+        AuthenticationHelper.GetSystemUserUuid(CtxWith(new Claim("authorization_details", json))).Should().Be(Guid.Empty);
+    }
+
+    [Fact]
+    public void GetSystemUserUuidString_SystemUserTypeWithoutIdArray_ReturnsEmptyString()
+    {
+        var json = """{"type":"urn:altinn:systemuser"}""";
+
+        AuthenticationHelper.GetSystemUserUuidString(CtxWith(new Claim("authorization_details", json))).Should().BeEmpty();
+    }
+
     // ── GetAuthenticatedPartyUuid composition ────────────────────────────────
     [Fact]
     public void GetAuthenticatedPartyUuid_PartyUuidPresent_ReturnsPartyUuid()

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Consent/ConsentPartyUrnTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Consent/ConsentPartyUrnTest.cs
@@ -1,0 +1,35 @@
+using Altinn.AccessManagement.Core.Models.Consent;
+
+namespace Altinn.AccessManagement.Tests.Unit.Models.Consent;
+
+/// <summary>
+/// Pins the hand-written party-id parse guard on <see cref="ConsentPartyUrn"/>.
+/// The generated <c>[KeyValueUrn]</c> machinery is library code; these tests cover
+/// only the custom <c>TryParsePartyId</c>, which uses <c>NumberStyles.None</c> so a
+/// signed or whitespace-padded party id is rejected (a negative party id must never
+/// parse).
+/// </summary>
+[UnitTest]
+[Collection("Models Test")]
+public class ConsentPartyUrnTest
+{
+    [Fact]
+    public void TryParse_PositivePartyId_ReturnsTrueWithValue()
+    {
+        ConsentPartyUrn.TryParse("urn:altinn:party:id:5", out var urn).Should().BeTrue();
+
+        urn!.IsPartyId(out var id).Should().BeTrue();
+        id.Should().Be(5);
+    }
+
+    [Theory]
+    [InlineData("urn:altinn:party:id:-5")]   // leading minus
+    [InlineData("urn:altinn:party:id:+5")]   // leading plus
+    [InlineData("urn:altinn:party:id: 5")]   // leading whitespace
+    public void TryParse_SignedOrWhitespacePartyId_ReturnsFalse(string urn)
+    {
+        // TryParsePartyId parses with NumberStyles.None, so a sign or whitespace must be
+        // rejected — guards against a refactor to a plain int.Parse that would accept them.
+        ConsentPartyUrn.TryParse(urn, out _).Should().BeFalse();
+    }
+}

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Register/OrganizationNumberTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Register/OrganizationNumberTest.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using Altinn.AccessManagement.Core.Models.Register;
+
+namespace Altinn.AccessManagement.Tests.Unit.Models.Register;
+
+/// <summary>
+/// Pure-logic tests for the <see cref="OrganizationNumber"/> in
+/// <c>Altinn.AccessManagement.Core.Models.Register</c>. Unlike the
+/// checksum-validating type in <c>Altinn.Authorization.Api.Contracts.Register</c>,
+/// this one validates length + digits only (no mod-11), and exposes
+/// <see cref="OrganizationNumber.CreateUnchecked"/>.
+/// </summary>
+[UnitTest]
+[Collection("Models Test")]
+public class OrganizationNumberTest
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    [Fact]
+    public void Parse_ValidNineDigits_ReturnsOrganizationNumber()
+    {
+        OrganizationNumber.Parse("987654321").ToString().Should().Be("987654321");
+    }
+
+    [Theory]
+    [InlineData("12345678")]    // 8 digits
+    [InlineData("1234567890")]  // 10 digits
+    public void TryParse_WrongLength_ReturnsFalse(string value)
+    {
+        OrganizationNumber.TryParse(value, null, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_NonNumeric_ReturnsFalse()
+    {
+        OrganizationNumber.TryParse("12345678X", null, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_Null_ReturnsFalse()
+    {
+        OrganizationNumber.TryParse(null, null, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_NineDigitBadChecksum_ReturnsTrue()
+    {
+        // This type validates length + digits only (no mod-11 checksum), so a value the
+        // checksum-validating Altinn.Authorization.Api.Contracts.Register.OrganizationNumber
+        // rejects is accepted here. Pins the deliberate cross-type validation divergence.
+        OrganizationNumber.TryParse("937884118", null, out var result).Should().BeTrue();
+        result!.ToString().Should().Be("937884118");
+    }
+
+    [Fact]
+    public void CreateUnchecked_InvalidValue_BypassesValidation()
+    {
+        OrganizationNumber.CreateUnchecked("not-an-org").ToString().Should().Be("not-an-org");
+    }
+
+    [Fact]
+    public void Json_DeserializeInvalid_ThrowsJsonException()
+    {
+        Action act = () => JsonSerializer.Deserialize<OrganizationNumber>("\"12345\"", JsonOptions);
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Json_RoundTrip_PreservesValue()
+    {
+        var orgNr = OrganizationNumber.Parse("987654321");
+        var json = JsonSerializer.Serialize(orgNr, JsonOptions);
+
+        json.Should().Be("\"987654321\"");
+        JsonSerializer.Deserialize<OrganizationNumber>(json, JsonOptions)!.ToString().Should().Be("987654321");
+    }
+}

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Urn/OrganizationNumberTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Urn/OrganizationNumberTest.cs
@@ -147,6 +147,20 @@ namespace Altinn.AccessManagement.Tests.Unit.Models.Urn
 
         /// <summary>
         /// Scenario:
+        /// Parse a 9-digit, all-numeric value whose mod-11 control digit is wrong.
+        /// Expected Result:
+        /// Rejected by the checksum branch (937884117 is valid; the flipped control digit must fail).
+        /// </summary>
+        [Fact]
+        public void Parse_NineDigitBadChecksum_Throws()
+        {
+            Action act = () => OrganizationNumber.Parse("937884118");
+
+            act.Should().Throw<Exception>();
+        }
+
+        /// <summary>
+        /// Scenario:
         /// Tests the OrganizationNumber GetExample
         /// Input:
         /// Get expected Example

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Urn/ResourceIdentifierTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Urn/ResourceIdentifierTest.cs
@@ -145,6 +145,31 @@ namespace Altinn.AccessManagement.Tests.Unit.Models.Urn
         }
 
         /// <summary>
+        /// Parse a 4-character lowercase value: the lower boundary of the
+        /// ^[a-z0-9_-]{4,}$ identifier rule (existing tests only use long values).
+        /// </summary>
+        [Fact]
+        public void TryParse_ExactlyFourLowercaseChars_Succeeds()
+        {
+            ResourceIdentifier.TryParse("abcd", null, out var id).Should().BeTrue();
+            id!.ToString().Should().Be("abcd");
+        }
+
+        /// <summary>
+        /// Values containing characters outside [a-z0-9_-] (uppercase, whitespace,
+        /// punctuation) are rejected — pins case-sensitivity and the allowed charset.
+        /// </summary>
+        [Theory]
+        [InlineData("ABCD")]
+        [InlineData("ABCDEFG")]
+        [InlineData("exam ple")]
+        [InlineData("exa.mple")]
+        public void TryParse_DisallowedCharacters_ReturnsFalse(string value)
+        {
+            ResourceIdentifier.TryParse(value, null, out _).Should().BeFalse();
+        }
+
+        /// <summary>
         /// Scenario:
         /// Tests the ResourceIdentifier
         /// Input:

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Utilities/IdentifierUtilTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Utilities/IdentifierUtilTest.cs
@@ -50,6 +50,12 @@ public class IdentifierUtilTest
         IdentifierUtil.IsValidOrganizationNumber(string.Empty).Should().BeFalse();
     }
 
+    [Fact]
+    public void IsValidOrganizationNumber_Null_ReturnsFalse()
+    {
+        IdentifierUtil.IsValidOrganizationNumber(null).Should().BeFalse();
+    }
+
     // ── MaskSSN ──────────────────────────────────────────────────────────────
     [Fact]
     public void MaskSSN_ReturnsFirstSixDigitsPlusFiveAsterisks()

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Unit/Utils/TranslationMiddlewareTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Unit/Utils/TranslationMiddlewareTest.cs
@@ -106,6 +106,24 @@ public class TranslationMiddlewareTest
         Assert.Equal("nob", ctx.Items[TranslationConstants.LanguageCodeKey]);
     }
 
+    [Fact]
+    public async Task QualityZeroValue_NotTreatedAsExclusion_StillSelected()
+    {
+        // RFC 7231 treats q=0 as "not acceptable", but the middleware only orders by
+        // quality without excluding q=0 — so en (its sole candidate) is still selected.
+        var ctx = await Run(c => c.Request.Headers["Accept-Language"] = "en;q=0");
+        Assert.Equal("eng", ctx.Items[TranslationConstants.LanguageCodeKey]);
+    }
+
+    [Fact]
+    public async Task MalformedQualityValue_FallsBackToDefaultQuality()
+    {
+        // A non-numeric q-value can't be parsed, so quality stays the default 1.0;
+        // en (q=abc → 1.0) therefore outranks nb (q=0.5).
+        var ctx = await Run(c => c.Request.Headers["Accept-Language"] = "en;q=abc,nb;q=0.5");
+        Assert.Equal("eng", ctx.Items[TranslationConstants.LanguageCodeKey]);
+    }
+
     // ── X-Accept-Partial-Translation parsing ──────────────────────────────────
     [Theory]
     [InlineData("true", true)]


### PR DESCRIPTION
Pure-logic edge-case tests + two latent-bug fixes across AccessManagement, under umbrella #3475. Each class is a commit; both bug fixes were verified failing-first (revert the SUT → the pinning test fails; with the fix → green).

## Bug fixes
- **AuthenticationHelper** — `GetSystemUserUuid` / `GetSystemUserUuidString` indexed `SystemUserId[0]` with no guard, so a system-user token with a missing/empty `systemuser_id` threw (NRE / IndexOutOfRange) instead of returning empty. Guarded with `is { Length: > 0 }`.
- **IdentifierUtil** — `IsValidOrganizationNumber(null)` threw `NullReferenceException` (dereferenced `orgNo.Length` before any guard). Now returns false.

## Pinned behaviors (previously untested)
- **OrganizationNumber (Contracts)** — mod-11 bad-checksum rejection.
- **OrganizationNumber (Core)** — zero→full coverage + the cross-type divergence (Core validates length+digits only, so it accepts a bad-checksum value the Contracts type rejects).
- **ConsentPartyUrn** — signed/whitespace party-id rejected (`NumberStyles.None`; a negative party id never parses).
- **ResourceIdentifier** — `^[a-z0-9_-]{4,}$` 4-char lower boundary + uppercase/whitespace/punctuation rejection.
- **TranslationMiddleware** — Accept-Language `q=0` (not treated as exclusion) and malformed-`q` (falls back to default quality).

## Out of scope (deliberate non-goal)
`TranslationService` language-code case-sensitivity: the HTTP middleware already lowercases input and lowercase ISO codes are the convention, so this is by-design, not a defect — not pinned.

Also spun off a background chip for the identical null-NRE in the PEP twin `IDFormatDeterminator.IsValidOrganizationNumber`.

Closes #3475
