### PR TITLE
fix: guard nullable PartyUuid in ContextHandler.EnrichResourceParty

### DIFF
--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Services/Implementation/ContextHandler.cs
@@ -234,7 +234,10 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     resourceAttributes.ResourcePartyValue = party.PartyId.ToString();
                     requestResourceAttributes.Attributes.Add(GetPartyIdsAttribute(new List<int> { party.PartyId }));
 
-                    resourceAttributes.PartyUuid = party.PartyUuid.Value;
+                    if (party.PartyUuid.HasValue)
+                    {
+                        resourceAttributes.PartyUuid = party.PartyUuid.Value;
+                    }
                 }
             }
             else if (string.IsNullOrEmpty(resourceAttributes.ResourcePartyValue) && !string.IsNullOrEmpty(resourceAttributes.PersonId))
@@ -250,7 +253,10 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     resourceAttributes.ResourcePartyValue = party.PartyId.ToString();
                     requestResourceAttributes.Attributes.Add(GetPartyIdsAttribute(new List<int> { party.PartyId }));
 
-                    resourceAttributes.PartyUuid = party.PartyUuid.Value;
+                    if (party.PartyUuid.HasValue)
+                    {
+                        resourceAttributes.PartyUuid = party.PartyUuid.Value;
+                    }
                 }
             }
             else if (string.IsNullOrEmpty(resourceAttributes.ResourcePartyValue) && resourceAttributes.PartyUuid != Guid.Empty)
@@ -262,7 +268,10 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                     resourceAttributes.ResourcePartyValue = party.PartyId.ToString();
                     requestResourceAttributes.Attributes.Add(GetPartyIdsAttribute(new List<int> { party.PartyId }));
 
-                    resourceAttributes.PartyUuid = party.PartyUuid.Value;
+                    if (party.PartyUuid.HasValue)
+                    {
+                        resourceAttributes.PartyUuid = party.PartyUuid.Value;
+                    }
                 }
             }
 

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/ContextHandlerUnitTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/ContextHandlerUnitTest.cs
@@ -394,6 +394,66 @@ public class ContextHandlerUnitTest : IDisposable
         Assert.Equal(uuid, resourceAttrs.PartyUuid);
     }
 
+    [Fact]
+    public async Task EnrichResourceParty_OrgNumber_PartyWithoutUuid_DoesNotThrow()
+    {
+        var party = new Party { PartyId = 50001337, PartyUuid = null };
+        _registerServiceMock
+            .Setup(r => r.PartyLookup("910514318", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(party);
+
+        // The party-id fallback also returns a party without a UUID, so PartyUuid stays unresolved.
+        _registerServiceMock
+            .Setup(r => r.GetPartiesAsync(It.Is<List<int>>(l => l.Contains(50001337)), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Party> { new() { PartyId = 50001337, PartyUuid = null } });
+
+        var resourceAttrs = new XacmlResourceAttributes { OrganizationNumber = "910514318" };
+        var contextAttrs = CreateResourceAttributes();
+
+        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, false, TestContext.Current.CancellationToken);
+
+        Assert.Equal("50001337", resourceAttrs.ResourcePartyValue);
+        Assert.Equal(Guid.Empty, resourceAttrs.PartyUuid);
+    }
+
+    [Fact]
+    public async Task EnrichResourceParty_PersonId_PartyWithoutUuid_DoesNotThrow()
+    {
+        var party = new Party { PartyId = 50001338, PartyUuid = null };
+        _registerServiceMock
+            .Setup(r => r.PartyLookup(null, "01017012345", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(party);
+
+        // The party-id fallback also returns a party without a UUID, so PartyUuid stays unresolved.
+        _registerServiceMock
+            .Setup(r => r.GetPartiesAsync(It.Is<List<int>>(l => l.Contains(50001338)), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Party> { new() { PartyId = 50001338, PartyUuid = null } });
+
+        var resourceAttrs = new XacmlResourceAttributes { PersonId = "01017012345" };
+        var contextAttrs = CreateResourceAttributes();
+
+        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, true, TestContext.Current.CancellationToken);
+
+        Assert.Equal("50001338", resourceAttrs.ResourcePartyValue);
+        Assert.Equal(Guid.Empty, resourceAttrs.PartyUuid);
+    }
+
+    [Fact]
+    public async Task EnrichResourceParty_PartyUuid_PartyWithoutUuid_DoesNotThrow()
+    {
+        var uuid = Guid.NewGuid();
+        _registerServiceMock
+            .Setup(r => r.GetPartiesAsync(It.Is<List<Guid>>(l => l.Contains(uuid)), false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Party> { new() { PartyId = 50001339, PartyUuid = null } });
+
+        var resourceAttrs = new XacmlResourceAttributes { PartyUuid = uuid };
+        var contextAttrs = CreateResourceAttributes();
+
+        await _sut.TestEnrichResourceParty(contextAttrs, resourceAttrs, false, TestContext.Current.CancellationToken);
+
+        Assert.Equal("50001339", resourceAttrs.ResourcePartyValue);
+    }
+
     #endregion
 
     #region Cached lookups


### PR DESCRIPTION
`ContextHandler.EnrichResourceParty` resolves a resource party from an organization number, a person id, or a party UUID, then copies the looked-up party's UUID into the resource attributes. Three of those assignments read `party.PartyUuid.Value` directly. `Party.PartyUuid` is nullable, so when register returns a party without a UUID the call throws `InvalidOperationException` and enrichment fails for the whole authorization request.

The same method already guards the nullable everywhere else: the party-id fallback checks `PartyUuid.HasValue` before reading `.Value`, and the subject-resolution paths use `PartyUuid.HasValue ? .Value : Guid.Empty`. This brings the three resource-party sites in line with that convention and leaves `PartyUuid` at `Guid.Empty` when no UUID is available.

Adds unit tests that drive each branch with a UUID-less party. They throw `InvalidOperationException` against the unguarded code and pass with the guard.

Fixes #3543
