### PR TITLE
fix: correct validation asserter defects (Any never fails; wrong error key)

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Asserters/Asserter.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Asserters/Asserter.cs
@@ -29,7 +29,7 @@ public class Asserter<TModel> : IAssert<TModel>
 
         foreach (var entry in result)
         {
-            foreach (var err in errors)
+            foreach (var err in entry)
             {
                 AddError(errors, err);
             }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Asserters/AttributeMatchAsserter.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Asserters/AttributeMatchAsserter.cs
@@ -51,7 +51,7 @@ public static class AttributeMatchAsserter
         var matchingAttributes = values.Where(attribute => types.Any(type => type.Equals(attribute.Id, StringComparison.InvariantCultureIgnoreCase)));
         if (matchingAttributes.Where(attribute => !bool.TryParse(attribute.Value, out _)) is var assertedNoneIntegers && assertedNoneIntegers.Any())
         {
-            errors.Add(nameof(AttributesAreIntegers), [$"attributes {StringifyAttributeIds(values)} can't be parsed as boolean"]);
+            errors.Add(nameof(AttributesAreBoolean), [$"attributes {StringifyAttributeIds(values)} can't be parsed as boolean"]);
         }
     };
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Asserters/AsserterTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Asserters/AsserterTests.cs
@@ -1,4 +1,6 @@
 using Altinn.AccessManagement.Core.Asserters;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
 
 namespace Altinn.AccessManagement.Tests.Unit.Asserters;
 
@@ -14,4 +16,38 @@ public class AsserterTests
     /// <typeparam name="TModel"></typeparam>
     /// <returns></returns>
     public static IAssert<TModel> Asserter<TModel>() => new Asserter<TModel>();
+
+    /// <summary>
+    /// When every alternative in <see cref="IAssert{T}.Any"/> fails, the collected
+    /// errors must be reported — the combinator must be able to fail.
+    /// </summary>
+    [Fact]
+    public void Any_AllAssertionsFail_ReportsCollectedErrors()
+    {
+        var asserter = Asserter<string>();
+        Assertion<string> failA = (errors, values) => errors.Add("A", ["a failed"]);
+        Assertion<string> failB = (errors, values) => errors.Add("B", ["b failed"]);
+
+        var result = asserter.Evaluate([], asserter.Any(failA, failB));
+
+        Assert.NotNull(result);
+        Assert.Contains("A", result.Errors.Keys);
+        Assert.Contains("B", result.Errors.Keys);
+    }
+
+    /// <summary>
+    /// When at least one alternative in <see cref="IAssert{T}.Any"/> passes, no
+    /// errors are reported.
+    /// </summary>
+    [Fact]
+    public void Any_OneAssertionPasses_ReportsNoErrors()
+    {
+        var asserter = Asserter<string>();
+        Assertion<string> pass = (errors, values) => { };
+        Assertion<string> fail = (errors, values) => errors.Add("B", ["b failed"]);
+
+        var result = asserter.Evaluate([], asserter.Any(pass, fail));
+
+        Assert.Null(result);
+    }
 }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Asserters/AttributeMatchAsserterTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Asserters/AttributeMatchAsserterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Altinn.AccessManagement.Core.Asserters;
+using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Resolvers;
 using Microsoft.AspNetCore.Mvc;
@@ -77,7 +78,7 @@ public class AttributeMatchAsserterTests
     {
         var asserter = AsserterTests.Asserter<AttributeMatch>();
 
-        var result = asserter.Evaluate(values, asserter.DefaultTo);
+        var result = asserter.Evaluate(values, asserter.DefaultFrom);
 
         assert(result);
     }
@@ -119,6 +120,13 @@ public class AttributeMatchAsserterTests
             {
                 [new(BaseUrn.Altinn.Person.IdentifierNo, string.Empty)],
                 Assert.NotNull
+            },
+            {
+                // urn:altinn:userid is accepted as a "to" identifier but is NOT a valid
+                // "from" identifier, so DefaultFrom must reject it (DefaultTo accepts it).
+                // This is the one case that actually distinguishes DefaultFrom from DefaultTo.
+                [new(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, "123")],
+                Assert.NotNull
             }
         };
 
@@ -159,4 +167,21 @@ public class AttributeMatchAsserterTests
                 Assert.NotNull
             }
         };
+
+    /// <summary>
+    /// A non-boolean value for a boolean-typed attribute must be reported under the
+    /// <c>AttributesAreBoolean</c> key (regression: it was reported under
+    /// <c>AttributesAreIntegers</c> due to a copy-paste error).
+    /// </summary>
+    [Fact]
+    public void AttributesAreBoolean_NonBooleanValue_ReportsUnderBooleanKey()
+    {
+        var asserter = AsserterTests.Asserter<AttributeMatch>();
+        var values = new AttributeMatch[] { new("urn:test:flag", "notabool") };
+
+        var result = asserter.Evaluate(values, asserter.AttributesAreBoolean("urn:test:flag"));
+
+        Assert.NotNull(result);
+        Assert.Contains("AttributesAreBoolean", result.Errors.Keys);
+    }
 }


### PR DESCRIPTION
## What

Two validation-asserter correctness defects:

- `Asserter.Any` iterated the empty output dictionary instead of the collected errors, so `Any` could never fail — a validation bypass.
- `AttributeMatchAsserter.AttributesAreBoolean` reported failures under `nameof(AttributesAreIntegers)`, producing a misleading error key.

Both are fixed and pinned with unit tests that fail against the pre-fix code.

## Why a separate PR

This fix currently also rides inside the large structural test PR #3456. It is an independent correctness fix, so it is lifted back onto its own branch off `main` to land without waiting on that PR. The patch is identical to the copy in #3456; the two reconcile cleanly at merge (same diff). Once this merges, the commit can be dropped from #3456 on its next update.

Closes #3468
