### PR TITLE
enduser-request-systemuserauth check for systemuser

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/RequestController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/RequestController.cs
@@ -294,7 +294,7 @@ public class RequestController(
             return problem.ToActionResult();
         }
 
-        var authUserUuid = AuthenticationHelper.GetPartyUuid(HttpContext);
+        var authUserUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
 
         // Guaranteed non-null here: TryBuild above returned false, so the null/auth check passed.
         return request!.Type switch
@@ -349,7 +349,7 @@ public class RequestController(
     {
         ValidationErrorBuilder errorBuilder = default;
 
-        var authUserUuid = AuthenticationHelper.GetPartyUuid(HttpContext);
+        var authUserUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
         var (hasConnections, _) = await connectionQuery.HasConnection(to, party);
         if (!hasConnections)
         {
@@ -432,7 +432,7 @@ public class RequestController(
     {
         ValidationErrorBuilder errorBuilder = default;
 
-        var authUserUuid = AuthenticationHelper.GetPartyUuid(HttpContext);
+        var authUserUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(HttpContext);
         var (hasConnections, _) = await connectionQuery.HasConnection(to, party);
         if (!hasConnections)
         {


### PR DESCRIPTION
## Description
- Fixes enduser/request endpoint to check for systemuser identifiers and party.

## Related Issue(s)
- #3531 

For reference
``` 
/// <summary>
/// Gets the users PartyUuid or system user uuid.
/// </summary>
public static Guid GetAuthenticatedPartyUuid(HttpContext context)
{
    var partyuuid = GetPartyUuid(context);
    if (partyuuid == Guid.Empty)
    {
        return GetSystemUserUuid(context);
    }

    return partyuuid;
}
```