### PR TITLE
issues(3502): remove concurrent exec of funcs using EF.

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEfOld.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEfOld.cs
@@ -392,6 +392,7 @@ public class AuthorizedPartiesServiceEfOld(
             });
         }
 
+        var a2Result = await a2Task;
         if (filter.IncludeAltinn3)
         {
             a3Task = Task.Run(async () =>
@@ -401,9 +402,6 @@ public class AuthorizedPartiesServiceEfOld(
             });
         }
 
-        await Task.WhenAll(a2Task, a3Task);
-
-        var a2Result = await a2Task;
         var a3Result = await a3Task;
 
         // Since EF does not support parallel use of DbContexts, we need to fetch the Altinn 2 parties separately here


### PR DESCRIPTION

We are seeing recurring System.ObjectDisposedException at Npgsql.Internal.NpgsqlConnector.ResetCancellation across multiple endpoints that call GetAuthorizedParties.

Concurrent DbContext access — GetAuthorizedParties (around [AuthorizedPartiesServiceEfOld.cs:370](vscode-webview://10mb9q8opjgald0f960s608kgt9vsprro1m61ftbdgm4s562vf33/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEfOld.cs#L370)) was launching two Task.Run blocks and awaiting them concurrently via Task.WhenAll. Both tasks captured and used the injected EF DbContext, violating EF's documented single-threaded usage requirement. Fixed by making execution sequential.
## Related Issue(s)
- #3502 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
