### PR TITLE
fix+test: pure-logic correctness fixes and pinning tests (AccessManagement + contracts)

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Asserters/Asserter.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Asserters/Asserter.cs
@@ -29,7 +29,7 @@ public class Asserter<TModel> : IAssert<TModel>
 
         foreach (var entry in result)
         {
-            foreach (var err in errors)
+            foreach (var err in entry)
             {
                 AddError(errors, err);
             }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Asserters/AttributeMatchAsserter.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Asserters/AttributeMatchAsserter.cs
@@ -51,7 +51,7 @@ public static class AttributeMatchAsserter
         var matchingAttributes = values.Where(attribute => types.Any(type => type.Equals(attribute.Id, StringComparison.InvariantCultureIgnoreCase)));
         if (matchingAttributes.Where(attribute => !bool.TryParse(attribute.Value, out _)) is var assertedNoneIntegers && assertedNoneIntegers.Any())
         {
-            errors.Add(nameof(AttributesAreIntegers), [$"attributes {StringifyAttributeIds(values)} can't be parsed as boolean"]);
+            errors.Add(nameof(AttributesAreBoolean), [$"attributes {StringifyAttributeIds(values)} can't be parsed as boolean"]);
         }
     };
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Asserters/AttributeMatchAsserter.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Asserters/AttributeMatchAsserter.cs
@@ -88,7 +88,7 @@ public static class AttributeMatchAsserter
         var attributesWithEmptyValues = values.Where(attribute => string.IsNullOrEmpty(attribute?.Value));
         if (attributesWithEmptyValues.Any())
         {
-            errors.Add(nameof(AllAttributesHasValues), StringifyAttributeIds(attributesWithEmptyValues).Select(type => $"attribute {type} contains empty value").ToArray());
+            errors.Add(nameof(AllAttributesHasValues), attributesWithEmptyValues.Select(attribute => $"attribute {attribute.Id} contains empty value").ToArray());
         }
     }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/AuthenticationHelper.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Helpers/AuthenticationHelper.cs
@@ -72,7 +72,7 @@ namespace Altinn.AccessManagement.Core.Helpers
             }
 
             AuthorizationDetails authDetails = JsonSerializer.Deserialize<AuthorizationDetails>(claim.Value);
-            if (authDetails != null && authDetails.Type == "urn:altinn:systemuser")
+            if (authDetails != null && authDetails.Type == "urn:altinn:systemuser" && authDetails.SystemUserId is { Length: > 0 })
             {
                 return authDetails.SystemUserId[0];
             }
@@ -108,7 +108,7 @@ namespace Altinn.AccessManagement.Core.Helpers
             }
 
             AuthorizationDetails authDetails = JsonSerializer.Deserialize<AuthorizationDetails>(claim.Value);
-            if (authDetails != null && authDetails.Type == "urn:altinn:systemuser")
+            if (authDetails != null && authDetails.Type == "urn:altinn:systemuser" && authDetails.SystemUserId is { Length: > 0 })
             {
                 return Guid.Parse(authDetails.SystemUserId[0]);
             }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Utilities/IdentifierUtil.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Utilities/IdentifierUtil.cs
@@ -37,6 +37,11 @@ public static class IdentifierUtil
     /// </remarks>
     public static bool IsValidOrganizationNumber(string orgNo)
     {
+        if (string.IsNullOrEmpty(orgNo))
+        {
+            return false;
+        }
+
         int[] weight = { 3, 2, 7, 6, 5, 4, 3, 2 };
 
         // Validation only done for 8 and 9 digit numbers

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Asserters/AsserterTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Asserters/AsserterTests.cs
@@ -1,4 +1,6 @@
 using Altinn.AccessManagement.Core.Asserters;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
 
 namespace Altinn.AccessManagement.Tests.Unit.Asserters;
 
@@ -14,4 +16,38 @@ public class AsserterTests
     /// <typeparam name="TModel"></typeparam>
     /// <returns></returns>
     public static IAssert<TModel> Asserter<TModel>() => new Asserter<TModel>();
+
+    /// <summary>
+    /// When every alternative in <see cref="IAssert{T}.Any"/> fails, the collected
+    /// errors must be reported — the combinator must be able to fail.
+    /// </summary>
+    [Fact]
+    public void Any_AllAssertionsFail_ReportsCollectedErrors()
+    {
+        var asserter = Asserter<string>();
+        Assertion<string> failA = (errors, values) => errors.Add("A", ["a failed"]);
+        Assertion<string> failB = (errors, values) => errors.Add("B", ["b failed"]);
+
+        var result = asserter.Evaluate([], asserter.Any(failA, failB));
+
+        Assert.NotNull(result);
+        Assert.Contains("A", result.Errors.Keys);
+        Assert.Contains("B", result.Errors.Keys);
+    }
+
+    /// <summary>
+    /// When at least one alternative in <see cref="IAssert{T}.Any"/> passes, no
+    /// errors are reported.
+    /// </summary>
+    [Fact]
+    public void Any_OneAssertionPasses_ReportsNoErrors()
+    {
+        var asserter = Asserter<string>();
+        Assertion<string> pass = (errors, values) => { };
+        Assertion<string> fail = (errors, values) => errors.Add("B", ["b failed"]);
+
+        var result = asserter.Evaluate([], asserter.Any(pass, fail));
+
+        Assert.Null(result);
+    }
 }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Asserters/AttributeMatchAsserterTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Asserters/AttributeMatchAsserterTests.cs
@@ -184,4 +184,23 @@ public class AttributeMatchAsserterTests
         Assert.NotNull(result);
         Assert.Contains("AttributesAreBoolean", result.Errors.Keys);
     }
+
+    /// <summary>
+    /// An attribute with an empty value must produce ONE error that names the attribute,
+    /// not one bogus error per character of the stringified id list (regression: the error
+    /// projection ran <c>.Select</c> over a single string, iterating its characters).
+    /// </summary>
+    [Fact]
+    public void AllAttributesHasValues_EmptyValue_ReportsOneErrorNamingTheAttribute()
+    {
+        var asserter = AsserterTests.Asserter<AttributeMatch>();
+        var values = new AttributeMatch[] { new("urn:test:attr", string.Empty) };
+
+        var result = asserter.Evaluate(values, asserter.AllAttributesHasValues);
+
+        Assert.NotNull(result);
+        Assert.Contains("AllAttributesHasValues", result.Errors.Keys);
+        Assert.Single(result.Errors["AllAttributesHasValues"]);
+        Assert.Contains("urn:test:attr", result.Errors["AllAttributesHasValues"][0]);
+    }
 }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Asserters/AttributeMatchAsserterTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Asserters/AttributeMatchAsserterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Altinn.AccessManagement.Core.Asserters;
+using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Resolvers;
 using Microsoft.AspNetCore.Mvc;
@@ -77,7 +78,7 @@ public class AttributeMatchAsserterTests
     {
         var asserter = AsserterTests.Asserter<AttributeMatch>();
 
-        var result = asserter.Evaluate(values, asserter.DefaultTo);
+        var result = asserter.Evaluate(values, asserter.DefaultFrom);
 
         assert(result);
     }
@@ -119,6 +120,13 @@ public class AttributeMatchAsserterTests
             {
                 [new(BaseUrn.Altinn.Person.IdentifierNo, string.Empty)],
                 Assert.NotNull
+            },
+            {
+                // urn:altinn:userid is accepted as a "to" identifier but is NOT a valid
+                // "from" identifier, so DefaultFrom must reject it (DefaultTo accepts it).
+                // This is the one case that actually distinguishes DefaultFrom from DefaultTo.
+                [new(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, "123")],
+                Assert.NotNull
             }
         };
 
@@ -159,4 +167,21 @@ public class AttributeMatchAsserterTests
                 Assert.NotNull
             }
         };
+
+    /// <summary>
+    /// A non-boolean value for a boolean-typed attribute must be reported under the
+    /// <c>AttributesAreBoolean</c> key (regression: it was reported under
+    /// <c>AttributesAreIntegers</c> due to a copy-paste error).
+    /// </summary>
+    [Fact]
+    public void AttributesAreBoolean_NonBooleanValue_ReportsUnderBooleanKey()
+    {
+        var asserter = AsserterTests.Asserter<AttributeMatch>();
+        var values = new AttributeMatch[] { new("urn:test:flag", "notabool") };
+
+        var result = asserter.Evaluate(values, asserter.AttributesAreBoolean("urn:test:flag"));
+
+        Assert.NotNull(result);
+        Assert.Contains("AttributesAreBoolean", result.Errors.Keys);
+    }
 }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Helpers/AuthenticationHelperTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Helpers/AuthenticationHelperTest.cs
@@ -135,6 +135,22 @@ public class AuthenticationHelperTest
         AuthenticationHelper.GetSystemUserUuidString(CtxWith()).Should().BeEmpty();
     }
 
+    [Fact]
+    public void GetSystemUserUuid_SystemUserTypeWithEmptyIdArray_ReturnsEmpty()
+    {
+        var json = """{"type":"urn:altinn:systemuser","systemuser_id":[]}""";
+
+        AuthenticationHelper.GetSystemUserUuid(CtxWith(new Claim("authorization_details", json))).Should().Be(Guid.Empty);
+    }
+
+    [Fact]
+    public void GetSystemUserUuidString_SystemUserTypeWithoutIdArray_ReturnsEmptyString()
+    {
+        var json = """{"type":"urn:altinn:systemuser"}""";
+
+        AuthenticationHelper.GetSystemUserUuidString(CtxWith(new Claim("authorization_details", json))).Should().BeEmpty();
+    }
+
     // ── GetAuthenticatedPartyUuid composition ────────────────────────────────
     [Fact]
     public void GetAuthenticatedPartyUuid_PartyUuidPresent_ReturnsPartyUuid()

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Consent/ConsentPartyUrnTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Consent/ConsentPartyUrnTest.cs
@@ -1,0 +1,35 @@
+using Altinn.AccessManagement.Core.Models.Consent;
+
+namespace Altinn.AccessManagement.Tests.Unit.Models.Consent;
+
+/// <summary>
+/// Pins the hand-written party-id parse guard on <see cref="ConsentPartyUrn"/>.
+/// The generated <c>[KeyValueUrn]</c> machinery is library code; these tests cover
+/// only the custom <c>TryParsePartyId</c>, which uses <c>NumberStyles.None</c> so a
+/// signed or whitespace-padded party id is rejected (a negative party id must never
+/// parse).
+/// </summary>
+[UnitTest]
+[Collection("Models Test")]
+public class ConsentPartyUrnTest
+{
+    [Fact]
+    public void TryParse_PositivePartyId_ReturnsTrueWithValue()
+    {
+        ConsentPartyUrn.TryParse("urn:altinn:party:id:5", out var urn).Should().BeTrue();
+
+        urn!.IsPartyId(out var id).Should().BeTrue();
+        id.Should().Be(5);
+    }
+
+    [Theory]
+    [InlineData("urn:altinn:party:id:-5")]   // leading minus
+    [InlineData("urn:altinn:party:id:+5")]   // leading plus
+    [InlineData("urn:altinn:party:id: 5")]   // leading whitespace
+    public void TryParse_SignedOrWhitespacePartyId_ReturnsFalse(string urn)
+    {
+        // TryParsePartyId parses with NumberStyles.None, so a sign or whitespace must be
+        // rejected — guards against a refactor to a plain int.Parse that would accept them.
+        ConsentPartyUrn.TryParse(urn, out _).Should().BeFalse();
+    }
+}

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Register/OrganizationNumberTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Register/OrganizationNumberTest.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using Altinn.AccessManagement.Core.Models.Register;
+
+namespace Altinn.AccessManagement.Tests.Unit.Models.Register;
+
+/// <summary>
+/// Pure-logic tests for the <see cref="OrganizationNumber"/> in
+/// <c>Altinn.AccessManagement.Core.Models.Register</c>. Unlike the
+/// checksum-validating type in <c>Altinn.Authorization.Api.Contracts.Register</c>,
+/// this one validates length + digits only (no mod-11), and exposes
+/// <see cref="OrganizationNumber.CreateUnchecked"/>.
+/// </summary>
+[UnitTest]
+[Collection("Models Test")]
+public class OrganizationNumberTest
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    [Fact]
+    public void Parse_ValidNineDigits_ReturnsOrganizationNumber()
+    {
+        OrganizationNumber.Parse("987654321").ToString().Should().Be("987654321");
+    }
+
+    [Theory]
+    [InlineData("12345678")]    // 8 digits
+    [InlineData("1234567890")]  // 10 digits
+    public void TryParse_WrongLength_ReturnsFalse(string value)
+    {
+        OrganizationNumber.TryParse(value, null, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_NonNumeric_ReturnsFalse()
+    {
+        OrganizationNumber.TryParse("12345678X", null, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_Null_ReturnsFalse()
+    {
+        OrganizationNumber.TryParse(null, null, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_NineDigitBadChecksum_ReturnsTrue()
+    {
+        // This type validates length + digits only (no mod-11 checksum), so a value the
+        // checksum-validating Altinn.Authorization.Api.Contracts.Register.OrganizationNumber
+        // rejects is accepted here. Pins the deliberate cross-type validation divergence.
+        OrganizationNumber.TryParse("937884118", null, out var result).Should().BeTrue();
+        result!.ToString().Should().Be("937884118");
+    }
+
+    [Fact]
+    public void CreateUnchecked_InvalidValue_BypassesValidation()
+    {
+        OrganizationNumber.CreateUnchecked("not-an-org").ToString().Should().Be("not-an-org");
+    }
+
+    [Fact]
+    public void Json_DeserializeInvalid_ThrowsJsonException()
+    {
+        Action act = () => JsonSerializer.Deserialize<OrganizationNumber>("\"12345\"", JsonOptions);
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Json_RoundTrip_PreservesValue()
+    {
+        var orgNr = OrganizationNumber.Parse("987654321");
+        var json = JsonSerializer.Serialize(orgNr, JsonOptions);
+
+        json.Should().Be("\"987654321\"");
+        JsonSerializer.Deserialize<OrganizationNumber>(json, JsonOptions)!.ToString().Should().Be("987654321");
+    }
+}

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Urn/OrganizationNumberTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Urn/OrganizationNumberTest.cs
@@ -147,6 +147,20 @@ namespace Altinn.AccessManagement.Tests.Unit.Models.Urn
 
         /// <summary>
         /// Scenario:
+        /// Parse a 9-digit, all-numeric value whose mod-11 control digit is wrong.
+        /// Expected Result:
+        /// Rejected by the checksum branch (937884117 is valid; the flipped control digit must fail).
+        /// </summary>
+        [Fact]
+        public void Parse_NineDigitBadChecksum_Throws()
+        {
+            Action act = () => OrganizationNumber.Parse("937884118");
+
+            act.Should().Throw<Exception>();
+        }
+
+        /// <summary>
+        /// Scenario:
         /// Tests the OrganizationNumber GetExample
         /// Input:
         /// Get expected Example

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Urn/ResourceIdentifierTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Urn/ResourceIdentifierTest.cs
@@ -145,6 +145,31 @@ namespace Altinn.AccessManagement.Tests.Unit.Models.Urn
         }
 
         /// <summary>
+        /// Parse a 4-character lowercase value: the lower boundary of the
+        /// ^[a-z0-9_-]{4,}$ identifier rule (existing tests only use long values).
+        /// </summary>
+        [Fact]
+        public void TryParse_ExactlyFourLowercaseChars_Succeeds()
+        {
+            ResourceIdentifier.TryParse("abcd", null, out var id).Should().BeTrue();
+            id!.ToString().Should().Be("abcd");
+        }
+
+        /// <summary>
+        /// Values containing characters outside [a-z0-9_-] (uppercase, whitespace,
+        /// punctuation) are rejected — pins case-sensitivity and the allowed charset.
+        /// </summary>
+        [Theory]
+        [InlineData("ABCD")]
+        [InlineData("ABCDEFG")]
+        [InlineData("exam ple")]
+        [InlineData("exa.mple")]
+        public void TryParse_DisallowedCharacters_ReturnsFalse(string value)
+        {
+            ResourceIdentifier.TryParse(value, null, out _).Should().BeFalse();
+        }
+
+        /// <summary>
         /// Scenario:
         /// Tests the ResourceIdentifier
         /// Input:

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Utilities/IdentifierUtilTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Utilities/IdentifierUtilTest.cs
@@ -50,6 +50,12 @@ public class IdentifierUtilTest
         IdentifierUtil.IsValidOrganizationNumber(string.Empty).Should().BeFalse();
     }
 
+    [Fact]
+    public void IsValidOrganizationNumber_Null_ReturnsFalse()
+    {
+        IdentifierUtil.IsValidOrganizationNumber(null).Should().BeFalse();
+    }
+
     // ── MaskSSN ──────────────────────────────────────────────────────────────
     [Fact]
     public void MaskSSN_ReturnsFirstSixDigitsPlusFiveAsterisks()

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Extensions/ConsentExtensionsTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Extensions/ConsentExtensionsTest.cs
@@ -23,6 +23,22 @@ public class ConsentExtensionsTest
         dto.Value.Should().Be("ttd-some-app");
     }
 
+    // ── ConsentRequestStatusType contract sync ───────────────────────────────
+    [Fact]
+    public void ConsentRequestStatusType_EveryCoreValue_HasAContractCounterpart()
+    {
+        // The enterprise mapper casts the core status straight to the contract enum
+        // (ConsentRequestDetailsExtensions.ToConsentRequestDetailsExternal), so every
+        // core value must have a defined contract counterpart or it serializes as a
+        // bare number. Guards against future drift between the two enums.
+        foreach (Altinn.AccessManagement.Core.Models.Consent.ConsentRequestStatusType core
+            in Enum.GetValues<Altinn.AccessManagement.Core.Models.Consent.ConsentRequestStatusType>())
+        {
+            Enum.IsDefined(typeof(Altinn.Authorization.Api.Contracts.Consent.ConsentRequestStatusType), (int)core)
+                .Should().BeTrue($"core ConsentRequestStatusType.{core} ({(int)core}) must map to a defined contract value");
+        }
+    }
+
     // ── ConsentRightExtensions ───────────────────────────────────────────────
     [Fact]
     public void ToConsentRightExternal_EmptyResourceList_MapsToEmptyList()

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Unit/Utils/TranslationMiddlewareTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Unit/Utils/TranslationMiddlewareTest.cs
@@ -106,6 +106,24 @@ public class TranslationMiddlewareTest
         Assert.Equal("nob", ctx.Items[TranslationConstants.LanguageCodeKey]);
     }
 
+    [Fact]
+    public async Task QualityZeroValue_NotTreatedAsExclusion_StillSelected()
+    {
+        // RFC 7231 treats q=0 as "not acceptable", but the middleware only orders by
+        // quality without excluding q=0 — so en (its sole candidate) is still selected.
+        var ctx = await Run(c => c.Request.Headers["Accept-Language"] = "en;q=0");
+        Assert.Equal("eng", ctx.Items[TranslationConstants.LanguageCodeKey]);
+    }
+
+    [Fact]
+    public async Task MalformedQualityValue_FallsBackToDefaultQuality()
+    {
+        // A non-numeric q-value can't be parsed, so quality stays the default 1.0;
+        // en (q=abc → 1.0) therefore outranks nb (q=0.5).
+        var ctx = await Run(c => c.Request.Headers["Accept-Language"] = "en;q=abc,nb;q=0.5");
+        Assert.Equal("eng", ctx.Items[TranslationConstants.LanguageCodeKey]);
+    }
+
     // ── X-Accept-Partial-Translation parsing ──────────────────────────────────
     [Theory]
     [InlineData("true", true)]

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Consent/ConsentRequestStatusType.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Consent/ConsentRequestStatusType.cs
@@ -22,6 +22,9 @@ namespace Altinn.Authorization.Api.Contracts.Consent
         Revoked = 3,
 
         [EnumMember(Value = "deleted")]
-        Deleted = 4
+        Deleted = 4,
+
+        [EnumMember(Value = "expired")]
+        Expired = 5
     }
 }


### PR DESCRIPTION
A batch of small, independent correctness fixes surfaced during the test-gap review, each pinned with focused tests. Grouped into one PR so the related bug-class work reviews together rather than as several near-identical PRs.

## Production fixes
- **Validation asserters** (`Closes #3468`): three defects in `AttributeMatchAsserter`/`Asserter`: `Any` iterated the empty output dict instead of the collected errors (so it could never fail, a validation bypass); `AttributesAreBoolean` reported under the wrong error key; and `AllAttributesHasValues` projected over a single string, emitting one bogus error per character instead of one per empty attribute. All fixed + pinned.
- **Consent `Expired` status** (`Closes #3473`): added `Expired` to the public `Api.Contracts` consent-request-status enum; the enterprise API cast Core→Contracts and serialized `Expired` as an undefined value. Added an enum-sync test asserting every Core value has a contract counterpart.
- **Input guards** (`Closes #3475`): `AuthenticationHelper.GetSystemUserUuid` guards against an empty `SystemUserId` array (index-out-of-range); `IdentifierUtil.IsValidOrganizationNumber` guards against null (NRE).

## Pinning tests (no production change)
- `Core.Models.Register.OrganizationNumber` (length+digits validation, `CreateUnchecked`, JSON), previously untested.
- `ConsentPartyUrn` signed/whitespace party-id guard; `ResourceIdentifier` regex boundary + charset; `TranslationMiddleware` Accept-Language `q=0` and malformed-`q` edges; the `OrganizationNumber` mod-11 checksum branch.

## Verification
Unit lanes green (AccessMgmt.Tests, AccessMgmt.Core.Tests, AccessManagement.Api.Tests; 25 asserter tests included).

Supersedes #3474, #3476, #3488 (consolidated here). Related to #2976.

