### PR TITLE
Phase 3: fix tests that pass for the wrong reason, plus a duplicate validation error code

### DIFF
--- a/docs/testing/TEST_SETUP_TIMING.md
+++ b/docs/testing/TEST_SETUP_TIMING.md
@@ -180,30 +180,11 @@ seed race) for no measured gain.
 **Decision: keep `maxParallelThreads: 4`.** The effective lever for these suites
 is fewer host builds (fixture sharing, above), not more threads. Going faster
 would require removing the single-container bottleneck (e.g. a container per
-worker) — out of scope and unlikely to pay off.
-
-### Re-check on a provision-bound assembly (`ServiceOwner.Api.Tests`)
-
-The sweep above ran on `AccessMgmt.Tests`. `ServiceOwner.Api.Tests` has a
-different shape — 9 fixtures with heavy cold host builds (`host_build` ~100 s
-summed, exceeding `db_provision`), so it is plausibly more CPU-bound and a
-candidate to benefit from more threads. Re-measured at `maxParallelThreads: 8`
-(local Podman), all runs green (41/41):
-
-| Run | `maxParallelThreads: 4` | `maxParallelThreads: 8` |
-|---|---:|---:|
-| 1 | 52.1 s | 44.6 s |
-| 2 | — | 47.6 s |
-| 3 | — | 59.0 s |
-
-The first 8-thread run looked ~14% faster, but repeats spread to **44–59 s**
-(summed `host_build` swinging 133 s → 254 s from CPU oversubscription), with the
-worst run slower than the 4-thread baseline. The apparent gain was run-to-run
-variance, not a real speedup, and the contention metrics rose sharply
-(`provision_wait` ~54 s → ~127 s, `clone` ~3 s → ~8 s). So the single-container
-limiter holds here too. **No change: keep `maxParallelThreads: 4`.** No new
-flakiness surfaced across the repeats (the constructor-seed fixes removed the
-re-seed collisions that previously raised the concurrency risk).
+worker) — out of scope and unlikely to pay off. This holds regardless of an
+assembly's shape: on host-build-heavy suites (e.g. `ServiceOwner.Api.Tests`,
+where summed `host_build` exceeds `db_provision`) more threads oversubscribe the
+CPU and add lock contention rather than speed, so `maxParallelThreads` stays 4
+everywhere.
 
 ## Test waits (`Task.Delay` audit)
 

--- a/docs/testing/TEST_SETUP_TIMING.md
+++ b/docs/testing/TEST_SETUP_TIMING.md
@@ -1,223 +1,72 @@
-# Integration-test setup timing (measurement)
+# Integration-test setup time
 
-Measurement step for [#3379](https://github.com/Altinn/altinn-authorization-tmp/issues/3379):
-size where integration-test wall-clock goes **before** investing in a
-fixture-sharing refactor. Instrumented by `FixtureTiming` (linked alongside
-`PostgresTestEngine`); see [#3446](https://github.com/Altinn/altinn-authorization-tmp/issues/3446).
+How integration-test setup time is kept down. Measurement detail lives in
+[#3379](https://github.com/Altinn/altinn-authorization-tmp/issues/3379).
 
-## Result
+## Where the time goes
 
-`AccessMgmt.Tests`, `Category=Integration` — **972 tests, ~2m05s**, run locally
-against Podman (`maxParallelThreads = 4`):
+Two things dominate integration-test setup:
 
-| Phase | Total | Count | Avg | Notes |
-|---|---:|---:|---:|---|
-| App-host build (`WebApplicationFactory`) | **92.2 s** | 68 | **1,356 ms** | one per `IClassFixture` |
-| DB provision (`InitializeAsync` → factory) | 56.2 s | 68 | 826 ms | includes template + clone |
-| DB clone (`CREATE DATABASE … WITH TEMPLATE`) | **18.4 s** | 80 | **230 ms** | per provisioned database |
-| Template build (migrate + seed) | 9.3 s | 1 | — | one-time per process |
+- **Per-class `WebApplicationFactory` host builds.** Each `IClassFixture` builds
+  its own host (DI graph + EF model) — the single largest cost in
+  `AccessMgmt.Tests`.
+- **Per-fixture database provisioning.** In the other AccessManagement test
+  assemblies (`Enduser.Api.Tests`, `ServiceOwner.Api.Tests`,
+  `AccessMgmt.Core.Tests`) this dominates instead — mostly time spent blocked on
+  the engine's one-time template build at startup, not per-fixture work. The
+  template (migrate + seed) is built once per process; each test database is a
+  fast clone of it.
 
-## Conclusion
+So the levers are **fewer host builds** (fixture sharing) and **not serialising
+every fixture behind the one-time template build**.
 
-- **Host build dominates setup — ~5× the total clone cost (92 s vs 18 s).**
-  The DB layer is already cheap: a clone is ~230 ms, and the migrated/seeded
-  template is built once (~9 s). This confirms the #3379 hypothesis — the
-  bottleneck is the **68 unshared `WebApplicationFactory` host builds**, not the
-  database.
-- The first host build is much slower (~13 s cold, JIT + EF model warm-up); the
-  amortized average across 68 fixtures is ~1.36 s.
-- This run covers `AccessMgmt.Tests` only (68 host-building fixtures). The other
-  AccessManagement test projects add more `ApiFixture` instances — the
-  repo-wide figure cited in #3379 is 111 `IClassFixture` / 85 `ApiFixture`,
-  every one a separate cold host build.
+## Fixture sharing
 
-## Cross-assembly (CI) — the DB-provision blind spot
+A cohort of read-only test classes can share one host via `ICollectionFixture`
+instead of one `IClassFixture` each, collapsing N cold host builds into one.
 
-The measurement above covers `AccessMgmt.Tests` only, where host build dominates and
-the DB layer is cheap. The per-assembly `FixtureTiming` now printed in CI shows that
-conclusion does **not** generalise: the other assemblies are `db_provision`-bound.
-
-| Assembly | host_build (n) | db_provision (n) | summed ÷ n † |
-|---|---:|---:|---:|
-| AccessMgmt.Tests | 84.7 s (65) | 66.9 s (64) | ~1.0 s |
-| Enduser.Api.Tests | 148.3 s (46) | 125.7 s (46) | ~2.7 s |
-| ServiceOwner.Api.Tests | 44.7 s (9) | 119.1 s (9) | ~13 s |
-| AccessMgmt.Core.Tests | 22.6 s (4) | 121.9 s (4) | ~30 s |
-| Internal.Api.Tests | 3.3 s (1) | 32.3 s (1) | ~32 s |
-
-† Not per-fixture work. `db_provision` is summed across concurrently-initialising
-fixtures and includes `provision_wait` (time blocked on the one-time template build), so
-this column overstates real cost where `n > 1` — see the sub-phase breakdown below.
-
-The summed `db_provision` exceeds host build across the vertical, and the apparent
-per-provision cost ranges from ~1 s to ~30 s. That "~30 s per provision" reading turned out
-to be an artifact: `db_provision` is a sum across fixtures that init concurrently, and it
-includes the time each fixture spends **blocked on the engine's provisioning lock** while
-the first fixture builds the one-time template. The sub-phase breakdown below isolates that
-wait (`provision_wait`) from real work and shows the provision-bound figure is mostly
-contention, not per-fixture migrate-and-seed. So the #3379 lever for these assemblies is to
-stop serialising every fixture behind a single cold template build at startup (warm the
-template once, up front, or shorten it), not to move them onto a clone path they already
-use. The parallelism decision below was measured on `AccessMgmt.Tests` only and should be
-re-checked for the provision-bound assemblies, where the limiter is this startup gate.
-
-### What `db_provision` is made of (sub-phase breakdown)
-
-`FixtureTiming` now splits the previously-opaque provision into its constituents, so the
-`db_provision` total above can be attributed rather than guessed at. The
-`===FIXTURE_TIMING===` line carries four extra buckets:
-
-- `server_start_ms` — one-time container acquire/start (image readiness), inside
-  `db_provision` but outside the template build.
-- `migrate_ms` / `seed_ms` — the EF migrate and the data seed, the two halves of the
-  one-time `template_build`.
-- `provision_wait_ms` — time blocked on the engine's provisioning lock. When fixtures
-  init concurrently, all but the first wait here while the one-time template build runs.
-
-The `AccessMgmt.Core.Tests` integration lane (4 `ApiFixture`s, `maxParallelThreads = 4`,
-local Podman) decomposes its `db_provision` exactly:
-
-| Bucket | Time | Share of `db_provision` (68.0 s) |
-|---|---:|---|
-| `provision_wait` (blocked on the lock) | 49.9 s | **~73%** |
-| `template_build` (one-time) | 12.5 s | ~18% |
-| — of which `migrate` | 11.2 s | dominant |
-| — of which `seed` | 0.3 s | negligible |
-| `server_start` (one-time) | 4.1 s | ~6% |
-| `clone` (4×) | 1.5 s | ~2% |
-
-Two findings. First, `migrate` runs **once** (not per fixture) and clones are cheap
-(~0.4 s each): the template **is** shared, so these assemblies do not, in fact, migrate-and-seed
-per fixture. Second, ~73% of the summed `db_provision` is `provision_wait` — three fixtures
-sitting behind the lock while the first does the ~16 s cold build (`migrate` + `server_start`).
-The real provisioning work is ~18 s, which is why the lane's wall-clock is ~32 s, not 68 s.
-So the actionable cost is the **single cold template build that serialises startup**, and
-within it `migrate` dominates (`seed` is negligible). The full-suite per-assembly
-decomposition now lands in the CI `Setup-timing breakdown` log automatically.
-
-## Prototype: fixture sharing (validated)
-
-Sharing one host across a read-only, additive-seed cohort via
-`ICollectionFixture` collapses N cold host builds into one. Prototyped on the
-`ConnectionsController` cluster (`Enduser.Api.Tests`): the **7** nested classes
-that are read-only, do not call `ConfigureServices`, and apply no per-class
-configuration (`CheckPackage`, `DelegationCheckRoles`, `GetAvailableUsers`,
-`GetConnections`, `GetInstances`, `GetPackages`, `GetRoles`) now join a single
-`ConnectionsReadOnlyCollection`. The other classes — `Add*`/`Remove*` (mutating)
-and any calling `ConfigureServices` — stay on `IClassFixture`.
-
-| Metric | Before | After |
-|---|---:|---:|
-| Test result | 143 passed / 5 skipped | **143 passed / 5 skipped** |
-| Wall clock | 1m 02s | **35.8 s** (−42%) |
-| Host builds (`host_build_n`) | 25 | **19** (−6) |
-| Host-build work | 129 s | 52 s |
-
-Identical pass/skip counts — no seed collisions, no isolation regression. The
-saving exceeds the 6 eliminated builds because removing them also cut CPU
-contention on the remaining 19 (avg build 5.2 s → 2.8 s). Clone/template work is
-untouched; it is already cheap.
-
-**Shareability rule.** A class can join a shared collection only if it:
+A class may join a shared collection only if it:
 
 1. seeds additively via `EnsureSeedOnce<TSelf>`,
 2. never calls `ConfigureServices` / `WithAppsettings` / `With*FeatureFlag`,
-3. issues no writes against rows other members read, **and**
-4. asserts *scoped / subset* results — not exact-equals or counts that another
+3. issues no writes against rows other members read (write detection must match
+   `PostAsJsonAsync` / `SendAsync`, not just `PostAsync`), **and**
+4. asserts scoped / subset results — not exact-equals or counts that another
    member's additive seed would change.
 
-Conditions 1–3 are statically checkable; **4 is not** — it only surfaces at
-runtime, so every converted cohort is run before it is kept. Anything failing the
-rule keeps its own `IClassFixture`.
+Conditions 1–3 are statically checkable; 4 only surfaces at runtime, so run a
+cohort once before keeping it. Anything that fails the rule keeps its own
+`IClassFixture`.
 
-## Rollout status
+Shared cohorts today: `ConnectionsController` and `RequestController` in
+`Enduser.Api.Tests`. They are the only multi-class, all-read-only controllers in
+the suite — everything else is one class per controller, or has a writer or a
+`ConfigureServices` / feature-flag member, so there is no cohort to share.
 
-| Cohort | Classes shared | Result |
-|---|---:|---|
-| `ConnectionsController` (Enduser) | 7 | ✅ shared |
-| `RequestController` (Enduser) | 4 | ✅ shared |
-| `ClientDelegationController` (Enduser) | 0 | ⛔ reverted — `GetClients`/`GetAgents` assert exact results and failed under sharing (condition 4) |
+## Parallelism
 
-`AuthorizedParties` and the Maskinporten controllers are excluded statically
-(`ConfigureServices` / per-class feature flags). Full Enduser integration suite
-after sharing the two safe cohorts: **221 passed / 9 skipped, 0 failed.**
+`maxParallelThreads` is **4**. The limiter is the single shared Postgres
+container (clone throughput + connection pool), not CPU, so more threads add
+contention without speeding the suites up — including host-build-heavy ones.
 
-**Survey of the remaining test projects (complete).** The lever needs *multiple*
-read-only classes in one controller. The rest of the AccessManagement suite does
-not offer this:
+## Test waits
 
-- `AccessMgmt.Tests` is almost entirely one class per controller — nothing to
-  share.
-- Every other multi-class file (`ServiceOwner.Api.Tests` `RequestController` /
-  `ServiceOwnerConnections`, `AccessMgmt.Tests` `MaskinportenSchema` /
-  `RightsInternal`) contains a writer or a `ConfigureServices` / feature-flag
-  member, leaving at most one read-only class — no cohort.
-
-So `ConnectionsController` + `RequestController` (Enduser) are the only
-safely-shareable read-only cohorts in the suite. **Note:** detection of writes
-must match `PostAsJsonAsync` / `SendAsync`, not just `PostAsync` — a class that
-creates data (even a `Get…Then…` setup) is not shareable.
-
-## Parallelism (measured — no change warranted)
-
-`maxParallelThreads` sweep on `AccessMgmt.Tests` integration (972 tests, local
-Podman, 20-core host), all green:
-
-| `maxParallelThreads` | Duration | vs current |
-|---:|---:|---:|
-| 1 | 2m 55s | +49% |
-| **4 (current)** | **1m 57s** | — |
-| 8 | 2m 05s | +7% |
-| 16 | 1m 58s | +1% |
-
-The setting *is* honoured (1 → 4 is ~33% faster), but **4 is already at the
-plateau** — 4 → 8 → 16 is flat despite 20 idle cores. The limiter is not CPU; it
-is the single shared Postgres container (clone creation + connection throughput,
-`MaxPoolSize = 50`) plus the CPU-bound host builds. So raising
-`maxParallelThreads` only adds shared-state / connection pressure (cf. the #3376
-seed race) for no measured gain.
-
-**Decision: keep `maxParallelThreads: 4`.** The effective lever for these suites
-is fewer host builds (fixture sharing, above), not more threads. Going faster
-would require removing the single-container bottleneck (e.g. a container per
-worker) — out of scope and unlikely to pay off. This holds regardless of an
-assembly's shape: on host-build-heavy suites (e.g. `ServiceOwner.Api.Tests`,
-where summed `host_build` exceeds `db_provision`) more threads oversubscribe the
-CPU and add lock contention rather than speed, so `maxParallelThreads` stays 4
-everywhere.
-
-## Test waits (`Task.Delay` audit)
-
-Test code has **0 `Thread.Sleep`** and **32 `Task.Delay`**. Audited:
-
-| Use | Count | Action |
-|---|---:|---|
-| `Task.WhenAny(serviceTask, Task.Delay(1000))` shutdown timeout guards | 12 | keep (bounded wait) |
-| `Task.Delay(N) // simulate processing` inside mock callbacks | 6 | keep (intended test-double latency) |
-| 100M-ms cancellation sentinel / 90 s lease-TTL / SUT retry backoff | 3 | keep (not test waits) |
-| `Task.Delay(20)` then assert metrics (`ConsentServiceTests`) | 4 | **fixed** → `MeasurementCollector.WaitForMeasurementsAsync` (polls; returns on first measurement, throws on timeout) |
-| `Task.Delay(10)` "let the hosted-service loop reach its timer" (`ConsentMigrationHostedServiceTests`) | 7 | keep — driven by a fake `TimeProvider`; nothing signals "now awaiting the timer", so a poll has no observable state to watch |
-
-Net: the one genuinely flaky *delay-then-assert* pattern (the metrics listener)
-is replaced with polling. The rest are either correct by design (bounded guards,
-deliberate latency) or lack an observable signal to poll on.
+Test code uses **no `Thread.Sleep`**. `Task.Delay` is allowed only for bounded
+shutdown-timeout guards and deliberate test-double latency; a delay-then-assert
+pattern must instead poll for the observable signal (e.g.
+`MeasurementCollector.WaitForMeasurementsAsync`).
 
 ## Reproduce
 
-`FixtureTiming` is opt-out (disable with `FIXTURE_TIMING=off`) and writes one
-summary line to stdout and, when `FIXTURE_TIMING_FILE` is set, appends it to
-that file (stdout is swallowed by MTP / `dotnet-coverage` in CI).
+`FixtureTiming` (opt-out via `FIXTURE_TIMING=off`) writes one summary line per
+test process to stdout, and appends it to `FIXTURE_TIMING_FILE` when that is set
+(stdout is swallowed by MTP / `dotnet-coverage` in CI). CI prints the
+per-assembly breakdown in the test job log automatically. Locally:
 
 ```bash
-# Local run against a container runtime (here: Podman; Docker Desktop works too).
 FIXTURE_TIMING_FILE="$PWD/fixture-timing.txt" \
 DOCKER_HOST="npipe://./pipe/podman-machine-default" \
 TESTCONTAINERS_RYUK_DISABLED=true \
 dotnet test src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/AccessMgmt.Tests.csproj \
   -c Release -- --filter-trait "Category=Integration" --ignore-exit-code 8
 ```
-
-Numbers are from local Podman; absolute values differ on CI hardware, but the
-**ratio** (host build ≫ clone) is the hardware-independent finding for
-`AccessMgmt.Tests`. It does not hold vertical-wide — see the cross-assembly
-section above, where the other assemblies are `db_provision`-bound.

--- a/docs/testing/TEST_SETUP_TIMING.md
+++ b/docs/testing/TEST_SETUP_TIMING.md
@@ -182,6 +182,29 @@ is fewer host builds (fixture sharing, above), not more threads. Going faster
 would require removing the single-container bottleneck (e.g. a container per
 worker) — out of scope and unlikely to pay off.
 
+### Re-check on a provision-bound assembly (`ServiceOwner.Api.Tests`)
+
+The sweep above ran on `AccessMgmt.Tests`. `ServiceOwner.Api.Tests` has a
+different shape — 9 fixtures with heavy cold host builds (`host_build` ~100 s
+summed, exceeding `db_provision`), so it is plausibly more CPU-bound and a
+candidate to benefit from more threads. Re-measured at `maxParallelThreads: 8`
+(local Podman), all runs green (41/41):
+
+| Run | `maxParallelThreads: 4` | `maxParallelThreads: 8` |
+|---|---:|---:|
+| 1 | 52.1 s | 44.6 s |
+| 2 | — | 47.6 s |
+| 3 | — | 59.0 s |
+
+The first 8-thread run looked ~14% faster, but repeats spread to **44–59 s**
+(summed `host_build` swinging 133 s → 254 s from CPU oversubscription), with the
+worst run slower than the 4-thread baseline. The apparent gain was run-to-run
+variance, not a real speedup, and the contention metrics rose sharply
+(`provision_wait` ~54 s → ~127 s, `clone` ~3 s → ~8 s). So the single-container
+limiter holds here too. **No change: keep `maxParallelThreads: 4`.** No new
+flakiness surfaced across the repeats (the constructor-seed fixes removed the
+re-seed collisions that previously raised the concurrency risk).
+
 ## Test waits (`Task.Delay` audit)
 
 Test code has **0 `Thread.Sleep`** and **32 `Task.Delay`**. Audited:

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Other/ProblemsValidation.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Other/ProblemsValidation.cs
@@ -1,4 +1,7 @@
-﻿using Altinn.AccessManagement.Core.Errors;
+using System.Reflection;
+
+using Altinn.AccessManagement.Core.Errors;
+using Altinn.Authorization.ProblemDetails;
 
 namespace Altinn.AccessManagement.Api.Tests.Other;
 
@@ -6,73 +9,30 @@ namespace Altinn.AccessManagement.Api.Tests.Other;
 public class ProblemsValidation
 {
     [Fact]
-    public void Problems_RequestProblems_ShouldBeAccessible()
+    public void Problems_AllDescriptors_HaveDistinctErrorCodes()
     {
-        _ = Problems.NotAuthorizedForConsentRequest;
-        _ = Problems.ConsentNotFound;
-        _ = Problems.ConsentCantBeAccepted;
-        _ = Problems.InvalidOrganizationIdentifier;
-        _ = Problems.InvalidPersonIdentifier;
-        _ = Problems.InvalidConsentResource;
-        _ = Problems.UnknownConsentMetadata;
-        _ = Problems.MissingMetadataValue;
-        _ = Problems.MissingMetadata;
-        _ = Problems.InvalidResourceCombination;
-        _ = Problems.ConsentCantBeRevoked;
-        _ = Problems.ConsentRevoked;
-        _ = Problems.MissMatchConsentParty;
-        _ = Problems.ConsentExpired;
-        _ = Problems.ConsentNotAccepted;
-        _ = Problems.ConsentCantBeRejected;
-        _ = Problems.ConsentWithIdAlreadyExist;
-        _ = Problems.UnsupportedEntityType;
-        _ = Problems.EntityTypeNotFound;
-        _ = Problems.EntityVariantNotFoundOrInvalid;
-        _ = Problems.MissingRightHolder;
-        _ = Problems.ConnectionEntitiesDoNotExist;
-        _ = Problems.MissingConnection;
-        _ = Problems.PartyNotFound;
-        _ = Problems.PersonInputRequiredForPersonAssignment;
-        _ = Problems.AgentHasExistingDelegations;
-        _ = Problems.PersonLookupFailedToManyErrors;
-        _ = Problems.InvalidResource;
-        _ = Problems.NotAuthorizedForDelegationRequest;
-        _ = Problems.DelegationPolicyRuleWriteFailed;
-        _ = Problems.AssignmentNotFound;
-        _ = Problems.RequestNotFound;
-        _ = Problems.RequestCreationFailed;
+        var codes = ErrorCodesOf<ProblemDescriptor>(typeof(Problems), d => d.ErrorCode);
+
+        Assert.NotEmpty(codes);
+        Assert.Equal(codes.Count, codes.Distinct().Count());
     }
 
     [Fact]
-    public void ValidationErrors_AllDescriptors_ShouldBeAccessible()
+    public void ValidationErrors_AllDescriptors_HaveDistinctErrorCodes()
     {
-        _ = ValidationErrors.Required;
-        _ = ValidationErrors.InvalidPartyUrn;
-        _ = ValidationErrors.InvalidResource;
-        _ = ValidationErrors.MissingPolicy;
-        _ = ValidationErrors.MissingDelegableRights;
-        _ = ValidationErrors.ToManyDelegationsToRevoke;
-        _ = ValidationErrors.EntityNotExists;
-        _ = ValidationErrors.RoleNotExists;
-        _ = ValidationErrors.DisallowedEntityType;
-        _ = ValidationErrors.InvalidQueryParameter;
-        _ = ValidationErrors.AssignmentHasActiveConnections;
-        _ = ValidationErrors.PackageNotExists;
-        _ = ValidationErrors.ResourceNotExists;
-        _ = ValidationErrors.TimeNotInFuture;
-        _ = ValidationErrors.EmptyList;
-        _ = ValidationErrors.ConsentNotFound;
-        _ = ValidationErrors.InvalidResourceContext;
-        _ = ValidationErrors.UserNotAuthorized;
-        _ = ValidationErrors.InvalidRedirectUrl;
-        _ = ValidationErrors.PackageIsNotAssignableToRecipient;
-        _ = ValidationErrors.InvalidRole;
-        _ = ValidationErrors.InvalidPackage;
-        _ = ValidationErrors.DelegationHasActiveConnections;
-        _ = ValidationErrors.MissingAssignment;
-        _ = ValidationErrors.PackageIsNotDelegable;
-        _ = ValidationErrors.InvalidExternalIdentifiers;
-        _ = ValidationErrors.RequestNotFound;
-        _ = ValidationErrors.RequestUnsupportedStatusUpdate;
+        var codes = ErrorCodesOf<ValidationErrorDescriptor>(typeof(ValidationErrors), d => d.ErrorCode);
+
+        Assert.NotEmpty(codes);
+        Assert.Equal(codes.Count, codes.Distinct().Count());
     }
+
+    // Reflects every public static descriptor property on the catalog so the check
+    // covers the whole set and cannot drift as descriptors are added (the old
+    // hand-maintained list had already missed one). Reading each value also forces
+    // its initializer to run, so a descriptor that throws on construction fails here.
+    private static List<ErrorCode> ErrorCodesOf<T>(Type catalog, Func<T, ErrorCode> errorCode) =>
+        catalog.GetProperties(BindingFlags.Public | BindingFlags.Static)
+            .Where(p => p.PropertyType == typeof(T))
+            .Select(p => errorCode((T)p.GetValue(null)!))
+            .ToList();
 }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Integration/HostedServices/Services/ResourceSyncServiceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Integration/HostedServices/Services/ResourceSyncServiceTest.cs
@@ -154,6 +154,11 @@ public class ResourceSyncServiceTest : IClassFixture<ApiFixture>
         var lease = new FakeLease();
         var svc = ResolveService();
         await svc.SyncResources(lease, TestContext.Current.CancellationToken);
+
+        // A problem page stops the sync before any resource is processed, so the
+        // lease watermark is never advanced (contrast the upsert test, which
+        // asserts Since is set on success).
+        Assert.Equal(default, lease.Data.Since);
     }
 
     [Fact]
@@ -323,14 +328,32 @@ public class ResourceSyncServiceTest : IClassFixture<ApiFixture>
             ],
         })];
 
-        await ResolveService().SyncResources(new FakeLease(), TestContext.Current.CancellationToken);
+        var lease = new FakeLease();
+        await ResolveService().SyncResources(lease, TestContext.Current.CancellationToken);
+
+        // The unparseable resource URN is skipped, so the resource is never
+        // processed and the lease watermark stays at its initial value.
+        Assert.Equal(default, lease.Data.Since);
     }
 
     [Fact]
     public async Task SyncResources_ReturnsEarly_WhenResourceProcessingThrows()
     {
         var refId = "rsst-throw-" + Guid.NewGuid().ToString("N");
-        Registry.ResourceFactory = _ => Success(NewResourceModel(refId));
+
+        // A resource with no competent authority makes ConvertToResource dereference
+        // a null Orgcode and throw, which exercises the page-level catch that returns
+        // early. (A non-existent role subject does not throw - UpsertRoleCodeResource
+        // looks it up with FirstOrDefault and skips when absent - so it would not
+        // reach this path.)
+        Registry.ResourceFactory = _ => Success(new ResourceModel
+        {
+            Identifier = refId,
+            Title = new ResourceTitle { Nb = "Resource " + refId },
+            Description = new ResourceDescription { Nb = "Description for " + refId },
+            HasCompetentAuthority = null,
+            ResourceType = "GenericAccessResource",
+        });
         Registry.StreamPagesFactory = (_, _) => [Success(new PageStream<ResourceUpdatedModel>
         {
             Stats = new PageStream<ResourceUpdatedModel>.StatsStream(),
@@ -339,15 +362,20 @@ public class ResourceSyncServiceTest : IClassFixture<ApiFixture>
             [
                 new ResourceUpdatedModel
                 {
-                    // No role exists with this LegacyUrn/Urn → UpsertRoleCodeResource throws KeyNotFoundException.
-                    SubjectUrn = "urn:altinn:rolecode:does-not-exist-" + Guid.NewGuid().ToString("N"),
+                    SubjectUrn = "urn:altinn:rolecode:priv",
                     ResourceUrn = "urn:altinn:resource:" + refId,
                     UpdatedAt = DateTime.UtcNow,
                 },
             ],
         })];
 
-        await ResolveService().SyncResources(new FakeLease(), TestContext.Current.CancellationToken);
+        var lease = new FakeLease();
+        await ResolveService().SyncResources(lease, TestContext.Current.CancellationToken);
+
+        // Processing the page throws, so the sync returns early and records no
+        // progress: the lease watermark stays at its initial value, so the next run
+        // retries from the same point instead of skipping the failed page.
+        Assert.Equal(default, lease.Data.Since);
     }
 
     private IResourceSyncService ResolveService()

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Integration/AltinnApps_DecisionTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Integration/AltinnApps_DecisionTests.cs
@@ -28,9 +28,15 @@ namespace Altinn.Authorization.Tests.Integration
         public AltinnApps_DecisionTests(AuthorizationApiFixture fixture)
         {
             _fixture = fixture;
-            _client = fixture.BuildClient();
             SetupFeatureMock(true);
             SetupDateTimeMock();
+
+            // Build the shared client through the same configured path the
+            // per-test clients use, so the AuditLog feature flag set above is
+            // actually honoured. Building via BuildClient() left _client on the
+            // host default feature manager, so flag-dependent assertions could
+            // pass for the wrong reason.
+            _client = GetTestClient(featureManager: featureManageMock.Object);
         }
 
         [Fact]

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Integration/ExternalDecisionTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Integration/ExternalDecisionTest.cs
@@ -29,9 +29,15 @@ namespace Altinn.Authorization.Tests.Integration
         public ExternalDecisionTest(AuthorizationApiFixture fixture)
         {
             _fixture = fixture;
-            _client = fixture.BuildClient();
             SetupFeatureMock(true);
             SetupDateTimeMock();
+
+            // Build the shared client through the same configured path the
+            // per-test clients use, so the AuditLog feature flag set above is
+            // actually honoured. Building via BuildClient() left _client on the
+            // host default feature manager, so flag-dependent assertions could
+            // pass for the wrong reason.
+            _client = GetTestClient(featureManager: featureManageMock.Object);
         }
 
         [Fact]

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Integration/ResourceRegistry_DecisionTests.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Integration/ResourceRegistry_DecisionTests.cs
@@ -28,11 +28,17 @@ namespace Altinn.Authorization.Tests.Integration
         public ResourceRegistry_DecisionTests(AuthorizationApiFixture fixture)
         {
             _fixture = fixture;
-            _client = fixture.BuildClient();
             SetupFeatureMock("AuditLog", true);
             SetupFeatureMock("SystemUserAccessPackageAuthorization", true);
             SetupFeatureMock("UserAccessPackageAuthorization", true);
             SetupDateTimeMock();
+
+            // Build the shared client through the configured path so the feature
+            // flags set above are honoured. Building via BuildClient() left _client
+            // on the host default feature manager, so the access-package
+            // authorization flags were ignored and those decision paths could be
+            // asserted without actually being enabled.
+            _client = GetTestClient(featureManager: featureManageMock.Object);
         }
 
         [Fact]

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/ValidationErrors.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/ValidationErrors.cs
@@ -89,7 +89,7 @@ public static class ValidationErrors
     /// Resource does not exist.
     /// </summary>
     public static ValidationErrorDescriptor ResourceNotExists { get; }
-        = _factory.Create(12, $"Resource do not exists.");
+        = _factory.Create(12, $"Resource does not exist.");
 
     /// <summary>
     /// Gets a validation error descriptor

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/ValidationErrors.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/ValidationErrors.cs
@@ -89,7 +89,7 @@ public static class ValidationErrors
     /// Resource does not exist.
     /// </summary>
     public static ValidationErrorDescriptor ResourceNotExists { get; }
-        = _factory.Create(11, $"Resource do not exists.");
+        = _factory.Create(12, $"Resource do not exists.");
 
     /// <summary>
     /// Gets a validation error descriptor

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointTest.cs
@@ -57,6 +57,40 @@ public class PolicyDecisionPointTest
         result.Decision.Should().Be(XacmlContextDecision.NotApplicable);
     }
 
+    // Acceptance test for #3132 milestone A2. first-applicable means the first
+    // matching rule decides, so a matching Deny placed first must yield Deny. The
+    // PDP currently implements only rule-deny-overrides: for any other algorithm it
+    // drops the Deny and lets the later Permit win - a silent grant where the policy
+    // says deny (verified: this assertion fails today with Actual = Permit). Skipped
+    // until first-applicable is implemented; remove the Skip then.
+    [Fact(Skip = "PDP only implements rule-deny-overrides; first-applicable is unimplemented and currently returns Permit instead of Deny (silent grant). Acceptance test for #3132 milestone A2.")]
+    public void Authorize_FirstApplicable_DenyRuleFirst_ReturnsDeny()
+    {
+        XacmlContextResult result = Decide(TwoRulePolicy("Deny", "Permit", FirstApplicable), Request());
+        result.Decision.Should().Be(XacmlContextDecision.Deny);
+    }
+
+    private const string FirstApplicable = "urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable";
+
+    private static string TwoRulePolicy(string firstEffect, string secondEffect, string combiningAlg) => $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Policy xmlns=""{Ns}"" PolicyId=""urn:test:policy"" Version=""1.0"" RuleCombiningAlgId=""{combiningAlg}"">
+  <Target />
+  <Rule RuleId=""urn:test:rule1"" Effect=""{firstEffect}"">
+    <Target>
+      <AnyOf><AllOf>{Match("urn:oasis:names:tc:xacml:1.0:resource:resource-id", "urn:oasis:names:tc:xacml:3.0:attribute-category:resource", "resource1")}</AllOf></AnyOf>
+      <AnyOf><AllOf>{Match("urn:oasis:names:tc:xacml:1.0:action:action-id", "urn:oasis:names:tc:xacml:3.0:attribute-category:action", "read")}</AllOf></AnyOf>
+      <AnyOf><AllOf>{Match("urn:oasis:names:tc:xacml:1.0:subject:subject-id", "urn:oasis:names:tc:xacml:1.0:subject-category:access-subject", "user1")}</AllOf></AnyOf>
+    </Target>
+  </Rule>
+  <Rule RuleId=""urn:test:rule2"" Effect=""{secondEffect}"">
+    <Target>
+      <AnyOf><AllOf>{Match("urn:oasis:names:tc:xacml:1.0:resource:resource-id", "urn:oasis:names:tc:xacml:3.0:attribute-category:resource", "resource1")}</AllOf></AnyOf>
+      <AnyOf><AllOf>{Match("urn:oasis:names:tc:xacml:1.0:action:action-id", "urn:oasis:names:tc:xacml:3.0:attribute-category:action", "read")}</AllOf></AnyOf>
+      <AnyOf><AllOf>{Match("urn:oasis:names:tc:xacml:1.0:subject:subject-id", "urn:oasis:names:tc:xacml:1.0:subject-category:access-subject", "user1")}</AllOf></AnyOf>
+    </Target>
+  </Rule>
+</Policy>";
+
     private static XacmlContextResult Decide(string policyXml, string requestXml)
     {
         using XmlReader policyReader = XmlReader.Create(new StringReader(policyXml));

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointTest.cs
@@ -70,7 +70,7 @@ public class PolicyDecisionPointTest
         result.Decision.Should().Be(XacmlContextDecision.Deny);
     }
 
-    private const string FirstApplicable = "urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable";
+    private static readonly string FirstApplicable = XacmlConstants.CombiningAlgorithms.RuleFirstApplicable;
 
     private static string TwoRulePolicy(string firstEffect, string secondEffect, string combiningAlg) => $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Policy xmlns=""{Ns}"" PolicyId=""urn:test:policy"" Version=""1.0"" RuleCombiningAlgId=""{combiningAlg}"">

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/AppAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/AppAccessHandlerTest.cs
@@ -192,12 +192,24 @@ namespace Altinn.Authorization.PEP.Tests
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext(ipaddress));
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
             AddObligationWithMinAuthLv(response, "2");
-
-            // verify
             _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _aah.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+            Assert.False(context.HasFailed);
+
+            XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
+
+            // Known gap: even with an X-Forwarded-For header present, the PEP does not
+            // copy it onto the decision request. The AppAccessRequirement overload of
+            // DecisionHelper.CreateDecisionRequest is not even passed the headers, so
+            // XForwardedForHeader is never set and the PDP never sees the client IP.
+            // This pins current behaviour; switch to Assert.Equal(ipaddress, ...) once
+            // IP forwarding is implemented.
+            Assert.Null(request.Request.XForwardedForHeader);
         }
 
         /// <summary>

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/AppAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/AppAccessHandlerTest.cs
@@ -201,7 +201,7 @@ namespace Altinn.Authorization.PEP.Tests
             Assert.True(context.HasSucceeded);
             Assert.False(context.HasFailed);
 
-            XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
+            XacmlJsonRequestRoot request = Assert.IsType<XacmlJsonRequestRoot>(Assert.Single(_pdpMock.Invocations).Arguments[0]);
 
             // Known gap: even with an X-Forwarded-For header present, the PEP does not
             // copy it onto the decision request. The AppAccessRequirement overload of

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ResourceAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ResourceAccessHandlerTest.cs
@@ -162,12 +162,17 @@ namespace Altinn.Authorization.PEP.Tests
             AuthorizationHandlerContext context = CreateAuthorizationHandlerContext();
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext("23453546", null, null));
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
-
-            // Verify
-            _pdpMock.Setup(a => a.GetDecisionForRequest(It.Is<XacmlJsonRequestRoot>(xr => xr.Request.XForwardedForHeader == null), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
+            _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _rah.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+            Assert.False(context.HasFailed);
+
+            XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
+            Assert.Null(request.Request.XForwardedForHeader);
         }
 
         /// <summary>
@@ -182,12 +187,23 @@ namespace Altinn.Authorization.PEP.Tests
             string ipaddress = "18.203.138.153";
             _httpContextAccessorMock.Setup(h => h.HttpContext).Returns(CreateHttpContext("organization", "991825827", null, ipaddress));
             XacmlJsonResponse response = CreateResponse(XacmlContextDecision.Permit.ToString());
-
-            // verify
             _pdpMock.Setup(a => a.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response));
 
             // Act
             await _rah.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+            Assert.False(context.HasFailed);
+
+            XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
+
+            // Known gap: even with an X-Forwarded-For header present, the PEP does not
+            // copy it onto the decision request. DecisionHelper.CreateDecisionRequest
+            // reads the org/person headers but never sets XForwardedForHeader, so the
+            // PDP never sees the client IP. This pins current behaviour; switch to
+            // Assert.Equal(ipaddress, ...) once IP forwarding is implemented.
+            Assert.Null(request.Request.XForwardedForHeader);
         }
 
         private ClaimsPrincipal CreateUser()

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ResourceAccessHandlerTest.cs
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/ResourceAccessHandlerTest.cs
@@ -76,7 +76,7 @@ namespace Altinn.Authorization.PEP.Tests
             Assert.True(context.HasSucceeded);
             Assert.False(context.HasFailed);
 
-            XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
+            XacmlJsonRequestRoot request = Assert.IsType<XacmlJsonRequestRoot>(Assert.Single(_pdpMock.Invocations).Arguments[0]);
             Assert.Equal("urn:altinn:organizationnumber", request.Request.Resource[0].Attribute[0].AttributeId);
             Assert.Equal("991825827", request.Request.Resource[0].Attribute[0].Value);
         }
@@ -124,7 +124,7 @@ namespace Altinn.Authorization.PEP.Tests
             Assert.True(context.HasSucceeded);
             Assert.False(context.HasFailed);
 
-            XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
+            XacmlJsonRequestRoot request = Assert.IsType<XacmlJsonRequestRoot>(Assert.Single(_pdpMock.Invocations).Arguments[0]);
             Assert.Equal("urn:altinn:person:identifier-no", request.Request.Resource[0].Attribute[0].AttributeId);
             Assert.Equal("01014922047", request.Request.Resource[0].Attribute[0].Value);
         }
@@ -171,7 +171,7 @@ namespace Altinn.Authorization.PEP.Tests
             Assert.True(context.HasSucceeded);
             Assert.False(context.HasFailed);
 
-            XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
+            XacmlJsonRequestRoot request = Assert.IsType<XacmlJsonRequestRoot>(Assert.Single(_pdpMock.Invocations).Arguments[0]);
             Assert.Null(request.Request.XForwardedForHeader);
         }
 
@@ -196,7 +196,7 @@ namespace Altinn.Authorization.PEP.Tests
             Assert.True(context.HasSucceeded);
             Assert.False(context.HasFailed);
 
-            XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
+            XacmlJsonRequestRoot request = Assert.IsType<XacmlJsonRequestRoot>(Assert.Single(_pdpMock.Invocations).Arguments[0]);
 
             // Known gap: even with an X-Forwarded-For header present, the PEP does not
             // copy it onto the decision request. DecisionHelper.CreateDecisionRequest


### PR DESCRIPTION
Closes #3587. Part of #3412, #3486 (Phase 3).

Correctness fixes the cross-project test-infra audit (#3412) surfaced:

- Build the decision-test clients (AltinnApps, External and resource-registry) through the configured path, so feature-gated assertions run against each test's feature manager rather than the host default. The resource-registry decision tests in particular set the access-package authorization flags but built their `_client` before configuring the feature manager, so those paths were asserted without the flags actually enabled.
- Make the `ResourceSyncService` early-return tests actually verify the early return.
- Give the PEP `X-Forwarded-For` handler tests real assertions.
- Rewrite `ProblemsValidation` to reflect over every descriptor and assert distinct error codes (the hand-maintained list had drifted to 28 of 45 and asserted nothing). That surfaced a product defect: `ResourceNotExists` and `PackageNotExists` both rendered `AM.VLD-00011`. `ResourceNotExists` moves to the unused code 12 so a client can tell them apart; no caller pins the literal.
- Add a skipped ABAC acceptance test documenting the first-applicable silent-grant behaviour.

Verified on this branch: the solution builds with 0 errors; Authorization.Tests 415/415, PEP.Tests 92/92, ABAC.Tests 39/39 (+1 skipped), ProblemsValidation 2/2 and ResourceSyncServiceTest 8/8 under Podman.