### PR TITLE
fix: pin MessagePack to 2.5.302 to clear CVE-2026-48109 in the AppHost

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -48,6 +48,7 @@
     <PackageVersion Include="MassTransit.Analyzers" Version="8.5.9" />
     <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.5.9" />
     <PackageVersion Include="MassTransit.Extensions.DependencyInjection" Version=" 7.3.1" />
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.AppHost/Altinn.AccessManagement.AppHost.csproj
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.AppHost/Altinn.AccessManagement.AppHost.csproj
@@ -9,6 +9,13 @@
 
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.AppHost" />
+
+        <!-- Pin MessagePack above the 2.5.192 that Aspire 9.5.2 pulls in transitively,
+             to clear CVE-2026-48109 (GHSA-hv8m-jj95-wg3x): an out-of-bounds read in LZ4
+             decompression. Same 2.5.x line, so it stays compatible with Aspire's
+             orchestration. Remove when the repo moves to Aspire >= 13.x (which ships a
+             patched MessagePack). -->
+        <PackageReference Include="MessagePack" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Clears the high-severity NuGet advisory **NU1903 / [GHSA-hv8m-jj95-wg3x](https://github.com/advisories/GHSA-hv8m-jj95-wg3x)** (CVE-2026-48109, out-of-bounds read in MessagePack LZ4 decompression, CVSS 8.2) reported on the `Altinn.AccessManagement.AppHost` project.

### Root cause
MessagePack 2.5.192 is pulled in transitively by .NET Aspire 9.5.2 (`Aspire.AppHost.Sdk` / `Aspire.Hosting.AppHost` -> `Aspire.Hosting` -> `MessagePack`). It only surfaces in the AppHost (the Aspire orchestration/composition root, a local dev-orchestration host rather than a shipped service), so real exposure is minimal, but it is a high-severity warning worth clearing. There is no in-major Aspire fix: 9.5.2 is the latest 9.x, and the next release line is a 13.x major migration.

### Change
- Promote `MessagePack` to a direct reference in the AppHost, pinned to **2.5.302** (the patched 2.5.x line; the advisory affects v2 < 2.5.301), overriding Aspire's transitive 2.5.192.
- Same minor line, so it stays compatible with Aspire 9.5.2's orchestration.
- Annotated for removal once the repo migrates to Aspire >= 13.x (which ships a patched MessagePack).

### Verification
AppHost builds with 0 errors; `MessagePack` resolves to 2.5.302 and a fresh restore reports no MessagePack advisory.

Closes #3537
