### PR TITLE
ci: report failed tests on the test lane itself, in a readable form

### DIFF
--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -216,16 +216,28 @@ jobs:
       # TestResults/*.coverage into one report, so the threshold gate and Sonar
       # still see whole-suite coverage. `dotnet-coverage collect -- dotnet test`
       # propagates the test exit code, so a real failure (exit 2) fails the step.
+      # On failure a lane prints its own failing tests (assertion, source line and
+      # stack) inline via eng/testing/report-failed-tests.ps1, then re-raises the
+      # exit code — so the failures show up on the step that ran them.
       - name: Test - unit lane (with coverage)
         id: test_unit
         shell: bash
         working-directory: ${{ inputs.path }}
         run: |
+          set +e
           dotnet-coverage collect --nologo \
             --output TestResults/coverage.unit.coverage --output-format coverage \
             -- dotnet test -c Release --no-build -bl:binlog/test-unit.binlog \
               -- --results-directory TestResults/unit --report-xunit-trx \
                  --filter-trait "Category=Unit" --ignore-exit-code 8
+          code=$?
+          set -e
+          # Surface the failing tests on this step (with assertion, source line and
+          # stack), then re-raise the real exit code so the lane still fails.
+          if [ "$code" -ne 0 ]; then
+            pwsh -NoProfile -File "$GITHUB_WORKSPACE/eng/testing/report-failed-tests.ps1" -ResultsDirectory TestResults/unit
+          fi
+          exit "$code"
 
       - name: Test - integration lane (with coverage)
         # Runs even when the unit lane failed (but not when the build failed),
@@ -241,11 +253,20 @@ jobs:
           # coverage swallow the test host's process-exit stdout.
           FIXTURE_TIMING_FILE: ${{ github.workspace }}/fixture-timing.txt
         run: |
+          set +e
           dotnet-coverage collect --nologo \
             --output TestResults/coverage.integration.coverage --output-format coverage \
             -- dotnet test -c Release --no-build -bl:binlog/test-integration.binlog \
               -- --results-directory TestResults/integration --report-xunit-trx \
                  --filter-trait "Category=Integration" --ignore-exit-code 8
+          code=$?
+          set -e
+          # Surface the failing tests on this step (with assertion, source line and
+          # stack), then re-raise the real exit code so the lane still fails.
+          if [ "$code" -ne 0 ]; then
+            pwsh -NoProfile -File "$GITHUB_WORKSPACE/eng/testing/report-failed-tests.ps1" -ResultsDirectory TestResults/integration
+          fi
+          exit "$code"
 
       - name: Setup-timing breakdown (FixtureTiming)
         # Surface FixtureTiming's per-assembly setup-time breakdown (host build vs DB
@@ -263,75 +284,6 @@ jobs:
           else
             echo "No FixtureTiming output (this vertical's tests do not use the Postgres engine)."
           fi
-
-      - name: Report failed tests
-        # When the Test step fails, surface the specific failing test names
-        # (plus their assertion / stack context) directly in the workflow log.
-        # The workflow's dotnet-test output otherwise only contains per-DLL
-        # summary lines ("Failed: N, Passed: M, ...") — MTP writes the test-
-        # level detail to bin/.../TestResults/<Project>_<tfm>_<arch>.log,
-        # which this step parses. The same files are uploaded as artifacts by
-        # the step below; we mirror the failures into the log (and as
-        # ::error:: annotations for the PR checks summary) so reviewers don't
-        # need to download the artifact for the most common case.
-        if: failure() && (steps.test_unit.conclusion == 'failure' || steps.test_integration.conclusion == 'failure')
-        shell: pwsh
-        working-directory: ${{ inputs.path }}
-        run: |
-          # Each lane passes `--results-directory TestResults/<lane>` to MTP,
-          # so the per-project logs land under `<vertical>/TestResults/unit/`
-          # and `.../integration/` (and, for some configurations, in the
-          # per-project `bin/.../TestResults/`). Matching any path that
-          # contains a `TestResults/` segment covers all of these while the
-          # `*_net10.0_x64.log` filename pattern keeps us on MTP-shaped
-          # per-project logs.
-          $logs = Get-ChildItem -Path . -Recurse -Filter '*_net10.0_x64.log' -ErrorAction SilentlyContinue |
-                  Where-Object { ($_.FullName -replace '\\','/') -match '/TestResults/' }
-
-          if (-not $logs) {
-              Write-Host "No MTP per-project logs found in any TestResults/ directory under $(Get-Location)." -ForegroundColor Yellow
-              exit 0
-          }
-
-          $total = 0
-          foreach ($log in $logs) {
-              # MTP's per-project log prints a line of the form
-              #   failed <Test Display Name> (duration)
-              # followed by the assertion message, source location, and stack.
-              # We grab each "failed " line plus a bounded block of context.
-              # Note: `$matches` is an automatic variable in PowerShell (written
-              # by the -match operator), so use a distinct name here.
-              $failures = Select-String -Path $log.FullName -Pattern '^\s*failed\s+' -Context 0, 15
-              if (-not $failures) { continue }
-
-              Write-Host ""
-              Write-Host "::group::Failed tests in $($log.BaseName)"
-              foreach ($m in $failures) {
-                  $total++
-                  $title = ($m.Line -replace '^\s*failed\s+', '').Trim()
-                  # Take context up to (but not past) the next "failed " line or
-                  # an unrelated xUnit/MTP summary line — whichever comes first.
-                  $ctx = @()
-                  foreach ($line in $m.Context.PostContext) {
-                      if ($line -match '^\s*failed\s+' -or $line -match '^\s*(passed|skipped)\s+' -or $line -match 'Test run summary' -or $line -match 'Tests (failed|succeeded):' ) { break }
-                      $ctx += $line
-                  }
-                  $body = ($ctx -join "`n").TrimEnd()
-                  Write-Host "`n  $title"
-                  if ($body) { Write-Host $body }
-
-                  # PR-checks annotation (first non-empty context line as message)
-                  $msgLine = ($ctx | Where-Object { $_.Trim() } | Select-Object -First 1)
-                  if (-not $msgLine) { $msgLine = 'See workflow log / test-results artifact for details.' }
-                  $escTitle = $title -replace '%','%25' -replace "`r",'' -replace "`n",' '
-                  $escMsg = $msgLine.Trim() -replace '%','%25' -replace "`r",'' -replace "`n",' '
-                  Write-Host "::error title=$escTitle::$escMsg"
-              }
-              Write-Host "::endgroup::"
-          }
-
-          Write-Host ""
-          Write-Host "Total failing tests: $total"
 
       - name: Convert coverage to cobertura
         # Merges the per-lane .coverage binaries (unit + integration) written
@@ -408,12 +360,12 @@ jobs:
         if: inputs.type == 'pkg'
 
       - name: Upload test results
-        # On failure only: capture MTP per-project logs and TRX reports so the
-        # cause can be diagnosed from GHA artifacts. The workflow `Test.txt`
-        # log contains only summary lines like "Failed: N, Passed: M"; per-test
-        # detail lives in bin/.../TestResults/<Project>_<tfm>_<arch>.log.
-        # We intentionally skip this on success — the logs aren't needed and
-        # uploading them every run added 10+ MB per CI pipeline.
+        # On failure only: keep the full MTP per-project logs and TRX reports as
+        # GHA artifacts. The failing tests (assertion, source line, stack) are
+        # already printed inline on the test lane that ran them; these artifacts
+        # are the complete record for the cases that need more than the inline
+        # summary. We intentionally skip this on success — the logs aren't needed
+        # and uploading them every run added 10+ MB per CI pipeline.
         # Coverage XML is not uploaded (it's reproducible locally via
         # eng/testing/run-coverage.ps1 and was the bulk of the artifact size).
         if: failure()

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -1,0 +1,194 @@
+#!/usr/bin/env pwsh
+# Surfaces failing tests from a test lane directly in that lane's own step log,
+# in a human-readable form, plus GitHub `::error::` annotations that point at the
+# failing source line.
+#
+# The xUnit-v3 / Microsoft-Testing-Platform per-project log
+# (`<Project>_<tfm>_<arch>.log`, UTF-16) carries the test-level detail that the
+# step's console output drops (the console only shows per-DLL `failed: N`). Each
+# failure block in that log looks like:
+#
+#     failed <FullyQualifiedName>[(theory args)] (<duration>)
+#         <assertion / exception message, may span lines>
+#             at <stack frame>
+#             at <... in /path/File.cs:line>
+#
+# Called from the test lane after `dotnet test`; the lane keeps and propagates the
+# real test exit code, so this script is best-effort and always exits 0.
+[CmdletBinding()]
+param(
+    # The relative results directory the lane passed to `--results-directory`
+    # (e.g. "TestResults/unit"). MTP resolves that path per test project, so the
+    # per-project logs land in several places that all share the
+    # "/TestResults/unit/" path segment; we match on the segment rather than a
+    # single directory, which also keeps the two lanes apart.
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsDirectory
+)
+
+$ErrorActionPreference = 'Continue'
+
+# The box-drawing separator and the cross mark are UTF-8; make sure the host emits
+# UTF-8 regardless of the runner's default console encoding.
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch { }
+
+function Get-RepoRelativePath {
+    param([string]$Path)
+    $root = $env:GITHUB_WORKSPACE
+    if ([string]::IsNullOrWhiteSpace($root)) { return $Path }
+    $norm = $Path -replace '\\', '/'
+    $root = $root -replace '\\', '/'
+    if ($norm.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $norm.Substring($root.Length).TrimStart('/')
+    }
+    return $norm
+}
+
+$segment = '/' + (($ResultsDirectory -replace '\\', '/').Trim('/')) + '/'
+
+$logs = Get-ChildItem -Path . -Recurse -Filter '*_x64.log' -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Name -match '_net\d' -and
+            (($_.FullName -replace '\\', '/') -like "*$segment*")
+        }
+
+if (-not $logs) {
+    Write-Host "No '$ResultsDirectory' test logs found to scan for failing tests."
+    exit 0
+}
+
+$grandTotal = 0
+
+foreach ($log in $logs) {
+    # PS7 Get-Content auto-detects the UTF-16 BOM these logs carry.
+    $lines = Get-Content -LiteralPath $log.FullName
+    if (-not $lines) { continue }
+
+    # Collect each failure as the "failed ..." header line plus every line up to
+    # the next failed header or the run summary.
+    $blocks = @()
+    $current = $null
+    foreach ($raw in $lines) {
+        $line = $raw -replace "`r", ''
+        if ($line -match '^\s*failed\s+\S') {
+            if ($current) { $blocks += , $current }
+            $current = [System.Collections.Generic.List[string]]::new()
+            $current.Add($line)
+            continue
+        }
+        if (-not $current) { continue }
+        if ($line -match '^\s*(passed|skipped)\s+\S' -or
+            $line -match '^\s*Test run summary' -or
+            $line -match '^\s*In process file artifacts' -or
+            $line -match '^\s*total:\s') {
+            $blocks += , $current
+            $current = $null
+            continue
+        }
+        $current.Add($line)
+    }
+    if ($current) { $blocks += , $current }
+    if ($blocks.Count -eq 0) { continue }
+
+    $project = $log.BaseName -replace '_net\d.*$', ''
+
+    Write-Host ''
+    Write-Host ('─' * 78)
+    Write-Host ("  ❌  {0} failed test{1} in {2}" -f $blocks.Count, ($(if ($blocks.Count -eq 1) { '' } else { 's' })), $project)
+    Write-Host ('─' * 78)
+
+    $index = 0
+    foreach ($block in $blocks) {
+        $index++
+        $grandTotal++
+
+        # Header: "failed <FQN>[(args)] (<duration>)" — duration is the last (...).
+        $header = $block[0].Trim() -replace '^failed\s+', ''
+        $duration = ''
+        $m = [regex]::Match($header, '^(?<name>.+)\s+\((?<dur>[^)]*)\)\s*$')
+        if ($m.Success) {
+            $fqn = $m.Groups['name'].Value.Trim()
+            $duration = $m.Groups['dur'].Value.Trim()
+        }
+        else {
+            $fqn = $header
+        }
+
+        # Short, recognisable headline: Class.Method(args), full FQN kept for the
+        # annotation title.
+        $namePart = $fqn
+        $argPart = ''
+        $paren = $fqn.IndexOf('(')
+        if ($paren -ge 0) {
+            $namePart = $fqn.Substring(0, $paren)
+            $argPart = $fqn.Substring($paren)
+        }
+        $segments = $namePart.Split('.')
+        $short = if ($segments.Length -ge 2) { ($segments[-2..-1] -join '.') } else { $namePart }
+        $short = "$short$argPart"
+
+        # Message = block lines before the first stack frame ("at ...").
+        # Stack = from the first "at ..." onward.
+        $body = $block | Select-Object -Skip 1
+        $messageLines = [System.Collections.Generic.List[string]]::new()
+        $stackLines = [System.Collections.Generic.List[string]]::new()
+        $inStack = $false
+        foreach ($l in $body) {
+            if (-not $inStack -and $l -match '^\s*at\s') { $inStack = $true }
+            if ($inStack) {
+                if ($l.Trim()) { $stackLines.Add($l.Trim()) }
+            }
+            elseif ($l.Trim()) {
+                $messageLines.Add($l.Trim())
+            }
+        }
+        $message = ($messageLines -join ' ').Trim()
+        # Drop the MTP/xUnit exception-wrapper prefix so the real exception type and
+        # message lead.
+        $message = $message -replace '^Xunit\.Runner\.InProc\.SystemConsole\.TestingPlatform\.XunitException:\s*', ''
+        if (-not $message) { $message = '(no message — see stack trace / test-results artifact)' }
+
+        # Source location: first user stack frame carrying " in <file>:line".
+        $sourceFile = ''
+        $sourceLine = ''
+        foreach ($s in $stackLines) {
+            $sm = [regex]::Match($s, ' in (?<file>.+):(?:line )?(?<line>\d+)\s*$')
+            if ($sm.Success) {
+                $sourceFile = Get-RepoRelativePath $sm.Groups['file'].Value
+                $sourceLine = $sm.Groups['line'].Value
+                break
+            }
+        }
+
+        Write-Host ''
+        Write-Host ("  {0}) {1}" -f $index, $short)
+        Write-Host ("     Reason   {0}" -f $message)
+        if ($sourceFile) {
+            Write-Host ("     Source   {0}:{1}" -f $sourceFile, $sourceLine)
+        }
+        if ($duration) {
+            Write-Host ("     Time     {0}" -f $duration)
+        }
+        if ($stackLines.Count -gt 0) {
+            Write-Host "::group::     Stack trace"
+            foreach ($s in $stackLines) { Write-Host "       $s" }
+            Write-Host '::endgroup::'
+        }
+
+        # PR-checks annotation, anchored at the failing source line when known.
+        $escTitle = $fqn -replace '%', '%25' -replace "`r", '' -replace "`n", ' '
+        $escMsg = $message -replace '%', '%25' -replace "`r", '' -replace "`n", ' '
+        if ($sourceFile) {
+            Write-Host ("::error file={0},line={1},title={2}::{3}" -f $sourceFile, $sourceLine, $escTitle, $escMsg)
+        }
+        else {
+            Write-Host ("::error title={0}::{1}" -f $escTitle, $escMsg)
+        }
+    }
+}
+
+Write-Host ''
+if ($grandTotal -gt 0) {
+    Write-Host ("  Total: {0} failing test{1}." -f $grandTotal, ($(if ($grandTotal -eq 1) { '' } else { 's' })))
+}
+exit 0


### PR DESCRIPTION
Closes #3567.

A separate `Report failed tests` step used to run after the test lanes and parse the MTP per-project logs, so failing tests showed up on a different step from the one that ran them, and only as a `failed <name>` line plus a slab of raw context.

This moves the reporting onto each lane. After `dotnet test`, on a non-zero exit the lane runs `eng/testing/report-failed-tests.ps1` against its own results directory and then re-raises the exit code, so the lane still fails the build. The standalone step is removed.

The formatter reads the UTF-16 MTP logs and prints, per failing test:

- a recognisable `Class.Method(args)` headline,
- the assertion or exception message (the xUnit wrapper prefix stripped),
- the repo-relative source `file:line`,
- the duration,
- and a foldable stack trace.

It also emits a GitHub `::error file=…,line=…::` annotation anchored at the failing source line, so the failure surfaces inline on the PR diff. Each lane matches only its own `/TestResults/<lane>/` logs, so unit and integration stay separate.

Validated locally against real MTP failure logs (assertion failure, thrown exception, theory case): parsing, the repo-relative path, the annotation, and exit-code propagation all check out. Example output:

```
──────────────────────────────────────────────────────────────────
  ❌  1 failed test in Altinn.Authorization.ABAC.Tests
──────────────────────────────────────────────────────────────

  1) ZzzTempFailingProbe.Probe_AssertionFailure
     Reason   Expected value to be 42 because deliberate probe failure, but found 7 (difference of -35).
     Source   src/pkgs/Altinn.Authorization.ABAC/test/.../ZzzTempFailingProbe.cs:6
     Time     1s 509ms
```
