### PR TITLE
fix(abac): deny-overrides returns the matching Deny instead of dropping it

### DIFF
--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/PolicyDecisionPoint.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/PolicyDecisionPoint.cs
@@ -116,8 +116,16 @@ namespace Altinn.Authorization.ABAC
                     if (policy.RuleCombiningAlgId.Equals(XacmlConstants.CombiningAlgorithms.RuleDenyOverrides)
                         && decision.Equals(XacmlContextDecision.Deny))
                     {
-                        contextResult = new XacmlContextResult(XacmlContextDecision.Deny);
-                        break;
+                        // Deny-overrides: a single matching Deny is decisive, so return it directly.
+                        // Breaking out of the loop instead would fall through to the post-loop result,
+                        // which rebuilds the response from overallDecision (still NotApplicable here)
+                        // and would silently discard this Deny.
+                        contextResult = new XacmlContextResult(XacmlContextDecision.Deny)
+                        {
+                            Status = new XacmlContextStatus(XacmlContextStatusCode.Success),
+                        };
+                        this.AddRequestAttributes(decisionRequest, contextResult);
+                        return new XacmlContextResponse(contextResult);
                     }
                     else if (decision.Equals(XacmlContextDecision.Permit))
                     {

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointTest.cs
@@ -26,9 +26,7 @@ public class PolicyDecisionPointTest
         result.Decision.Should().Be(XacmlContextDecision.Permit);
     }
 
-    [Fact(Skip = "Blocked by #3490: PolicyDecisionPoint drops a matching Deny under deny-overrides " +
-                 "(the post-loop result is rebuilt from overallDecision, overwriting the Deny set on the break). " +
-                 "Unskip when #3490 is fixed — this test reproduces the defect (currently returns NotApplicable).")]
+    [Fact]
     public void Authorize_MatchingDenyRule_DenyOverrides_ReturnsDeny()
     {
         XacmlContextResult result = Decide(Policy("Deny", DenyOverrides), Request());


### PR DESCRIPTION
## What

Fixes the engine defect surfaced by the new ABAC test project (#3489): under `deny-overrides`, a matching **Deny** rule was dropped and the PDP returned **NotApplicable**.

## Root cause

The deny path set a local `contextResult = Deny` and `break`-ed out of the rule loop, but the code after the loop unconditionally rebuilds the response from `overallDecision` (never set to Deny on that path), overwriting the Deny. The fix returns the Deny response directly (with a Success status and the result attributes), so it can't be overwritten.

## Impact

Likely latent in production because Altinn policies are permit-oriented (an allow-list, where `NotApplicable` and `Deny` both fail to grant access), but it is incorrect XACML behavior for any explicit-deny policy.

## Verification

- The reproducing test in `ABAC.Tests` (added **skipped** in #3489) is **unskipped** here and now passes.
- The full XACML 3.0 conformance suite still passes **36/36** — no regression.

Stacked on #3489 (the reproducing test lives in the new ABAC test project); retarget to `main` once #3489 merges.

Closes #3490
