### PR TITLE
[DEMO - DO NOT MERGE] show CI failed-test reporting output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  actions: read # the per-vertical CI reads the jobs API to deep-link the failed-test summary
 
 # Cancel a superseded run when a PR is pushed again; let main-push runs finish.
 concurrency:

--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -90,6 +90,21 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Cache NuGet packages
+        # The Build step below restores the vertical's package closure (Azure SDK,
+        # Mongo, Spectre, Yarp, ...) on a cold runner every run. Cache the global
+        # packages folder so restore is served from disk instead of the network.
+        # Keyed by the hash of every csproj plus the central-package-management
+        # version files, so adding/removing/bumping a package invalidates the key;
+        # restore-keys falls back to the newest partial cache. Fail-safe: a miss
+        # just restores normally, and actions/cache never fails the job.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore dotnet workloads
         # Only verticals that contain an Aspire AppHost (currently AccessManagement)
         # need a workload restore; skip the ~20s on every other vertical.

--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -231,16 +231,28 @@ jobs:
       # TestResults/*.coverage into one report, so the threshold gate and Sonar
       # still see whole-suite coverage. `dotnet-coverage collect -- dotnet test`
       # propagates the test exit code, so a real failure (exit 2) fails the step.
+      # On failure a lane prints its own failing tests (assertion, source line and
+      # stack) inline via eng/testing/report-failed-tests.ps1, then re-raises the
+      # exit code — so the failures show up on the step that ran them.
       - name: Test - unit lane (with coverage)
         id: test_unit
         shell: bash
         working-directory: ${{ inputs.path }}
         run: |
+          set +e
           dotnet-coverage collect --nologo \
             --output TestResults/coverage.unit.coverage --output-format coverage \
             -- dotnet test -c Release --no-build -bl:binlog/test-unit.binlog \
               -- --results-directory TestResults/unit --report-xunit-trx \
                  --filter-trait "Category=Unit" --ignore-exit-code 8
+          code=$?
+          set -e
+          # Surface the failing tests on this step (with assertion, source line and
+          # stack), then re-raise the real exit code so the lane still fails.
+          if [ "$code" -ne 0 ]; then
+            pwsh -NoProfile -File "$GITHUB_WORKSPACE/eng/testing/report-failed-tests.ps1" -ResultsDirectory TestResults/unit
+          fi
+          exit "$code"
 
       - name: Test - integration lane (with coverage)
         # Runs even when the unit lane failed (but not when the build failed),
@@ -256,11 +268,20 @@ jobs:
           # coverage swallow the test host's process-exit stdout.
           FIXTURE_TIMING_FILE: ${{ github.workspace }}/fixture-timing.txt
         run: |
+          set +e
           dotnet-coverage collect --nologo \
             --output TestResults/coverage.integration.coverage --output-format coverage \
             -- dotnet test -c Release --no-build -bl:binlog/test-integration.binlog \
               -- --results-directory TestResults/integration --report-xunit-trx \
                  --filter-trait "Category=Integration" --ignore-exit-code 8
+          code=$?
+          set -e
+          # Surface the failing tests on this step (with assertion, source line and
+          # stack), then re-raise the real exit code so the lane still fails.
+          if [ "$code" -ne 0 ]; then
+            pwsh -NoProfile -File "$GITHUB_WORKSPACE/eng/testing/report-failed-tests.ps1" -ResultsDirectory TestResults/integration
+          fi
+          exit "$code"
 
       - name: Setup-timing breakdown (FixtureTiming)
         # Surface FixtureTiming's per-assembly setup-time breakdown (host build vs DB
@@ -278,75 +299,6 @@ jobs:
           else
             echo "No FixtureTiming output (this vertical's tests do not use the Postgres engine)."
           fi
-
-      - name: Report failed tests
-        # When the Test step fails, surface the specific failing test names
-        # (plus their assertion / stack context) directly in the workflow log.
-        # The workflow's dotnet-test output otherwise only contains per-DLL
-        # summary lines ("Failed: N, Passed: M, ...") — MTP writes the test-
-        # level detail to bin/.../TestResults/<Project>_<tfm>_<arch>.log,
-        # which this step parses. The same files are uploaded as artifacts by
-        # the step below; we mirror the failures into the log (and as
-        # ::error:: annotations for the PR checks summary) so reviewers don't
-        # need to download the artifact for the most common case.
-        if: failure() && (steps.test_unit.conclusion == 'failure' || steps.test_integration.conclusion == 'failure')
-        shell: pwsh
-        working-directory: ${{ inputs.path }}
-        run: |
-          # Each lane passes `--results-directory TestResults/<lane>` to MTP,
-          # so the per-project logs land under `<vertical>/TestResults/unit/`
-          # and `.../integration/` (and, for some configurations, in the
-          # per-project `bin/.../TestResults/`). Matching any path that
-          # contains a `TestResults/` segment covers all of these while the
-          # `*_net10.0_x64.log` filename pattern keeps us on MTP-shaped
-          # per-project logs.
-          $logs = Get-ChildItem -Path . -Recurse -Filter '*_net10.0_x64.log' -ErrorAction SilentlyContinue |
-                  Where-Object { ($_.FullName -replace '\\','/') -match '/TestResults/' }
-
-          if (-not $logs) {
-              Write-Host "No MTP per-project logs found in any TestResults/ directory under $(Get-Location)." -ForegroundColor Yellow
-              exit 0
-          }
-
-          $total = 0
-          foreach ($log in $logs) {
-              # MTP's per-project log prints a line of the form
-              #   failed <Test Display Name> (duration)
-              # followed by the assertion message, source location, and stack.
-              # We grab each "failed " line plus a bounded block of context.
-              # Note: `$matches` is an automatic variable in PowerShell (written
-              # by the -match operator), so use a distinct name here.
-              $failures = Select-String -Path $log.FullName -Pattern '^\s*failed\s+' -Context 0, 15
-              if (-not $failures) { continue }
-
-              Write-Host ""
-              Write-Host "::group::Failed tests in $($log.BaseName)"
-              foreach ($m in $failures) {
-                  $total++
-                  $title = ($m.Line -replace '^\s*failed\s+', '').Trim()
-                  # Take context up to (but not past) the next "failed " line or
-                  # an unrelated xUnit/MTP summary line — whichever comes first.
-                  $ctx = @()
-                  foreach ($line in $m.Context.PostContext) {
-                      if ($line -match '^\s*failed\s+' -or $line -match '^\s*(passed|skipped)\s+' -or $line -match 'Test run summary' -or $line -match 'Tests (failed|succeeded):' ) { break }
-                      $ctx += $line
-                  }
-                  $body = ($ctx -join "`n").TrimEnd()
-                  Write-Host "`n  $title"
-                  if ($body) { Write-Host $body }
-
-                  # PR-checks annotation (first non-empty context line as message)
-                  $msgLine = ($ctx | Where-Object { $_.Trim() } | Select-Object -First 1)
-                  if (-not $msgLine) { $msgLine = 'See workflow log / test-results artifact for details.' }
-                  $escTitle = $title -replace '%','%25' -replace "`r",'' -replace "`n",' '
-                  $escMsg = $msgLine.Trim() -replace '%','%25' -replace "`r",'' -replace "`n",' '
-                  Write-Host "::error title=$escTitle::$escMsg"
-              }
-              Write-Host "::endgroup::"
-          }
-
-          Write-Host ""
-          Write-Host "Total failing tests: $total"
 
       - name: Convert coverage to cobertura
         # Merges the per-lane .coverage binaries (unit + integration) written
@@ -423,12 +375,12 @@ jobs:
         if: inputs.type == 'pkg'
 
       - name: Upload test results
-        # On failure only: capture MTP per-project logs and TRX reports so the
-        # cause can be diagnosed from GHA artifacts. The workflow `Test.txt`
-        # log contains only summary lines like "Failed: N, Passed: M"; per-test
-        # detail lives in bin/.../TestResults/<Project>_<tfm>_<arch>.log.
-        # We intentionally skip this on success — the logs aren't needed and
-        # uploading them every run added 10+ MB per CI pipeline.
+        # On failure only: keep the full MTP per-project logs and TRX reports as
+        # GHA artifacts. The failing tests (assertion, source line, stack) are
+        # already printed inline on the test lane that ran them; these artifacts
+        # are the complete record for the cases that need more than the inline
+        # summary. We intentionally skip this on success — the logs aren't needed
+        # and uploading them every run added 10+ MB per CI pipeline.
         # Coverage XML is not uploaded (it's reproducible locally via
         # eng/testing/run-coverage.ps1 and was the bulk of the artifact size).
         if: failure()

--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -59,6 +59,7 @@ on:
 
 permissions:
   contents: read
+  actions: read # report-failed-tests.ps1 reads the jobs API to deep-link the summary
 
 jobs:
   build-test-analyze:
@@ -238,6 +239,8 @@ jobs:
         id: test_unit
         shell: bash
         working-directory: ${{ inputs.path }}
+        env:
+          GH_API_TOKEN: ${{ github.token }} # lets report-failed-tests.ps1 deep-link the job summary
         run: |
           set +e
           dotnet-coverage collect --nologo \
@@ -267,6 +270,7 @@ jobs:
           # next step prints it into the log. A file is used because MTP / dotnet-
           # coverage swallow the test host's process-exit stdout.
           FIXTURE_TIMING_FILE: ${{ github.workspace }}/fixture-timing.txt
+          GH_API_TOKEN: ${{ github.token }} # lets report-failed-tests.ps1 deep-link the job summary
         run: |
           set +e
           dotnet-coverage collect --nologo \

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -1,7 +1,6 @@
 #!/usr/bin/env pwsh
 # Surfaces failing tests from a test lane directly in that lane's own step log,
-# in a human-readable form, plus GitHub `::error::` annotations that point at the
-# failing source line.
+# in a human-readable form.
 #
 # The xUnit-v3 / Microsoft-Testing-Platform per-project log
 # (`<Project>_<tfm>_<arch>.log`, UTF-16) carries the test-level detail that the
@@ -173,16 +172,6 @@ foreach ($log in $logs) {
             Write-Host "::group::     Stack trace"
             foreach ($s in $stackLines) { Write-Host "       $s" }
             Write-Host '::endgroup::'
-        }
-
-        # PR-checks annotation, anchored at the failing source line when known.
-        $escTitle = $fqn -replace '%', '%25' -replace "`r", '' -replace "`n", ' '
-        $escMsg = $message -replace '%', '%25' -replace "`r", '' -replace "`n", ' '
-        if ($sourceFile) {
-            Write-Host ("::error file={0},line={1},title={2}::{3}" -f $sourceFile, $sourceLine, $escTitle, $escMsg)
-        }
-        else {
-            Write-Host ("::error title={0}::{1}" -f $escTitle, $escMsg)
         }
     }
 }

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -236,12 +236,19 @@ foreach ($log in $logs) {
             Write-Host '::endgroup::'
         }
 
-        # One list item in the job summary: `Class.Method`: reason (source link).
+        # One list item per failure, with the test name, reason and source each on
+        # its own line. A trailing two-space sequence is a Markdown hard break, so
+        # the indented continuation lines stay part of the same bullet.
         $reasonText = (($messageLines | ForEach-Object { Format-SummaryText $_ }) -join ' ')
         $src = Format-Source $sourceFile $sourceLine
-        $item = '- `{0}`: {1}' -f $short, $reasonText
-        if ($src) { $item = '{0} ({1})' -f $item, $src }
-        [void]$summary.AppendLine($item)
+        [void]$summary.AppendLine(('- `{0}`  ' -f $short))
+        if ($src) {
+            [void]$summary.AppendLine(('  {0}  ' -f $reasonText))
+            [void]$summary.AppendLine(('  {0}' -f $src))
+        }
+        else {
+            [void]$summary.AppendLine(('  {0}' -f $reasonText))
+        }
     }
 
     [void]$summary.AppendLine('')

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -1,0 +1,194 @@
+#!/usr/bin/env pwsh
+# Surfaces failing tests from a test lane directly in that lane's own step log,
+# in a human-readable form, plus GitHub `::error::` annotations that point at the
+# failing source line.
+#
+# The xUnit-v3 / Microsoft-Testing-Platform per-project log
+# (`<Project>_<tfm>_<arch>.log`, UTF-16) carries the test-level detail that the
+# step's console output drops (the console only shows per-DLL `failed: N`). Each
+# failure block in that log looks like:
+#
+#     failed <FullyQualifiedName>[(theory args)] (<duration>)
+#         <assertion / exception message, may span lines>
+#             at <stack frame>
+#             at <... in /path/File.cs:line>
+#
+# Called from the test lane after `dotnet test`; the lane keeps and propagates the
+# real test exit code, so this script is best-effort and always exits 0.
+[CmdletBinding()]
+param(
+    # The relative results directory the lane passed to `--results-directory`
+    # (e.g. "TestResults/unit"). MTP resolves that path per test project, so the
+    # per-project logs land in several places that all share the
+    # "/TestResults/unit/" path segment; we match on the segment rather than a
+    # single directory, which also keeps the two lanes apart.
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsDirectory
+)
+
+$ErrorActionPreference = 'Continue'
+
+# The box-drawing separator and the cross mark are UTF-8; make sure the host emits
+# UTF-8 regardless of the runner's default console encoding.
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch { }
+
+function Get-RepoRelativePath {
+    param([string]$Path)
+    $root = $env:GITHUB_WORKSPACE
+    if ([string]::IsNullOrWhiteSpace($root)) { return $Path }
+    $norm = $Path -replace '\\', '/'
+    $root = $root -replace '\\', '/'
+    if ($norm.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $norm.Substring($root.Length).TrimStart('/')
+    }
+    return $norm
+}
+
+$segment = '/' + (($ResultsDirectory -replace '\\', '/').Trim('/')) + '/'
+
+$logs = Get-ChildItem -Path . -Recurse -Filter '*_x64.log' -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Name -match '_net\d' -and
+            (($_.FullName -replace '\\', '/') -like "*$segment*")
+        }
+
+if (-not $logs) {
+    Write-Host "No '$ResultsDirectory' test logs found to scan for failing tests."
+    exit 0
+}
+
+$grandTotal = 0
+
+foreach ($log in $logs) {
+    # PS7 Get-Content auto-detects the UTF-16 BOM these logs carry.
+    $lines = Get-Content -LiteralPath $log.FullName
+    if (-not $lines) { continue }
+
+    # Collect each failure as the "failed ..." header line plus every line up to
+    # the next failed header or the run summary.
+    $blocks = @()
+    $current = $null
+    foreach ($raw in $lines) {
+        $line = $raw -replace "`r", ''
+        if ($line -match '^\s*failed\s+\S') {
+            if ($current) { $blocks += , $current }
+            $current = [System.Collections.Generic.List[string]]::new()
+            $current.Add($line)
+            continue
+        }
+        if (-not $current) { continue }
+        if ($line -match '^\s*(passed|skipped)\s+\S' -or
+            $line -match '^\s*Test run summary' -or
+            $line -match '^\s*In process file artifacts' -or
+            $line -match '^\s*total:\s') {
+            $blocks += , $current
+            $current = $null
+            continue
+        }
+        $current.Add($line)
+    }
+    if ($current) { $blocks += , $current }
+    if ($blocks.Count -eq 0) { continue }
+
+    $project = $log.BaseName -replace '_net\d.*$', ''
+
+    Write-Host ''
+    Write-Host ('─' * 78)
+    Write-Host ("  ❌  {0} failed test{1} in {2}" -f $blocks.Count, ($(if ($blocks.Count -eq 1) { '' } else { 's' })), $project)
+    Write-Host ('─' * 78)
+
+    $index = 0
+    foreach ($block in $blocks) {
+        $index++
+        $grandTotal++
+
+        # Header: "failed <FQN>[(args)] (<duration>)" — duration is the last (...).
+        $header = $block[0].Trim() -replace '^failed\s+', ''
+        $duration = ''
+        $m = [regex]::Match($header, '^(?<name>.+)\s+\((?<dur>[^)]*)\)\s*$')
+        if ($m.Success) {
+            $fqn = $m.Groups['name'].Value.Trim()
+            $duration = $m.Groups['dur'].Value.Trim()
+        }
+        else {
+            $fqn = $header
+        }
+
+        # Short, recognisable headline: Class.Method(args), full FQN kept for the
+        # annotation title.
+        $namePart = $fqn
+        $argPart = ''
+        $paren = $fqn.IndexOf('(')
+        if ($paren -ge 0) {
+            $namePart = $fqn.Substring(0, $paren)
+            $argPart = $fqn.Substring($paren)
+        }
+        $segments = $namePart.Split('.')
+        $short = if ($segments.Length -ge 2) { ($segments[-2..-1] -join '.') } else { $namePart }
+        $short = "$short$argPart"
+
+        # Message = block lines before the first stack frame ("at ...").
+        # Stack = from the first "at ..." onward.
+        $body = $block | Select-Object -Skip 1
+        $messageLines = [System.Collections.Generic.List[string]]::new()
+        $stackLines = [System.Collections.Generic.List[string]]::new()
+        $inStack = $false
+        foreach ($l in $body) {
+            if (-not $inStack -and $l -match '^\s*at\s') { $inStack = $true }
+            if ($inStack) {
+                if ($l.Trim()) { $stackLines.Add($l.Trim()) }
+            }
+            elseif ($l.Trim()) {
+                $messageLines.Add($l.Trim())
+            }
+        }
+        $message = ($messageLines -join ' ').Trim()
+        # Drop the MTP/xUnit exception-wrapper prefix so the real exception type and
+        # message lead.
+        $message = $message -replace '^Xunit\.Runner\.InProc\.SystemConsole\.TestingPlatform\.XunitException:\s*', ''
+        if (-not $message) { $message = '(no message — see stack trace / test-results artifact)' }
+
+        # Source location: first user stack frame carrying " in <file>:line".
+        $sourceFile = ''
+        $sourceLine = ''
+        foreach ($s in $stackLines) {
+            $sm = [regex]::Match($s, ' in (?<file>.+):(?:line )?(?<line>\d+)\s*$')
+            if ($sm.Success) {
+                $sourceFile = Get-RepoRelativePath $sm.Groups['file'].Value
+                $sourceLine = $sm.Groups['line'].Value
+                break
+            }
+        }
+
+        Write-Host ''
+        Write-Host ("  {0}) {1}" -f $index, $short)
+        Write-Host ("     Reason   {0}" -f $message)
+        if ($sourceFile) {
+            Write-Host ("     Source   {0}:{1}" -f $sourceFile, $sourceLine)
+        }
+        if ($duration) {
+            Write-Host ("     Time     {0}" -f $duration)
+        }
+        if ($stackLines.Count -gt 0) {
+            Write-Host "::group::     Stack trace"
+            foreach ($s in $stackLines) { Write-Host "       $s" }
+            Write-Host '::endgroup::'
+        }
+
+        # PR-checks annotation, anchored at the failing source line when known.
+        $escTitle = $fqn -replace '%', '%25' -replace "`r", '' -replace "`n", ' '
+        $escMsg = $message -replace '%', '%25' -replace "`r", '' -replace "`n", ' '
+        if ($sourceFile) {
+            Write-Host ("::error file={0},line={1},title={2}::{3}" -f $sourceFile, $sourceLine, $escTitle, $escMsg)
+        }
+        else {
+            Write-Host ("::error title={0}::{1}" -f $escTitle, $escMsg)
+        }
+    }
+}
+
+Write-Host ''
+if ($grandTotal -gt 0) {
+    Write-Host ("  Total: {0} failing test{1}." -f $grandTotal, ($(if ($grandTotal -eq 1) { '' } else { 's' })))
+}
+exit 0

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -48,20 +48,20 @@ function Get-RepoRelativePath {
     return $norm
 }
 
-function Format-TableText {
-    # Plain-text Markdown table cell: neutralise HTML angle brackets / ampersands so
-    # type names and <null> render literally, and escape the row delimiter.
+function Format-SummaryText {
+    # Neutralise HTML angle brackets / ampersands so type names like List<int> and
+    # <null> render literally in the Markdown summary.
     param([string]$Text)
-    $t = $Text -replace '&', '&amp;' -replace '<', '&lt;' -replace '>', '&gt;'
-    return ($t -replace '\|', '\|')
+    return ($Text -replace '&', '&amp;' -replace '<', '&lt;' -replace '>', '&gt;')
 }
 
 function Get-SourceMarkdown {
-    # A linked `path:line` for the job-summary table when the run context is known,
-    # otherwise the path as inline code.
+    # A linked "<file>:<line>" (filename only; the project line gives the rest) when
+    # the run context is known, otherwise the same text as inline code.
     param([string]$File, [string]$Line)
     if (-not $File) { return '' }
-    $text = '{0}:{1}' -f $File, $Line
+    $name = ($File -split '/')[-1]
+    $text = '{0}:{1}' -f $name, $Line
     if ($env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $env:GITHUB_SHA) {
         return '[{0}]({1}/{2}/blob/{3}/{4}#L{5})' -f $text, $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $env:GITHUB_SHA, $File, $Line
     }
@@ -127,10 +127,8 @@ foreach ($log in $logs) {
     Write-Host ('─' * 78)
 
     $anyFailures = $true
-    [void]$summary.AppendLine(('#### {0} — {1} failed' -f $project, $blocks.Count))
+    [void]$summary.AppendLine(('**{0}** ({1} failed)' -f $project, $blocks.Count))
     [void]$summary.AppendLine('')
-    [void]$summary.AppendLine('| Test | Reason | Source |')
-    [void]$summary.AppendLine('| --- | --- | --- |')
 
     $index = 0
     foreach ($block in $blocks) {
@@ -221,17 +219,19 @@ foreach ($log in $logs) {
             Write-Host '::endgroup::'
         }
 
-        # One row in the job-summary table.
-        $reasonCell = (($messageLines | ForEach-Object { Format-TableText $_ }) -join '<br>')
-        $testCell = '`' + ($short -replace '\|', '\|') + '`'
-        [void]$summary.AppendLine(('| {0} | {1} | {2} |' -f $testCell, $reasonCell, (Get-SourceMarkdown $sourceFile $sourceLine)))
+        # One list item in the job summary: `Class.Method`: reason (source link).
+        $reasonText = (($messageLines | ForEach-Object { Format-SummaryText $_ }) -join ' ')
+        $src = Get-SourceMarkdown $sourceFile $sourceLine
+        $item = '- `{0}`: {1}' -f $short, $reasonText
+        if ($src) { $item = '{0} ({1})' -f $item, $src }
+        [void]$summary.AppendLine($item)
     }
 
     [void]$summary.AppendLine('')
 }
 
 if ($anyFailures -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
-    $heading = "### ❌ Failed tests — {0} lane`n`n" -f $lane
+    $heading = "### ❌ Failed tests ({0} lane)`n`n" -f $lane
     Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value ($heading + $summary.ToString())
 }
 

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -248,6 +248,7 @@ if ($totalFailures -gt 0 -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP
     [void]$sb.AppendLine(('{0} failed: {1}.' -f $totalFailures, ($projectSummaries -join ', ')))
     [void]$sb.AppendLine('')
     $jobUrl = Get-JobUrl
+    Write-Host "[demo-verify] resolved summary link -> $jobUrl"
     if ($jobUrl) {
         [void]$sb.AppendLine(('[See the failing tests in this job''s log]({0})' -f $jobUrl))
     }

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -56,8 +56,6 @@ if (-not $logs) {
     exit 0
 }
 
-$grandTotal = 0
-
 foreach ($log in $logs) {
     # PS7 Get-Content auto-detects the UTF-16 BOM these logs carry.
     $lines = Get-Content -LiteralPath $log.FullName
@@ -99,7 +97,6 @@ foreach ($log in $logs) {
     $index = 0
     foreach ($block in $blocks) {
         $index++
-        $grandTotal++
 
         # Header: "failed <FQN>[(args)] (<duration>)" — duration is the last (...).
         $header = $block[0].Trim() -replace '^failed\s+', ''
@@ -176,8 +173,4 @@ foreach ($log in $logs) {
     }
 }
 
-Write-Host ''
-if ($grandTotal -gt 0) {
-    Write-Host ("  Total: {0} failing test{1}." -f $grandTotal, ($(if ($grandTotal -eq 1) { '' } else { 's' })))
-}
 exit 0

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -55,14 +55,31 @@ function Format-SummaryText {
     return ($Text -replace '&', '&amp;' -replace '<', '&lt;' -replace '>', '&gt;')
 }
 
+function Get-CommitSha {
+    # The sha to link blobs against. On a pull_request run GITHUB_SHA is the
+    # ephemeral merge commit, whose blob URLs 404 in the web UI; use the PR head
+    # sha from the event payload instead. Falls back to GITHUB_SHA (push to main).
+    if ($env:GITHUB_EVENT_PATH -and (Test-Path -LiteralPath $env:GITHUB_EVENT_PATH)) {
+        try {
+            $sha = (Get-Content -LiteralPath $env:GITHUB_EVENT_PATH -Raw | ConvertFrom-Json).pull_request.head.sha
+            if ($sha) { return $sha }
+        }
+        catch { }
+    }
+    return $env:GITHUB_SHA
+}
+
 function Format-Source {
-    # "<file>:<line>" as inline code (filename only; the project line gives the
-    # rest). Deliberately not hyperlinked: a pull_request run exposes only the
-    # ephemeral merge commit (GITHUB_SHA), whose blob URLs 404 in the web UI, and
-    # the full path is already in the step log.
+    # "<file>:<line>" (filename only; the project line gives the rest), linked to
+    # the exact line on the head commit when the run context is known, otherwise
+    # the same text as inline code.
     param([string]$File, [string]$Line)
     if (-not $File) { return '' }
-    return '`{0}:{1}`' -f (($File -split '/')[-1]), $Line
+    $text = '{0}:{1}' -f (($File -split '/')[-1]), $Line
+    if ($env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $script:CommitSha) {
+        return '[{0}]({1}/{2}/blob/{3}/{4}#L{5})' -f $text, $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $script:CommitSha, $File, $Line
+    }
+    return '`{0}`' -f $text
 }
 
 $segment = '/' + (($ResultsDirectory -replace '\\', '/').Trim('/')) + '/'
@@ -80,6 +97,9 @@ if (-not $logs) {
 
 # Lane name (e.g. "unit" / "integration") for the job-summary heading.
 $lane = (($ResultsDirectory -replace '\\', '/').TrimEnd('/') -split '/')[-1]
+
+# Commit the job-summary source links point at (resolved once).
+$script:CommitSha = Get-CommitSha
 
 # Markdown accumulated for the GitHub job summary, written once at the end.
 $summary = [System.Text.StringBuilder]::new()

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -1,6 +1,7 @@
 #!/usr/bin/env pwsh
-# Surfaces failing tests from a test lane directly in that lane's own step log,
-# in a human-readable form.
+# Surfaces failing tests from a test lane in two places: a human-readable block in
+# that lane's own step log, and a Markdown table appended to the GitHub job summary
+# ($GITHUB_STEP_SUMMARY) so the failures also show on the run's summary page.
 #
 # The xUnit-v3 / Microsoft-Testing-Platform per-project log
 # (`<Project>_<tfm>_<arch>.log`, UTF-16) carries the test-level detail that the
@@ -43,6 +44,26 @@ function Get-RepoRelativePath {
     return $norm
 }
 
+function Format-TableText {
+    # Plain-text Markdown table cell: neutralise HTML angle brackets / ampersands so
+    # type names and <null> render literally, and escape the row delimiter.
+    param([string]$Text)
+    $t = $Text -replace '&', '&amp;' -replace '<', '&lt;' -replace '>', '&gt;'
+    return ($t -replace '\|', '\|')
+}
+
+function Get-SourceMarkdown {
+    # A linked `path:line` for the job-summary table when the run context is known,
+    # otherwise the path as inline code.
+    param([string]$File, [string]$Line)
+    if (-not $File) { return '' }
+    $text = '{0}:{1}' -f $File, $Line
+    if ($env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $env:GITHUB_SHA) {
+        return '[{0}]({1}/{2}/blob/{3}/{4}#L{5})' -f $text, $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $env:GITHUB_SHA, $File, $Line
+    }
+    return '`{0}`' -f $text
+}
+
 $segment = '/' + (($ResultsDirectory -replace '\\', '/').Trim('/')) + '/'
 
 $logs = Get-ChildItem -Path . -Recurse -Filter '*_x64.log' -ErrorAction SilentlyContinue |
@@ -55,6 +76,13 @@ if (-not $logs) {
     Write-Host "No '$ResultsDirectory' test logs found to scan for failing tests."
     exit 0
 }
+
+# Lane name (e.g. "unit" / "integration") for the job-summary heading.
+$lane = (($ResultsDirectory -replace '\\', '/').TrimEnd('/') -split '/')[-1]
+
+# Markdown accumulated for the GitHub job summary, written once at the end.
+$summary = [System.Text.StringBuilder]::new()
+$anyFailures = $false
 
 foreach ($log in $logs) {
     # PS7 Get-Content auto-detects the UTF-16 BOM these logs carry.
@@ -93,6 +121,12 @@ foreach ($log in $logs) {
     Write-Host ('─' * 78)
     Write-Host ("  ❌  {0} failed test{1} in {2}" -f $blocks.Count, ($(if ($blocks.Count -eq 1) { '' } else { 's' })), $project)
     Write-Host ('─' * 78)
+
+    $anyFailures = $true
+    [void]$summary.AppendLine(('#### {0} — {1} failed' -f $project, $blocks.Count))
+    [void]$summary.AppendLine('')
+    [void]$summary.AppendLine('| Test | Reason | Source |')
+    [void]$summary.AppendLine('| --- | --- | --- |')
 
     $index = 0
     foreach ($block in $blocks) {
@@ -138,11 +172,12 @@ foreach ($log in $logs) {
                 $messageLines.Add($l.Trim())
             }
         }
-        $message = ($messageLines -join ' ').Trim()
-        # Drop the MTP/xUnit exception-wrapper prefix so the real exception type and
-        # message lead.
-        $message = $message -replace '^Xunit\.Runner\.InProc\.SystemConsole\.TestingPlatform\.XunitException:\s*', ''
-        if (-not $message) { $message = '(no message — see stack trace / test-results artifact)' }
+        if ($messageLines.Count -eq 0) {
+            $messageLines.Add('(no message — see the stack trace below)')
+        }
+        # Drop the MTP/xUnit exception-wrapper prefix from the first line so the real
+        # exception type and message lead.
+        $messageLines[0] = $messageLines[0] -replace '^Xunit\.Runner\.InProc\.SystemConsole\.TestingPlatform\.XunitException:\s*', ''
 
         # Source location: first user stack frame carrying " in <file>:line".
         $sourceFile = ''
@@ -158,7 +193,11 @@ foreach ($log in $logs) {
 
         Write-Host ''
         Write-Host ("  {0}) {1}" -f $index, $short)
-        Write-Host ("     Reason   {0}" -f $message)
+        # Reason may span several lines; align continuations under the first one.
+        Write-Host ("     Reason   {0}" -f $messageLines[0])
+        for ($i = 1; $i -lt $messageLines.Count; $i++) {
+            Write-Host ("              {0}" -f $messageLines[$i])
+        }
         if ($sourceFile) {
             Write-Host ("     Source   {0}:{1}" -f $sourceFile, $sourceLine)
         }
@@ -170,7 +209,19 @@ foreach ($log in $logs) {
             foreach ($s in $stackLines) { Write-Host "       $s" }
             Write-Host '::endgroup::'
         }
+
+        # One row in the job-summary table.
+        $reasonCell = (($messageLines | ForEach-Object { Format-TableText $_ }) -join '<br>')
+        $testCell = '`' + ($short -replace '\|', '\|') + '`'
+        [void]$summary.AppendLine(('| {0} | {1} | {2} |' -f $testCell, $reasonCell, (Get-SourceMarkdown $sourceFile $sourceLine)))
     }
+
+    [void]$summary.AppendLine('')
+}
+
+if ($anyFailures -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+    $heading = "### ❌ Failed tests — {0} lane`n`n" -f $lane
+    Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value ($heading + $summary.ToString())
 }
 
 exit 0

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 # Surfaces failing tests from a test lane in two places: a human-readable block in
-# that lane's own step log, and a Markdown table appended to the GitHub job summary
+# that lane's own step log, and a Markdown list appended to the GitHub job summary
 # ($GITHUB_STEP_SUMMARY) so the failures also show on the run's summary page.
 #
 # The xUnit-v3 / Microsoft-Testing-Platform per-project log
@@ -55,17 +55,14 @@ function Format-SummaryText {
     return ($Text -replace '&', '&amp;' -replace '<', '&lt;' -replace '>', '&gt;')
 }
 
-function Get-SourceMarkdown {
-    # A linked "<file>:<line>" (filename only; the project line gives the rest) when
-    # the run context is known, otherwise the same text as inline code.
+function Format-Source {
+    # "<file>:<line>" as inline code (filename only; the project line gives the
+    # rest). Deliberately not hyperlinked: a pull_request run exposes only the
+    # ephemeral merge commit (GITHUB_SHA), whose blob URLs 404 in the web UI, and
+    # the full path is already in the step log.
     param([string]$File, [string]$Line)
     if (-not $File) { return '' }
-    $name = ($File -split '/')[-1]
-    $text = '{0}:{1}' -f $name, $Line
-    if ($env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $env:GITHUB_SHA) {
-        return '[{0}]({1}/{2}/blob/{3}/{4}#L{5})' -f $text, $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $env:GITHUB_SHA, $File, $Line
-    }
-    return '`{0}`' -f $text
+    return '`{0}:{1}`' -f (($File -split '/')[-1]), $Line
 }
 
 $segment = '/' + (($ResultsDirectory -replace '\\', '/').Trim('/')) + '/'
@@ -221,7 +218,7 @@ foreach ($log in $logs) {
 
         # One list item in the job summary: `Class.Method`: reason (source link).
         $reasonText = (($messageLines | ForEach-Object { Format-SummaryText $_ }) -join ' ')
-        $src = Get-SourceMarkdown $sourceFile $sourceLine
+        $src = Format-Source $sourceFile $sourceLine
         $item = '- `{0}`: {1}' -f $short, $reasonText
         if ($src) { $item = '{0} ({1})' -f $item, $src }
         [void]$summary.AppendLine($item)

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -48,6 +48,43 @@ function Get-RepoRelativePath {
     return $norm
 }
 
+function Get-RunUrl {
+    if ($env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $env:GITHUB_RUN_ID) {
+        return '{0}/{1}/actions/runs/{2}' -f $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $env:GITHUB_RUN_ID
+    }
+    return $null
+}
+
+function Get-JobUrl {
+    # Deep link to THIS job's page (.../runs/<id>/job/<job_id>). The numeric job id
+    # is not in the environment, so resolve it from the jobs API and identify this
+    # job by the runner it is executing on. Falls back to the run URL if the token,
+    # permissions or a match are missing, so the link is never broken.
+    $runUrl = Get-RunUrl
+    if (-not ($env:GH_API_TOKEN -and $env:GITHUB_API_URL -and $env:GITHUB_REPOSITORY -and $env:GITHUB_RUN_ID -and $env:RUNNER_NAME)) {
+        return $runUrl
+    }
+    try {
+        $headers = @{
+            Authorization          = "Bearer $($env:GH_API_TOKEN)"
+            Accept                 = 'application/vnd.github+json'
+            'X-GitHub-Api-Version' = '2022-11-28'
+        }
+        $attempt = if ($env:GITHUB_RUN_ATTEMPT) { $env:GITHUB_RUN_ATTEMPT } else { '1' }
+        $uri = '{0}/repos/{1}/actions/runs/{2}/attempts/{3}/jobs?per_page=100' -f `
+            $env:GITHUB_API_URL, $env:GITHUB_REPOSITORY, $env:GITHUB_RUN_ID, $attempt
+        $jobs = (Invoke-RestMethod -Headers $headers -Uri $uri -Method Get).jobs
+        # One job per runner at a time, so the in-progress job on this runner is us.
+        $job = $jobs | Where-Object { $_.runner_name -eq $env:RUNNER_NAME -and $_.status -eq 'in_progress' } | Select-Object -First 1
+        if (-not $job) {
+            $job = $jobs | Where-Object { $_.runner_name -eq $env:RUNNER_NAME } | Select-Object -Last 1
+        }
+        if ($job -and $job.html_url) { return $job.html_url }
+    }
+    catch { }
+    return $runUrl
+}
+
 $segment = '/' + (($ResultsDirectory -replace '\\', '/').Trim('/')) + '/'
 
 $logs = Get-ChildItem -Path . -Recurse -Filter '*_x64.log' -ErrorAction SilentlyContinue |
@@ -210,9 +247,9 @@ if ($totalFailures -gt 0 -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP
     [void]$sb.AppendLine('')
     [void]$sb.AppendLine(('{0} failed: {1}.' -f $totalFailures, ($projectSummaries -join ', ')))
     [void]$sb.AppendLine('')
-    if ($env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $env:GITHUB_RUN_ID) {
-        $runUrl = '{0}/{1}/actions/runs/{2}' -f $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $env:GITHUB_RUN_ID
-        [void]$sb.AppendLine(('[See the failing tests in the run log]({0})' -f $runUrl))
+    $jobUrl = Get-JobUrl
+    if ($jobUrl) {
+        [void]$sb.AppendLine(('[See the failing tests in this job''s log]({0})' -f $jobUrl))
     }
     Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $sb.ToString()
 }

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -48,40 +48,6 @@ function Get-RepoRelativePath {
     return $norm
 }
 
-function Format-SummaryText {
-    # Neutralise HTML angle brackets / ampersands so type names like List<int> and
-    # <null> render literally in the Markdown summary.
-    param([string]$Text)
-    return ($Text -replace '&', '&amp;' -replace '<', '&lt;' -replace '>', '&gt;')
-}
-
-function Get-CommitSha {
-    # The sha to link blobs against. On a pull_request run GITHUB_SHA is the
-    # ephemeral merge commit, whose blob URLs 404 in the web UI; use the PR head
-    # sha from the event payload instead. Falls back to GITHUB_SHA (push to main).
-    if ($env:GITHUB_EVENT_PATH -and (Test-Path -LiteralPath $env:GITHUB_EVENT_PATH)) {
-        try {
-            $sha = (Get-Content -LiteralPath $env:GITHUB_EVENT_PATH -Raw | ConvertFrom-Json).pull_request.head.sha
-            if ($sha) { return $sha }
-        }
-        catch { }
-    }
-    return $env:GITHUB_SHA
-}
-
-function Format-Source {
-    # "<file>:<line>" (filename only; the project line gives the rest), linked to
-    # the exact line on the head commit when the run context is known, otherwise
-    # the same text as inline code.
-    param([string]$File, [string]$Line)
-    if (-not $File) { return '' }
-    $text = '{0}:{1}' -f (($File -split '/')[-1]), $Line
-    if ($env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $script:CommitSha) {
-        return '[{0}]({1}/{2}/blob/{3}/{4}#L{5})' -f $text, $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $script:CommitSha, $File, $Line
-    }
-    return '`{0}`' -f $text
-}
-
 $segment = '/' + (($ResultsDirectory -replace '\\', '/').Trim('/')) + '/'
 
 $logs = Get-ChildItem -Path . -Recurse -Filter '*_x64.log' -ErrorAction SilentlyContinue |
@@ -98,12 +64,10 @@ if (-not $logs) {
 # Lane name (e.g. "unit" / "integration") for the job-summary heading.
 $lane = (($ResultsDirectory -replace '\\', '/').TrimEnd('/') -split '/')[-1]
 
-# Commit the job-summary source links point at (resolved once).
-$script:CommitSha = Get-CommitSha
-
-# Markdown accumulated for the GitHub job summary, written once at the end.
-$summary = [System.Text.StringBuilder]::new()
-$anyFailures = $false
+# The job summary stays terse: a per-project count and a link to this run, where
+# the test step already shows the full detail. No point repeating it.
+$projectSummaries = [System.Collections.Generic.List[string]]::new()
+$totalFailures = 0
 
 foreach ($log in $logs) {
     # PS7 Get-Content auto-detects the UTF-16 BOM these logs carry.
@@ -143,9 +107,8 @@ foreach ($log in $logs) {
     Write-Host ("  ❌  {0} failed test{1} in {2}" -f $blocks.Count, ($(if ($blocks.Count -eq 1) { '' } else { 's' })), $project)
     Write-Host ('─' * 78)
 
-    $anyFailures = $true
-    [void]$summary.AppendLine(('**{0}** ({1} failed)' -f $project, $blocks.Count))
-    [void]$summary.AppendLine('')
+    $totalFailures += $blocks.Count
+    $projectSummaries.Add(('**{0}** ({1})' -f $project, $blocks.Count))
 
     $index = 0
     foreach ($block in $blocks) {
@@ -235,28 +198,23 @@ foreach ($log in $logs) {
             foreach ($s in $stackLines) { Write-Host "       $s" }
             Write-Host '::endgroup::'
         }
-
-        # One list item per failure, with the test name, reason and source each on
-        # its own line. A trailing two-space sequence is a Markdown hard break, so
-        # the indented continuation lines stay part of the same bullet.
-        $reasonText = (($messageLines | ForEach-Object { Format-SummaryText $_ }) -join ' ')
-        $src = Format-Source $sourceFile $sourceLine
-        [void]$summary.AppendLine(('- `{0}`  ' -f $short))
-        if ($src) {
-            [void]$summary.AppendLine(('  {0}  ' -f $reasonText))
-            [void]$summary.AppendLine(('  {0}' -f $src))
-        }
-        else {
-            [void]$summary.AppendLine(('  {0}' -f $reasonText))
-        }
     }
-
-    [void]$summary.AppendLine('')
 }
 
-if ($anyFailures -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
-    $heading = "### ❌ Failed tests ({0} lane)`n`n" -f $lane
-    Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value ($heading + $summary.ToString())
+# Job summary: a terse count per project plus a link to this run, where the test
+# step above shows the full detail. Deliberately does not repeat the per-test
+# names/messages/sources.
+if ($totalFailures -gt 0 -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine(('### ❌ Failed tests ({0} lane)' -f $lane))
+    [void]$sb.AppendLine('')
+    [void]$sb.AppendLine(('{0} failed: {1}.' -f $totalFailures, ($projectSummaries -join ', ')))
+    [void]$sb.AppendLine('')
+    if ($env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $env:GITHUB_RUN_ID) {
+        $runUrl = '{0}/{1}/actions/runs/{2}' -f $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $env:GITHUB_RUN_ID
+        [void]$sb.AppendLine(('[See the failing tests in the run log]({0})' -f $runUrl))
+    }
+    Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $sb.ToString()
 }
 
 exit 0

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -34,13 +34,17 @@ try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch { }
 
 function Get-RepoRelativePath {
     param([string]$Path)
-    $root = $env:GITHUB_WORKSPACE
-    if ([string]::IsNullOrWhiteSpace($root)) { return $Path }
     $norm = $Path -replace '\\', '/'
-    $root = $root -replace '\\', '/'
-    if ($norm.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) {
-        return $norm.Substring($root.Length).TrimStart('/')
+    $root = $env:GITHUB_WORKSPACE
+    if (-not [string]::IsNullOrWhiteSpace($root)) {
+        $root = $root -replace '\\', '/'
+        if ($norm.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $norm.Substring($root.Length).TrimStart('/')
+        }
     }
+    # Deterministic builds (ContinuousIntegrationBuild) map the repo root to "/_/",
+    # so lib verticals report frames as /_/src/...; normalise that too.
+    if ($norm -match '^/_/(.+)$') { return $Matches[1] }
     return $norm
 }
 
@@ -158,18 +162,25 @@ foreach ($log in $logs) {
         $short = "$short$argPart"
 
         # Message = block lines before the first stack frame ("at ...").
-        # Stack = from the first "at ..." onward.
+        # Stack = the "at ..." frames from there on.
         $body = $block | Select-Object -Skip 1
         $messageLines = [System.Collections.Generic.List[string]]::new()
         $stackLines = [System.Collections.Generic.List[string]]::new()
         $inStack = $false
         foreach ($l in $body) {
+            $t = $l.Trim()
+            if (-not $t) { continue }
+            # Under parallel execution MTP interleaves per-test progress lines like
+            # "[+10/x2/?0] Asm.dll - Other.Test (3s)"; they are not part of this
+            # failure, so drop them wherever they land.
+            if ($t -match '^\[[+\-x?\d/]+\]') { continue }
             if (-not $inStack -and $l -match '^\s*at\s') { $inStack = $true }
             if ($inStack) {
-                if ($l.Trim()) { $stackLines.Add($l.Trim()) }
+                # Only genuine "at ..." frames belong in the stack.
+                if ($l -match '^\s*at\s') { $stackLines.Add($t) }
             }
-            elseif ($l.Trim()) {
-                $messageLines.Add($l.Trim())
+            else {
+                $messageLines.Add($t)
             }
         }
         if ($messageLines.Count -eq 0) {

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Lease.Tests/CiDemoLeaseFailures.cs
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Lease.Tests/CiDemoLeaseFailures.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Authorization.Host.Lease.Tests;
+[UnitTest]
+public class CiDemoLeaseFailures
+{
+    [Fact]
+    public void Lease_ThrowsUnexpectedly() => throw new InvalidOperationException("lease renewal failed unexpectedly");
+}

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/CiDemoPipelineFailures.cs
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/CiDemoPipelineFailures.cs
@@ -1,0 +1,11 @@
+namespace Altinn.Authorization.Host.Pipeline.Tests;
+[UnitTest]
+public class CiDemoPipelineFailures
+{
+    [Fact]
+    public void Pipeline_StringsDiffer_MultiLineMessage() => Assert.Equal("pipeline: ready", "pipeline: reedy");
+
+    [Theory]
+    [InlineData(3)]
+    public void Pipeline_TheoryFails(int n) => Assert.True(n > 100, $"expected {n} to exceed 100");
+}

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/CiDemoAbacFailures.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/CiDemoAbacFailures.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Authorization.ABAC.Tests;
+[UnitTest]
+public class CiDemoAbacFailures
+{
+    [Fact]
+    public void Abac_DecisionMismatch() => "NotApplicable".Should().Be("Deny", "the first-applicable rule should deny");
+}

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/CiDemoPepFailures.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/CiDemoPepFailures.cs
@@ -1,0 +1,7 @@
+namespace Altinn.Authorization.PEP.Tests;
+[UnitTest]
+public class CiDemoPepFailures
+{
+    [Fact]
+    public void Pep_CollectionDiffers_MultiLine() => Assert.Equal(new[] { 1, 2, 3 }, new[] { 1, 9, 3 });
+}


### PR DESCRIPTION
Temporary, do not merge. Intentionally failing ABAC tests on top of #3566 so the new inline failed-test reporting can be seen in a real CI run. Will be closed and the branch deleted once the output has been captured.