### PR TITLE
Phase 3: migrate test assertions from FluentAssertions to AwesomeAssertions

### DIFF
--- a/docs/testing/AWESOME_ASSERTIONS_GUIDELINES.md
+++ b/docs/testing/AWESOME_ASSERTIONS_GUIDELINES.md
@@ -1,25 +1,29 @@
-﻿# FluentAssertions Usage Guidelines
+﻿# AwesomeAssertions Usage Guidelines
 
 **Status:** Adopted.
 **Scope:** All test projects in this repository.
-**Package:** `FluentAssertions` 7.0.0, globally imported via `Directory.Build.targets`.
+**Package:** `AwesomeAssertions` 9.4.0, globally imported via `Directory.Build.targets`.
 
 ---
 
 ## TL;DR
 
-- **New tests:** Use FluentAssertions (`.Should()`).
-- **Modified tests:** Convert the assertions you touch to FluentAssertions.
+- **New tests:** Use AwesomeAssertions (`.Should()`).
+- **Modified tests:** Convert the assertions you touch to AwesomeAssertions.
 - **Untouched existing tests:** Leave as-is. No bulk rewrites.
 - **Custom `AssertionUtil` helpers:** Prefer `Should().BeEquivalentTo(...)` for
   new code. Do not add new helpers to the two existing `AssertionUtil` classes.
 
-`Xunit` and `FluentAssertions` are both in `<Using>` — no `using` directive
+`Xunit` and `AwesomeAssertions` are both in `<Using>` — no `using` directive
 needed.
 
 ---
 
-## Why FluentAssertions
+## Why AwesomeAssertions
+
+AwesomeAssertions is the free, API-compatible fork of FluentAssertions
+(FluentAssertions 8.x is commercially licensed). The `.Should()` API is the
+same, so existing assertions are unchanged.
 
 More readable assertions, better failure messages, rich built-in
 support for collections / equivalence / exceptions / dates, and it lets us
@@ -27,7 +31,7 @@ retire ~1,300 lines of bespoke `AssertionUtil` code over time.
 
 ---
 
-## Patterns — xUnit → FluentAssertions
+## Patterns — xUnit → AwesomeAssertions
 
 ### Equality and nullness
 
@@ -37,7 +41,7 @@ Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 Assert.NotNull(result);
 Assert.Null(error);
 
-// FluentAssertions
+// AwesomeAssertions
 response.StatusCode.Should().Be(HttpStatusCode.OK);
 result.Should().NotBeNull();
 error.Should().BeNull();
@@ -60,7 +64,7 @@ context.HasFailed.Should().BeFalse();
 Assert.Contains("denied", message);
 Assert.StartsWith("Bearer ", header);
 
-// FluentAssertions
+// AwesomeAssertions
 message.Should().Contain("denied");
 header.Should().StartWith("Bearer ");
 
@@ -76,7 +80,7 @@ message.Should().NotBeNullOrEmpty()
 // xUnit
 Assert.True(count >= 1 && count <= 10);
 
-// FluentAssertions
+// AwesomeAssertions
 count.Should().BeInRange(1, 10);
 ```
 
@@ -98,7 +102,7 @@ Assert.Equal(3, results.Count);
 Assert.Contains(expectedItem, results);
 Assert.Empty(errors);
 
-// FluentAssertions
+// AwesomeAssertions
 results.Should().HaveCount(3).And.Contain(expectedItem);
 errors.Should().BeEmpty();
 
@@ -137,12 +141,12 @@ walking properties by hand or adding another overload to `AssertionUtil`.
 var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DoAsync());
 Assert.Contains("not allowed", ex.Message);
 
-// FluentAssertions — synchronous
+// AwesomeAssertions — synchronous
 Action act = () => svc.Do();
 act.Should().Throw<InvalidOperationException>()
     .WithMessage("*not allowed*");
 
-// FluentAssertions — async
+// AwesomeAssertions — async
 Func<Task> act = () => svc.DoAsync();
 await act.Should().ThrowAsync<InvalidOperationException>()
     .WithMessage("*not allowed*");
@@ -164,7 +168,7 @@ response.Headers.Location.Should().NotBeNull();
 
 ## When to keep using xUnit assertions
 
-FluentAssertions is preferred, but these cases are fine with plain xUnit:
+AwesomeAssertions is preferred, but these cases are fine with plain xUnit:
 
 - **`Assert.Fail("reason")`** inside a `catch` or unreachable branch — it
   short-circuits flow analysis cleanly.
@@ -172,7 +176,7 @@ FluentAssertions is preferred, but these cases are fine with plain xUnit:
   assertion (e.g. `Assert.Equal(input.Length, parsed.Length)` as the single
   line of a tiny parametrised test). Either style is acceptable; don't churn
   existing code for this.
-- **xUnit's `Assert.Raises` / `Assert.PropertyChanged`** — no FluentAssertions
+- **xUnit's `Assert.Raises` / `Assert.PropertyChanged`** — no AwesomeAssertions
   equivalent is currently used in this repo, keep the xUnit API.
 
 Never mix `Assert.Xxx(...)` and `.Should()` assertions on the **same value**
@@ -198,7 +202,7 @@ Guidelines:
 
 ## Failure message quality
 
-FluentAssertions failure messages include the expression text, expected
+AwesomeAssertions failure messages include the expression text, expected
 value, actual value, and any `because` reason you provide. Favor precise
 reasons over generic ones:
 
@@ -218,5 +222,5 @@ omit it.
 
 ## References
 
-- [FluentAssertions docs](https://fluentassertions.com/)
+- [AwesomeAssertions on NuGet](https://www.nuget.org/packages/AwesomeAssertions/)
 - [TEST_NAMING_CONVENTION.md](TEST_NAMING_CONVENTION.md)

--- a/docs/testing/MOCKS_AND_TESTUTILS.md
+++ b/docs/testing/MOCKS_AND_TESTUTILS.md
@@ -65,11 +65,13 @@ lift them into a shared `TestUtils/TestCertificates/` folder rather than copying
 5. Extract common seeding behaviour into a static helper so other projects can
    reuse it.
 
-## FluentAssertions is globally imported
+## Assertion library is globally imported
 
-`FluentAssertions` 7.0.0 is added via `Directory.Build.targets` for every test
+`AwesomeAssertions` (the free, API-compatible fork of FluentAssertions — FA 8.x is
+commercially licensed) is added via `Directory.Build.targets` for every test
 project and test library. It's in `<Using>` so you **don't** need a `using
-FluentAssertions;` directive — just call `.Should()` directly. See
+AwesomeAssertions;` directive — just call `.Should()` directly. The fluent API is
+identical to FluentAssertions; only the root namespace differs. See
 [FLUENT_ASSERTIONS_GUIDELINES.md](FLUENT_ASSERTIONS_GUIDELINES.md).
 
 ## Next: [WRITING_TESTS.md](WRITING_TESTS.md)

--- a/docs/testing/MOCKS_AND_TESTUTILS.md
+++ b/docs/testing/MOCKS_AND_TESTUTILS.md
@@ -67,11 +67,9 @@ lift them into a shared `TestUtils/TestCertificates/` folder rather than copying
 
 ## Assertion library is globally imported
 
-`AwesomeAssertions` (the free, API-compatible fork of FluentAssertions — FA 8.x is
-commercially licensed) is added via `Directory.Build.targets` for every test
+`AwesomeAssertions` is added via `Directory.Build.targets` for every test
 project and test library. It's in `<Using>` so you **don't** need a `using
-AwesomeAssertions;` directive — just call `.Should()` directly. The fluent API is
-identical to FluentAssertions; only the root namespace differs. See
+AwesomeAssertions;` directive — just call `.Should()` directly. See
 [FLUENT_ASSERTIONS_GUIDELINES.md](FLUENT_ASSERTIONS_GUIDELINES.md).
 
 ## Next: [WRITING_TESTS.md](WRITING_TESTS.md)

--- a/docs/testing/MOCKS_AND_TESTUTILS.md
+++ b/docs/testing/MOCKS_AND_TESTUTILS.md
@@ -70,6 +70,6 @@ lift them into a shared `TestUtils/TestCertificates/` folder rather than copying
 `AwesomeAssertions` is added via `Directory.Build.targets` for every test
 project and test library. It's in `<Using>` so you **don't** need a `using
 AwesomeAssertions;` directive — just call `.Should()` directly. See
-[FLUENT_ASSERTIONS_GUIDELINES.md](FLUENT_ASSERTIONS_GUIDELINES.md).
+[AWESOME_ASSERTIONS_GUIDELINES.md](AWESOME_ASSERTIONS_GUIDELINES.md).
 
 ## Next: [WRITING_TESTS.md](WRITING_TESTS.md)

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -18,7 +18,7 @@ self-contained; none of them is a wall of text.
 | 4 | [MOCKS_AND_TESTUTILS.md](MOCKS_AND_TESTUTILS.md) | The shared `TestUtils` library, canonical mocks, test certificates |
 | 5 | [WRITING_TESTS.md](WRITING_TESTS.md) | Patterns, xUnit v3 specifics, when to unit-test vs integration-test |
 | 6 | [TEST_NAMING_CONVENTION.md](TEST_NAMING_CONVENTION.md) | `MethodUnderTest_Scenario_ExpectedResult` |
-| 7 | [FLUENT_ASSERTIONS_GUIDELINES.md](FLUENT_ASSERTIONS_GUIDELINES.md) | When and how to use FluentAssertions |
+| 7 | [AWESOME_ASSERTIONS_GUIDELINES.md](AWESOME_ASSERTIONS_GUIDELINES.md) | When and how to use AwesomeAssertions |
 | 8 | [COVERAGE.md](COVERAGE.md) | Running coverage locally, per-assembly targets (reported, not gated) |
 | 9 | [CI.md](CI.md) | How tests run in the pipeline, Microsoft Testing Platform (MTP), artifacts |
 | 10 | [BRUNO_API_TESTS.md](BRUNO_API_TESTS.md) | The Bruno API collections — manual/exploratory API tests that double as a behavioral spec for the C# integration tests |
@@ -31,7 +31,7 @@ self-contained; none of them is a wall of text.
   `[IntegrationTest]` (a `Category` trait) and lives under a `Unit/` or
   `Integration/` folder with a matching namespace segment. CI runs them as
   two lanes; filter locally with `dotnet test -- --filter-trait "Category=Unit"`.
-- **Assertion library:** [AwesomeAssertions](FLUENT_ASSERTIONS_GUIDELINES.md)
+- **Assertion library:** [AwesomeAssertions](AWESOME_ASSERTIONS_GUIDELINES.md)
   (globally imported — no `using` needed).
 - **Integration tests** use a real PostgreSQL via Testcontainers. You need a
   **working Docker or Podman** on your machine. See

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -31,7 +31,7 @@ self-contained; none of them is a wall of text.
   `[IntegrationTest]` (a `Category` trait) and lives under a `Unit/` or
   `Integration/` folder with a matching namespace segment. CI runs them as
   two lanes; filter locally with `dotnet test -- --filter-trait "Category=Unit"`.
-- **Assertion library:** [AwesomeAssertions](FLUENT_ASSERTIONS_GUIDELINES.md) (free, API-compatible fork of FluentAssertions)
+- **Assertion library:** [AwesomeAssertions](FLUENT_ASSERTIONS_GUIDELINES.md)
   (globally imported — no `using` needed).
 - **Integration tests** use a real PostgreSQL via Testcontainers. You need a
   **working Docker or Podman** on your machine. See

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -31,7 +31,7 @@ self-contained; none of them is a wall of text.
   `[IntegrationTest]` (a `Category` trait) and lives under a `Unit/` or
   `Integration/` folder with a matching namespace segment. CI runs them as
   two lanes; filter locally with `dotnet test -- --filter-trait "Category=Unit"`.
-- **Assertion library:** [FluentAssertions](FLUENT_ASSERTIONS_GUIDELINES.md)
+- **Assertion library:** [AwesomeAssertions](FLUENT_ASSERTIONS_GUIDELINES.md) (free, API-compatible fork of FluentAssertions)
   (globally imported — no `using` needed).
 - **Integration tests** use a real PostgreSQL via Testcontainers. You need a
   **working Docker or Podman** on your machine. See

--- a/docs/testing/TEST_PROJECTS.md
+++ b/docs/testing/TEST_PROJECTS.md
@@ -80,7 +80,7 @@ helpers (mocks, fixtures, seed data) stay at the project-root namespace.
 
 It sets `<IsTestProject>true</IsTestProject>` (or `<IsTestLibrary>true</IsTestLibrary>`
 for `TestUtils`) and the xUnit version. The shared `Directory.Build.targets`
-at the root adds `xunit.v3`, `coverlet.collector`, and `FluentAssertions`
+at the root adds `xunit.v3`, `coverlet.collector`, and `AwesomeAssertions`
 automatically based on those flags — individual `.csproj` files stay tiny.
 
 ### `InternalsVisibleTo` is automatic

--- a/docs/testing/WRITING_TESTS.md
+++ b/docs/testing/WRITING_TESTS.md
@@ -2,7 +2,7 @@
 
 Short, opinionated guide. For naming, see
 [TEST_NAMING_CONVENTION.md](TEST_NAMING_CONVENTION.md). For assertions, see
-[FLUENT_ASSERTIONS_GUIDELINES.md](FLUENT_ASSERTIONS_GUIDELINES.md).
+[AWESOME_ASSERTIONS_GUIDELINES.md](AWESOME_ASSERTIONS_GUIDELINES.md).
 
 ## Pick the right test type
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -76,16 +76,19 @@
                 <PackageReference Include="xunit.v3.extensibility.core" Condition=" '$(XUnitVersion)' == 'v3' " />
             </ItemGroup>
 
-            <!-- FluentAssertions is available in both runnable test projects and
-                 shared test-helper libraries so the global using below resolves
-                 in either context. -->
+            <!-- AwesomeAssertions is the free, API-compatible fork of FluentAssertions
+                 (FluentAssertions 8.x is commercially licensed; 7.2.2 was the last free
+                 release). The assertion API (.Should()...) is unchanged; only the root
+                 namespace differs (AwesomeAssertions, not FluentAssertions), which is why
+                 the global using below is AwesomeAssertions. Available in both runnable
+                 test projects and shared test-helper libraries. -->
             <ItemGroup>
-                <PackageReference Include="FluentAssertions" />
+                <PackageReference Include="AwesomeAssertions" />
             </ItemGroup>
 
             <ItemGroup>
                 <Using Include="Xunit" />
-                <Using Include="FluentAssertions" />
+                <Using Include="AwesomeAssertions" />
             </ItemGroup>
 
         </When>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
-    <PackageVersion Include="FluentAssertions" Version="7.2.2" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="IdentityModel" Version="7.0.0" />
     <PackageVersion Include="JWTCookieAuthentication" Version="4.0.4" />
     <PackageVersion Include="MassTransit" Version="8.5.9" />

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Helpers/Extensions/ConsentStatusChangeExtensionsTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Helpers/Extensions/ConsentStatusChangeExtensionsTests.cs
@@ -22,8 +22,8 @@ namespace Altinn.AccessManagement.Tests.Unit.Helpers.Extensions;
 // Conventions used here:
 //  - Test naming follows `MethodUnderTest_Scenario_ExpectedResult`
 //    (docs/testing/TEST_NAMING_CONVENTION.md).
-//  - Assertions use FluentAssertions (`.Should()`); both Xunit and
-//    FluentAssertions are global usings via Directory.Build.targets, so no
+//  - Assertions use AwesomeAssertions (`.Should()`); both Xunit and
+//    AwesomeAssertions are global usings via Directory.Build.targets, so no
 //    `using` directives are needed for them.
 // ---------------------------------------------------------------------------
 [UnitTest]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Services/ConsentServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Services/ConsentServiceTests.cs
@@ -371,7 +371,7 @@ public class ConsentServiceTests
     // sets up the behaviour it actually exercises.
     //
     // Test naming follows MethodUnderTest_Scenario_ExpectedResult; assertions
-    // use FluentAssertions (`.Should()`).
+    // use AwesomeAssertions (`.Should()`).
     // =======================================================================
     [Fact]
     public async Task GetConsentStatusChangesForParty_RepositoryReturnsList_ReturnsValueUnchanged()

--- a/src/pkgs/Altinn.Authorization.ABAC/Directory.Packages.props
+++ b/src/pkgs/Altinn.Authorization.ABAC/Directory.Packages.props
@@ -5,7 +5,7 @@
     <ItemGroup>
         <PackageVersion Include="coverlet.collector" Version="6.0.4" />
         <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
-        <PackageVersion Include="FluentAssertions" Version="7.2.2" />
+        <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
         <PackageVersion Include="Microsoft.Build.Artifacts" Version="6.1.63" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />

--- a/src/pkgs/Directory.Packages.props
+++ b/src/pkgs/Directory.Packages.props
@@ -5,7 +5,7 @@
     <ItemGroup>
         <PackageVersion Include="coverlet.collector" Version="6.0.4" />
         <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
-        <PackageVersion Include="FluentAssertions" Version="7.2.2" />
+        <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
         <PackageVersion Include="Microsoft.Build.Artifacts" Version="6.1.63" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageVersion Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
Closes #3584. Part of #3486 (Phase 3).

FluentAssertions is pinned at 7.2.2 because 8.x is commercially licensed. AwesomeAssertions is the free, API-compatible fork: the `.Should()` fluent API is identical, only the root namespace differs. Every test resolves it through the global using in `Directory.Build.targets`, so this is a config-only swap with no test source changes.

Changes: the central package in the three `Directory.Packages.props`, the package reference and global using in `Directory.Build.targets`, and the docs and code comments that named the package.

Verified on this branch: the full solution builds with 0 errors; ABAC.Tests 39/39 and the AccessMgmt unit lane 427/427 pass (the latter exercises the AssertionUtil deep-equality helpers). No assertion-semantic changes.