### PR TITLE
fix(abac): string-is-in matches bag membership, not substring

### DIFF
--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/AttributeMatcherTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/AttributeMatcherTest.cs
@@ -1,0 +1,50 @@
+using Altinn.Authorization.ABAC.Constants;
+using Altinn.Authorization.ABAC.Xacml;
+using Xunit;
+
+namespace Altinn.Authorization.Tests.Unit
+{
+    /// <summary>
+    /// Pure-logic tests for <see cref="AttributeMatcher"/>, the XACML attribute-match
+    /// function dispatch.
+    ///
+    /// Focus is the <c>string-is-in</c> function. The matcher is invoked once per
+    /// (policy value, single request-bag element), so for bag membership each
+    /// element must be compared for equality with the policy value — never with a
+    /// substring test. The bundled OASIS conformance suite (IIA008/009, IIC008/009,
+    /// IIIF003/004/007) only exercises exact-match and clear non-match cases, where a
+    /// substring test happens to give the same answer as equality, so it does not on
+    /// its own catch a substring defect. These tests pin the membership semantics
+    /// directly.
+    /// </summary>
+    [UnitTest]
+    public class AttributeMatcherTest
+    {
+        private const string StringIsIn = XacmlConstants.AttributeMatchFunction.StringIsIn;
+
+        [Fact]
+        public void MatchAttributes_StringIsIn_RequestValueEqualsPolicyValue_ReturnsTrue()
+        {
+            // The request-bag element equals the policy value, so the value is a member of the bag.
+            Assert.True(AttributeMatcher.MatchAttributes("riddle me this", "riddle me this", StringIsIn));
+        }
+
+        [Theory]
+        [InlineData("admin", "superadmin")]   // policy value is a suffix of the request value
+        [InlineData("read", "readwrite")]     // policy value is a prefix of the request value
+        [InlineData("user", "superuser")]
+        public void MatchAttributes_StringIsIn_PolicyValueIsSubstringOfRequestValue_ReturnsFalse(string policyValue, string requestValue)
+        {
+            // Regression guard: string-is-in is bag membership (per-element equality), not
+            // String.Contains. A substring match would let the policy value "admin" match a
+            // request value "superadmin" and wrongly satisfy the target — a privilege escalation.
+            Assert.False(AttributeMatcher.MatchAttributes(policyValue, requestValue, StringIsIn));
+        }
+
+        [Fact]
+        public void MatchAttributes_StringIsIn_NoOverlap_ReturnsFalse()
+        {
+            Assert.False(AttributeMatcher.MatchAttributes("convicted-felon", "law-abiding-citizen", StringIsIn));
+        }
+    }
+}

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Xacml/AttributeMatcher.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Xacml/AttributeMatcher.cs
@@ -40,7 +40,10 @@ namespace Altinn.Authorization.ABAC.Xacml
                     isMatch = MatchInteger(policyAttribute, decisionRequestAttribute);
                     break;
                 case XacmlConstants.AttributeMatchFunction.StringIsIn:
-                    isMatch = decisionRequestAttribute.Contains(policyAttribute);
+                    // Invoked once per request-bag element, so membership is a per-element
+                    // equality check — not a substring test, which would let policy value
+                    // "admin" match request value "superadmin" (privilege escalation).
+                    isMatch = MatchStrings(policyAttribute, decisionRequestAttribute);
                     break;
                 case XacmlConstants.AttributeMatchFunction.TimeEqual:
                     isMatch = MatchTime(policyAttribute, decisionRequestAttribute);


### PR DESCRIPTION
## What

The XACML `string-is-in` attribute-match function was dispatched to `String.Contains`, so a policy value that was a *substring* of a request value matched. For example, a policy value `admin` matched a request value `superadmin`, and `read` matched `readwrite` — a possible privilege escalation in any policy that uses `string-is-in`.

`AttributeMatcher.MatchAttributes` is invoked once per request-bag element, so bag membership must be a per-element **equality** check. The fix routes `string-is-in` through the same comparison `string-equal` already uses.

## Why it wasn't caught

The bundled OASIS XACML 3.0 conformance suite exercises `string-is-in` only in `IIA008/009`, `IIC008/009`, `IIIF003/004/007`, and every one of those cases is either an exact match or a clear non-match — inputs where substring and equality give the same answer. So the suite passed before and after the change.

## Verification

- Added `AttributeMatcherTest` (direct unit test) pinning membership semantics: exact element → match; policy value that is a substring of the request value (`admin`/`superadmin`, `read`/`readwrite`, `user`/`superuser`) → no match. These three cases failed against the old `Contains` implementation and pass now.
- Re-ran the full XACML 3.0 conformance suite: **36/36 still pass**, confirming the fix changes no OASIS-conformant decision.

A note for reviewers: `string-is-in` is used by **no production Altinn policy** in this repo — only the conformance fixtures and the function constant reference it — so the real-world behavior change is limited to closing the substring-escalation hole.

Closes #3481
