### PR TITLE
Use sequence number in npgsql query text logging also for first sequence

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/ServiceCollectionExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Extensions/ServiceCollectionExtensions.cs
@@ -96,7 +96,7 @@ public static class ServiceCollectionExtensions
                             for (int i = 0; i < maxTags; i++)
                             {
                                 activity.SetTag(
-                                    $"db.statement{(i > 0 ? i : null)}",
+                                    $"db.statement{i}",
                                     commandSpan.Slice(i * maxTagLength, Math.Min(maxTagLength, commandSpan.Length - (i * maxTagLength))).ToString());
                                 if ((i + 1) * maxTagLength >= commandSpan.Length)
                                 {


### PR DESCRIPTION
## Description
- Use sequence number in npgsql query text logging also for first sequence

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
