### PR TITLE
test+fix(abac): dedicated XACML engine tests + string-is-in and deny-overrides fixes

### DIFF
--- a/Altinn.Authorization.sln
+++ b/Altinn.Authorization.sln
@@ -143,6 +143,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.Host.P
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.AccessManagement.Api.Internal.Tests", "src\apps\Altinn.AccessManagement\test\Altinn.AccessManagement.Api.Internal.Tests\Altinn.AccessManagement.Api.Internal.Tests.csproj", "{6FC78C8E-2C18-4CAA-AB16-F084C34BD99F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{F3ABD30E-526F-A724-0F5F-7E3DCEDDB17A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ABAC.Tests", "src\pkgs\Altinn.Authorization.ABAC\test\Altinn.Authorization.ABAC.Tests\Altinn.Authorization.ABAC.Tests.csproj", "{FFE3EC03-53E0-45CA-816E-0624C063CB27}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -609,6 +613,18 @@ Global
 		{6FC78C8E-2C18-4CAA-AB16-F084C34BD99F}.Release|x64.Build.0 = Release|Any CPU
 		{6FC78C8E-2C18-4CAA-AB16-F084C34BD99F}.Release|x86.ActiveCfg = Release|Any CPU
 		{6FC78C8E-2C18-4CAA-AB16-F084C34BD99F}.Release|x86.Build.0 = Release|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Debug|x64.Build.0 = Debug|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Debug|x86.Build.0 = Debug|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Release|x64.ActiveCfg = Release|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Release|x64.Build.0 = Release|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Release|x86.ActiveCfg = Release|Any CPU
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -679,5 +695,7 @@ Global
 		{18DED9BD-7B36-12AD-B80A-E12D59790D97} = {F1FD4040-A53F-F03F-1243-0A77D82D924E}
 		{A3E784AB-228E-4A44-8301-706FA429CEE4} = {18DED9BD-7B36-12AD-B80A-E12D59790D97}
 		{6FC78C8E-2C18-4CAA-AB16-F084C34BD99F} = {D2DF925C-A14F-80C1-51E0-7ECFD06D725B}
+		{F3ABD30E-526F-A724-0F5F-7E3DCEDDB17A} = {D0B11B6B-D80E-76FF-A56D-9420225ED058}
+		{FFE3EC03-53E0-45CA-816E-0624C063CB27} = {F3ABD30E-526F-A724-0F5F-7E3DCEDDB17A}
 	EndGlobalSection
 EndGlobal

--- a/src/pkgs/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.sln
+++ b/src/pkgs/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.sln
@@ -7,6 +7,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ABAC", "src\Altinn.Authorization.ABAC\Altinn.Authorization.ABAC.csproj", "{EE7C217D-2AB9-4D05-A4E8-9CA6CDE9BF1C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0C88DD14-F956-CE84-757C-A364CCF449FC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.Authorization.ABAC.Tests", "test\Altinn.Authorization.ABAC.Tests\Altinn.Authorization.ABAC.Tests.csproj", "{512019AD-6072-496A-BACE-FAB773927308}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,11 +33,24 @@ Global
 		{EE7C217D-2AB9-4D05-A4E8-9CA6CDE9BF1C}.Release|x64.Build.0 = Release|Any CPU
 		{EE7C217D-2AB9-4D05-A4E8-9CA6CDE9BF1C}.Release|x86.ActiveCfg = Release|Any CPU
 		{EE7C217D-2AB9-4D05-A4E8-9CA6CDE9BF1C}.Release|x86.Build.0 = Release|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Debug|x64.Build.0 = Debug|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Debug|x86.Build.0 = Debug|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Release|Any CPU.Build.0 = Release|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Release|x64.ActiveCfg = Release|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Release|x64.Build.0 = Release|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Release|x86.ActiveCfg = Release|Any CPU
+		{512019AD-6072-496A-BACE-FAB773927308}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EE7C217D-2AB9-4D05-A4E8-9CA6CDE9BF1C} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{512019AD-6072-496A-BACE-FAB773927308} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
 	EndGlobalSection
 EndGlobal

--- a/src/pkgs/Altinn.Authorization.ABAC/coverage-thresholds.json
+++ b/src/pkgs/Altinn.Authorization.ABAC/coverage-thresholds.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Per-vertical coverage floors for the ABAC vertical (takes precedence over eng/testing/coverage-thresholds.json for this vertical's CI run). The dedicated ABAC test project (#3489) is new, so this is the INITIAL enforced floor for the XACML engine assembly — until now it had no direct tests and the global 60 floor was dormant (no coverage file was produced). Ratchet this up toward the 60 target as JSON-profile and additional PDP/parser coverage is added.",
+  "globalThreshold": 0,
+  "assemblies": {
+    "Altinn.Authorization.ABAC": 30
+  }
+}

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/PolicyDecisionPoint.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/PolicyDecisionPoint.cs
@@ -116,8 +116,16 @@ namespace Altinn.Authorization.ABAC
                     if (policy.RuleCombiningAlgId.Equals(XacmlConstants.CombiningAlgorithms.RuleDenyOverrides)
                         && decision.Equals(XacmlContextDecision.Deny))
                     {
-                        contextResult = new XacmlContextResult(XacmlContextDecision.Deny);
-                        break;
+                        // Deny-overrides: a single matching Deny is decisive, so return it directly.
+                        // Breaking out of the loop instead would fall through to the post-loop result,
+                        // which rebuilds the response from overallDecision (still NotApplicable here)
+                        // and would silently discard this Deny.
+                        contextResult = new XacmlContextResult(XacmlContextDecision.Deny)
+                        {
+                            Status = new XacmlContextStatus(XacmlContextStatusCode.Success),
+                        };
+                        this.AddRequestAttributes(decisionRequest, contextResult);
+                        return new XacmlContextResponse(contextResult);
                     }
                     else if (decision.Equals(XacmlContextDecision.Permit))
                     {

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Xacml/AttributeMatcher.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Xacml/AttributeMatcher.cs
@@ -40,7 +40,10 @@ namespace Altinn.Authorization.ABAC.Xacml
                     isMatch = MatchInteger(policyAttribute, decisionRequestAttribute);
                     break;
                 case XacmlConstants.AttributeMatchFunction.StringIsIn:
-                    isMatch = decisionRequestAttribute.Contains(policyAttribute);
+                    // Invoked once per request-bag element, so membership is a per-element
+                    // equality check - not a substring test, which would let policy value
+                    // "admin" match request value "superadmin" (privilege escalation).
+                    isMatch = MatchStrings(policyAttribute, decisionRequestAttribute);
                     break;
                 case XacmlConstants.AttributeMatchFunction.TimeEqual:
                     isMatch = MatchTime(policyAttribute, decisionRequestAttribute);

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Xacml/AttributeMatcher.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Xacml/AttributeMatcher.cs
@@ -74,7 +74,9 @@ namespace Altinn.Authorization.ABAC.Xacml
             DateTime policyValue = DateTime.Parse(policyAttribute);
             DateTime requestValue = DateTime.Parse(decisionRequestAttribute);
 
-            return policyValue.Equals(requestValue);
+            // time-equal operates on xs:time (time-of-day only); the date component must be
+            // ignored - mirrors MatchDate, which compares only the .Date component.
+            return policyValue.TimeOfDay.Equals(requestValue.TimeOfDay);
         }
 
         private static bool MatchDate(string policyAttribute, string decisionRequestAttribute)

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Altinn.Authorization.ABAC.Tests.csproj
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Altinn.Authorization.ABAC.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net10.0</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Altinn.Authorization.ABAC\Altinn.Authorization.ABAC.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="xunit.runner.json" CopyToOutputDirectory="Always" />
+    </ItemGroup>
+
+</Project>

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointTest.cs
@@ -26,9 +26,7 @@ public class PolicyDecisionPointTest
         result.Decision.Should().Be(XacmlContextDecision.Permit);
     }
 
-    [Fact(Skip = "Blocked by #3490: PolicyDecisionPoint drops a matching Deny under deny-overrides " +
-                 "(the post-loop result is rebuilt from overallDecision, overwriting the Deny set on the break). " +
-                 "Unskip when #3490 is fixed — this test reproduces the defect (currently returns NotApplicable).")]
+    [Fact]
     public void Authorize_MatchingDenyRule_DenyOverrides_ReturnsDeny()
     {
         XacmlContextResult result = Decide(Policy("Deny", DenyOverrides), Request());

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointTest.cs
@@ -1,0 +1,101 @@
+using System.Xml;
+using Altinn.Authorization.ABAC.Constants;
+using Altinn.Authorization.ABAC.Utils;
+using Altinn.Authorization.ABAC.Xacml;
+
+namespace Altinn.Authorization.ABAC.Tests;
+
+/// <summary>
+/// Engine-level tests for <see cref="PolicyDecisionPoint"/>. Each test drives a
+/// crafted minimal XACML 3.0 policy + request through
+/// <see cref="PolicyDecisionPoint.Authorize"/>, exercising the parser, the Xacml
+/// object model, attribute matching, the deny-overrides rule-combining algorithm,
+/// and the missing-required-attribute path together — the breadth the indirect
+/// conformance suite covers, but localized and without a web host.
+/// </summary>
+[UnitTest]
+public class PolicyDecisionPointTest
+{
+    private const string Ns = "urn:oasis:names:tc:xacml:3.0:core:schema:wd-17";
+    private static readonly string DenyOverrides = XacmlConstants.CombiningAlgorithms.RuleDenyOverrides;
+
+    [Fact]
+    public void Authorize_SubjectResourceActionAllMatch_PermitRule_ReturnsPermit()
+    {
+        XacmlContextResult result = Decide(Policy("Permit", DenyOverrides), Request());
+        result.Decision.Should().Be(XacmlContextDecision.Permit);
+    }
+
+    [Fact(Skip = "Blocked by #3490: PolicyDecisionPoint drops a matching Deny under deny-overrides " +
+                 "(the post-loop result is rebuilt from overallDecision, overwriting the Deny set on the break). " +
+                 "Unskip when #3490 is fixed — this test reproduces the defect (currently returns NotApplicable).")]
+    public void Authorize_MatchingDenyRule_DenyOverrides_ReturnsDeny()
+    {
+        XacmlContextResult result = Decide(Policy("Deny", DenyOverrides), Request());
+        result.Decision.Should().Be(XacmlContextDecision.Deny);
+    }
+
+    [Fact]
+    public void Authorize_NoRuleMatchesResource_ReturnsNotApplicable()
+    {
+        // resource value is present but does not match the rule target -> no matching rule.
+        XacmlContextResult result = Decide(Policy("Permit", DenyOverrides), Request(resource: "other-resource"));
+        result.Decision.Should().Be(XacmlContextDecision.NotApplicable);
+    }
+
+    [Fact]
+    public void Authorize_RequiredResourceAttributeMissing_ReturnsIndeterminate()
+    {
+        // resource-id is MustBePresent in the rule target but absent from the request.
+        XacmlContextResult result = Decide(Policy("Permit", DenyOverrides), Request(resource: null));
+        result.Decision.Should().Be(XacmlContextDecision.Indeterminate);
+    }
+
+    [Fact]
+    public void Authorize_SubjectDoesNotMatch_ReturnsNotApplicable()
+    {
+        // resource + action match (rule applies) but the subject differs -> rule yields NotApplicable.
+        XacmlContextResult result = Decide(Policy("Permit", DenyOverrides), Request(subject: "other-user"));
+        result.Decision.Should().Be(XacmlContextDecision.NotApplicable);
+    }
+
+    private static XacmlContextResult Decide(string policyXml, string requestXml)
+    {
+        using XmlReader policyReader = XmlReader.Create(new StringReader(policyXml));
+        XacmlPolicy policy = XacmlParser.ParseXacmlPolicy(policyReader);
+
+        using XmlReader requestReader = XmlReader.Create(new StringReader(requestXml));
+        XacmlContextRequest request = XacmlParser.ReadContextRequest(requestReader);
+
+        return new PolicyDecisionPoint().Authorize(request, policy).Results.Single();
+    }
+
+    private static string Policy(string effect, string combiningAlg) => $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Policy xmlns=""{Ns}"" PolicyId=""urn:test:policy"" Version=""1.0"" RuleCombiningAlgId=""{combiningAlg}"">
+  <Target />
+  <Rule RuleId=""urn:test:rule"" Effect=""{effect}"">
+    <Target>
+      <AnyOf><AllOf>{Match("urn:oasis:names:tc:xacml:1.0:resource:resource-id", "urn:oasis:names:tc:xacml:3.0:attribute-category:resource", "resource1")}</AllOf></AnyOf>
+      <AnyOf><AllOf>{Match("urn:oasis:names:tc:xacml:1.0:action:action-id", "urn:oasis:names:tc:xacml:3.0:attribute-category:action", "read")}</AllOf></AnyOf>
+      <AnyOf><AllOf>{Match("urn:oasis:names:tc:xacml:1.0:subject:subject-id", "urn:oasis:names:tc:xacml:1.0:subject-category:access-subject", "user1")}</AllOf></AnyOf>
+    </Target>
+  </Rule>
+</Policy>";
+
+    private static string Match(string attributeId, string category, string value) => $@"
+        <Match MatchId=""urn:oasis:names:tc:xacml:1.0:function:string-equal"">
+          <AttributeValue DataType=""http://www.w3.org/2001/XMLSchema#string"">{value}</AttributeValue>
+          <AttributeDesignator AttributeId=""{attributeId}"" Category=""{category}"" DataType=""http://www.w3.org/2001/XMLSchema#string"" MustBePresent=""true""/>
+        </Match>";
+
+    private static string Request(string? subject = "user1", string? resource = "resource1", string? action = "read") => $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Request xmlns=""{Ns}"" ReturnPolicyIdList=""false"" CombinedDecision=""false"">{Attributes("urn:oasis:names:tc:xacml:1.0:subject-category:access-subject", "urn:oasis:names:tc:xacml:1.0:subject:subject-id", subject)}{Attributes("urn:oasis:names:tc:xacml:3.0:attribute-category:resource", "urn:oasis:names:tc:xacml:1.0:resource:resource-id", resource)}{Attributes("urn:oasis:names:tc:xacml:3.0:attribute-category:action", "urn:oasis:names:tc:xacml:1.0:action:action-id", action)}
+</Request>";
+
+    private static string Attributes(string category, string attributeId, string? value) => value is null ? string.Empty : $@"
+  <Attributes Category=""{category}"">
+    <Attribute AttributeId=""{attributeId}"" IncludeInResult=""false"">
+      <AttributeValue DataType=""http://www.w3.org/2001/XMLSchema#string"">{value}</AttributeValue>
+    </Attribute>
+  </Attributes>";
+}

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Xacml/AttributeMatcherTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Xacml/AttributeMatcherTest.cs
@@ -68,14 +68,15 @@ public class AttributeMatcherTest
     public void MatchAttributes_IntegerOneAndOnly_BehavesLikeIntegerEqual(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, IntegerOneAndOnly).Should().Be(expected);
 
-    // The substring-vs-membership regression (e.g. "admin" must NOT match "superadmin") is
-    // pinned in #3482 against the AttributeMatcher fix, which is not yet on main. This is the
-    // permanent home for those cases: fold them in here and drop the Altinn.Authorization.Tests
-    // copy once #3482 merges.
+    // string-is-in is bag membership (per-element equality), NOT a substring test: policy value
+    // "admin" must not match request value "superadmin". Regression guard for #3481 — the OASIS
+    // conformance suite only uses exact-match/non-match cases, so it never caught the substring bug.
     [Theory]
     [InlineData("admin", "admin", true)]
     [InlineData("reader", "reader", true)]
-    public void MatchAttributes_StringIsIn_ExactMember_ReturnsTrue(string policy, string request, bool expected)
+    [InlineData("admin", "superadmin", false)]
+    [InlineData("read", "readwrite", false)]
+    public void MatchAttributes_StringIsIn(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, StringIsIn).Should().Be(expected);
 
     [Theory]

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Xacml/AttributeMatcherTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Xacml/AttributeMatcherTest.cs
@@ -82,6 +82,7 @@ public class AttributeMatcherTest
     [Theory]
     [InlineData("09:30:00", "09:30:00", true)]
     [InlineData("09:30:00", "10:30:00", false)]
+    [InlineData("2024-01-01T09:30:00", "2024-06-15T09:30:00", true)]  // time-equal is time-of-day only; the date component must be ignored
     public void MatchAttributes_TimeEqual(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, TimeEqual).Should().Be(expected);
 

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Xacml/AttributeMatcherTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Xacml/AttributeMatcherTest.cs
@@ -28,20 +28,20 @@ public class AttributeMatcherTest
     [InlineData("alice", "alice", true)]
     [InlineData("alice", "bob", false)]
     [InlineData("Alice", "alice", false)] // string-equal is case-sensitive
-    public void MatchAttributes_StringEqual(string policy, string request, bool expected)
+    public void MatchAttributes_StringEqual_ReturnsExpectedMatch(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, StringEqual).Should().Be(expected);
 
     [Theory]
     [InlineData("Alice", "alice", true)]
     [InlineData("ALICE", "alice", true)]
     [InlineData("Alice", "alicia", false)]
-    public void MatchAttributes_StringEqualIgnoreCase(string policy, string request, bool expected)
+    public void MatchAttributes_StringEqualIgnoreCase_ReturnsExpectedMatch(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, StringEqualIgnoreCase).Should().Be(expected);
 
     [Theory]
     [InlineData("urn:a:b", "urn:a:b", true)]
     [InlineData("http://example.com/a", "http://example.com/b", false)]
-    public void MatchAttributes_AnyUriEqual(string policy, string request, bool expected)
+    public void MatchAttributes_AnyUriEqual_ReturnsExpectedMatch(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, AnyUriEqual).Should().Be(expected);
 
     [Fact]
@@ -59,7 +59,7 @@ public class AttributeMatcherTest
     [InlineData("007", "7", true)]  // numeric equality, not string equality
     [InlineData("x", "5", false)]   // non-numeric policy value -> false, not an exception
     [InlineData("5", "y", false)]   // non-numeric request value -> false
-    public void MatchAttributes_IntegerEqual(string policy, string request, bool expected)
+    public void MatchAttributes_IntegerEqual_ReturnsExpectedMatch(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, IntegerEqual).Should().Be(expected);
 
     [Theory]
@@ -76,33 +76,33 @@ public class AttributeMatcherTest
     [InlineData("reader", "reader", true)]
     [InlineData("admin", "superadmin", false)]
     [InlineData("read", "readwrite", false)]
-    public void MatchAttributes_StringIsIn(string policy, string request, bool expected)
+    public void MatchAttributes_StringIsIn_ReturnsExpectedMatch(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, StringIsIn).Should().Be(expected);
 
     [Theory]
     [InlineData("09:30:00", "09:30:00", true)]
     [InlineData("09:30:00", "10:30:00", false)]
     [InlineData("2024-01-01T09:30:00", "2024-06-15T09:30:00", true)]  // time-equal is time-of-day only; the date component must be ignored
-    public void MatchAttributes_TimeEqual(string policy, string request, bool expected)
+    public void MatchAttributes_TimeEqual_ReturnsExpectedMatch(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, TimeEqual).Should().Be(expected);
 
     [Theory]
     [InlineData("2002-09-24", "2002-09-24", true)]
     [InlineData("2002-09-24", "2002-09-25", false)]
-    public void MatchAttributes_DateEqual(string policy, string request, bool expected)
+    public void MatchAttributes_DateEqual_ReturnsExpectedMatch(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, DateEqual).Should().Be(expected);
 
     [Theory]
     [InlineData("2002-09-24T09:30:00", "2002-09-24T09:30:00", true)]
     [InlineData("2002-09-24T09:30:00", "2002-09-24T10:30:00", false)]
-    public void MatchAttributes_DateTimeEqual(string policy, string request, bool expected)
+    public void MatchAttributes_DateTimeEqual_ReturnsExpectedMatch(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, DateTimeEqual).Should().Be(expected);
 
     [Theory]
     [InlineData("a.c", "abc", true)]
     [InlineData("^[0-9]+$", "12345", true)]
     [InlineData("^[0-9]+$", "12a45", false)]
-    public void MatchAttributes_RegexpMatch(string policy, string request, bool expected)
+    public void MatchAttributes_RegexpMatch_ReturnsExpectedMatch(string policy, string request, bool expected)
         => AttributeMatcher.MatchAttributes(policy, request, RegexpMatch).Should().Be(expected);
 
     [Fact]

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Xacml/AttributeMatcherTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Xacml/AttributeMatcherTest.cs
@@ -1,0 +1,119 @@
+using Altinn.Authorization.ABAC.Constants;
+using Altinn.Authorization.ABAC.Xacml;
+
+namespace Altinn.Authorization.ABAC.Tests.Xacml;
+
+/// <summary>
+/// Direct unit tests for <see cref="AttributeMatcher"/>, the XACML attribute-match
+/// function dispatch. These cover every match function and the edge cases the bundled
+/// OASIS conformance suite does not exercise (substring vs membership, datatype
+/// mismatch, malformed values) — until now the engine was only tested indirectly
+/// through the Authorization conformance suite.
+/// </summary>
+[UnitTest]
+public class AttributeMatcherTest
+{
+    private const string StringEqual = XacmlConstants.AttributeMatchFunction.StringEqual;
+    private const string StringEqualIgnoreCase = XacmlConstants.AttributeMatchFunction.StringEqualIgnoreCase;
+    private const string AnyUriEqual = XacmlConstants.AttributeMatchFunction.AnyUriEqual;
+    private const string IntegerEqual = XacmlConstants.AttributeMatchFunction.IntegerEqual;
+    private const string IntegerOneAndOnly = XacmlConstants.AttributeMatchFunction.IntegerOneAndOnly;
+    private const string StringIsIn = XacmlConstants.AttributeMatchFunction.StringIsIn;
+    private const string TimeEqual = XacmlConstants.AttributeMatchFunction.TimeEqual;
+    private const string DateEqual = XacmlConstants.AttributeMatchFunction.DateEqual;
+    private const string DateTimeEqual = XacmlConstants.AttributeMatchFunction.DateTimeEqual;
+    private const string RegexpMatch = XacmlConstants.AttributeMatchFunction.RegexpMatch;
+
+    [Theory]
+    [InlineData("alice", "alice", true)]
+    [InlineData("alice", "bob", false)]
+    [InlineData("Alice", "alice", false)] // string-equal is case-sensitive
+    public void MatchAttributes_StringEqual(string policy, string request, bool expected)
+        => AttributeMatcher.MatchAttributes(policy, request, StringEqual).Should().Be(expected);
+
+    [Theory]
+    [InlineData("Alice", "alice", true)]
+    [InlineData("ALICE", "alice", true)]
+    [InlineData("Alice", "alicia", false)]
+    public void MatchAttributes_StringEqualIgnoreCase(string policy, string request, bool expected)
+        => AttributeMatcher.MatchAttributes(policy, request, StringEqualIgnoreCase).Should().Be(expected);
+
+    [Theory]
+    [InlineData("urn:a:b", "urn:a:b", true)]
+    [InlineData("http://example.com/a", "http://example.com/b", false)]
+    public void MatchAttributes_AnyUriEqual(string policy, string request, bool expected)
+        => AttributeMatcher.MatchAttributes(policy, request, AnyUriEqual).Should().Be(expected);
+
+    [Fact]
+    public void MatchAttributes_AnyUriEqual_MalformedUri_Throws()
+    {
+        // MatchAnyUri constructs new Uri(...) with no guard, so a non-URI value throws.
+        // Pins the current fail-loud behavior.
+        Action act = () => AttributeMatcher.MatchAttributes("not a uri", "also not a uri", AnyUriEqual);
+        act.Should().Throw<UriFormatException>();
+    }
+
+    [Theory]
+    [InlineData("5", "5", true)]
+    [InlineData("5", "6", false)]
+    [InlineData("007", "7", true)]  // numeric equality, not string equality
+    [InlineData("x", "5", false)]   // non-numeric policy value -> false, not an exception
+    [InlineData("5", "y", false)]   // non-numeric request value -> false
+    public void MatchAttributes_IntegerEqual(string policy, string request, bool expected)
+        => AttributeMatcher.MatchAttributes(policy, request, IntegerEqual).Should().Be(expected);
+
+    [Theory]
+    [InlineData("42", "42", true)]
+    [InlineData("42", "43", false)]
+    public void MatchAttributes_IntegerOneAndOnly_BehavesLikeIntegerEqual(string policy, string request, bool expected)
+        => AttributeMatcher.MatchAttributes(policy, request, IntegerOneAndOnly).Should().Be(expected);
+
+    // The substring-vs-membership regression (e.g. "admin" must NOT match "superadmin") is
+    // pinned in #3482 against the AttributeMatcher fix, which is not yet on main. This is the
+    // permanent home for those cases: fold them in here and drop the Altinn.Authorization.Tests
+    // copy once #3482 merges.
+    [Theory]
+    [InlineData("admin", "admin", true)]
+    [InlineData("reader", "reader", true)]
+    public void MatchAttributes_StringIsIn_ExactMember_ReturnsTrue(string policy, string request, bool expected)
+        => AttributeMatcher.MatchAttributes(policy, request, StringIsIn).Should().Be(expected);
+
+    [Theory]
+    [InlineData("09:30:00", "09:30:00", true)]
+    [InlineData("09:30:00", "10:30:00", false)]
+    public void MatchAttributes_TimeEqual(string policy, string request, bool expected)
+        => AttributeMatcher.MatchAttributes(policy, request, TimeEqual).Should().Be(expected);
+
+    [Theory]
+    [InlineData("2002-09-24", "2002-09-24", true)]
+    [InlineData("2002-09-24", "2002-09-25", false)]
+    public void MatchAttributes_DateEqual(string policy, string request, bool expected)
+        => AttributeMatcher.MatchAttributes(policy, request, DateEqual).Should().Be(expected);
+
+    [Theory]
+    [InlineData("2002-09-24T09:30:00", "2002-09-24T09:30:00", true)]
+    [InlineData("2002-09-24T09:30:00", "2002-09-24T10:30:00", false)]
+    public void MatchAttributes_DateTimeEqual(string policy, string request, bool expected)
+        => AttributeMatcher.MatchAttributes(policy, request, DateTimeEqual).Should().Be(expected);
+
+    [Theory]
+    [InlineData("a.c", "abc", true)]
+    [InlineData("^[0-9]+$", "12345", true)]
+    [InlineData("^[0-9]+$", "12a45", false)]
+    public void MatchAttributes_RegexpMatch(string policy, string request, bool expected)
+        => AttributeMatcher.MatchAttributes(policy, request, RegexpMatch).Should().Be(expected);
+
+    [Fact]
+    public void MatchAttributes_UnknownFunction_Throws()
+    {
+        Action act = () => AttributeMatcher.MatchAttributes("a", "a", "urn:not:a:real:function");
+        act.Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
+    public void MatchAttributes_NullArgument_Throws()
+    {
+        Action act = () => AttributeMatcher.MatchAttributes(null!, "a", StringEqual);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/XacmlSerializerTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/XacmlSerializerTest.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using System.Xml;
+using Altinn.Authorization.ABAC.Utils;
+using Altinn.Authorization.ABAC.Xacml;
+
+namespace Altinn.Authorization.ABAC.Tests;
+
+/// <summary>
+/// Round-trip tests for <see cref="XacmlSerializer"/> — serializing a decision
+/// response back to XACML 3.0 XML. Exercises the serializer and the context-result
+/// object model, which the parser-driven PDP tests only read.
+/// </summary>
+[UnitTest]
+public class XacmlSerializerTest
+{
+    [Fact]
+    public void WriteContextResponse_PermitResult_WritesPermitDecision()
+    {
+        var response = new XacmlContextResponse(
+            new XacmlContextResult(XacmlContextDecision.Permit)
+            {
+                Status = new XacmlContextStatus(XacmlContextStatusCode.Success),
+            });
+
+        string xml = Serialize(writer => XacmlSerializer.WriteContextResponse(writer, response));
+
+        xml.Should().Contain("Result");
+        xml.Should().Contain("Permit");
+    }
+
+    [Fact]
+    public void WriteContextResponse_DenyResult_WritesDenyDecision()
+    {
+        var response = new XacmlContextResponse(
+            new XacmlContextResult(XacmlContextDecision.Deny)
+            {
+                Status = new XacmlContextStatus(XacmlContextStatusCode.Success),
+            });
+
+        string xml = Serialize(writer => XacmlSerializer.WriteContextResponse(writer, response));
+
+        xml.Should().Contain("Deny");
+    }
+
+    private static string Serialize(Action<XmlWriter> write)
+    {
+        var sb = new StringBuilder();
+        using (var writer = XmlWriter.Create(sb))
+        {
+            write(writer);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/xunit.runner.json
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/xunit.runner.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": true,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 4,
+  "methodDisplay": "classAndMethod",
+  "methodDisplayOptions": "none",
+  "diagnosticMessages": false,
+  "internalDiagnosticMessages": false
+}

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Directory.Build.props
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+    <Import Project="..\..\Directory.Build.props" />
+
+    <PropertyGroup>
+        <XUnitVersion>v3</XUnitVersion>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Hardens the ABAC XACML engine, the highest-stakes code in the repo, which had no dedicated test project and was exercised only indirectly through the Authorization conformance suite. Standing up the suite also surfaced three engine correctness defects, fixed here.

## 1. Dedicated test project (`Closes #3489`)
New `Altinn.Authorization.ABAC.Tests` (xUnit v3 / MTP), wired into the ABAC and root solutions:
- **AttributeMatcher**: every match function + the edge cases the conformance suite misses (datatype mismatch, malformed URI, integer-parse failure, unknown function, null guard).
- **PolicyDecisionPoint**: Permit / NotApplicable / Indeterminate, driven through the parser, model, matcher and combining algorithm.
- **XacmlSerializer**: response round-trip.

The ABAC assembly goes from no direct coverage to ~31%, enforced by a per-vertical floor of 30 (the global 60 was dormant, with no test project, no coverage file was produced, so the gate never ran). Ratchet toward 60 via the JSON-profile surface as a follow-up.

## 2. `string-is-in` fix (`Closes #3481`)
`string-is-in` dispatched to `String.Contains`, so policy value `admin` matched request value `superadmin`. Fixed to per-element equality (bag membership). The conformance suite only uses exact-match/non-match cases, so it never caught this.

## 3. deny-overrides fix (`Closes #3490`)
Under `deny-overrides`, a matching `Deny` was dropped and the engine returned `NotApplicable` (the post-loop result overwrote the `Deny` set on the break). Fixed to return the `Deny` directly.

## 4. time-equal fix
`MatchTime` compared the full date+time, so two equal times-of-day with different dates did not match. XACML `time-equal` operates on `xs:time`; fixed to compare `.TimeOfDay` (mirrors `MatchDate`). Found while writing the matcher tests; no separate issue.

## Verification
ABAC.Tests: 39 passing. XACML 3.0 conformance suite: **36/36**, unchanged by any of the fixes.

Supersedes #3482, #3491, #3492 (consolidated here to keep review to one coherent change). Related to #3132.

