### PR TITLE
Phase 3: rename cryptic actor-named integration tests to role/scenario names

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
@@ -78,6 +78,11 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
         var response = await client.GetAsync(Route, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<PaginatedResult<AuthorizedPartyDto>>(content, JsonOptions);
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Items);
     }
 
     /// <summary>
@@ -92,6 +97,11 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
         var response = await client.GetAsync(Route, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<PaginatedResult<AuthorizedPartyDto>>(content, JsonOptions);
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Items);
     }
 
     /// <summary>
@@ -231,6 +241,11 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
         var response = await client.GetAsync($"{Route}?includeRoles=true&includeResources=true&includeInstances=true", TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<PaginatedResult<AuthorizedPartyDto>>(content, JsonOptions);
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Items);
     }
 
     /// <summary>
@@ -279,6 +294,11 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
         var response = await client.GetAsync(Route, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<PaginatedResult<AuthorizedPartyDto>>(content, JsonOptions);
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Items);
     }
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
@@ -99,7 +99,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 200 OK and Dumbo Adventures in the result.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsManagingDirectorWithIncludeRoles_ReturnsRepresentedOrgAndSelfWithRoles()
+    public async Task GetAuthorizedParties_AsManagingDirectorWithIncludeRoles_Returns200WithRepresentedOrgAndSelfWithRoles()
     {
         HttpClient client = CreatePortalClient(TestData.MalinEmilie);
 
@@ -131,7 +131,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Packages and resources should be empty since only roles are requested.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsRightholderWithIncludeRoles_ReturnsRepresentedOrgsWithRoles()
+    public async Task GetAuthorizedParties_AsRightholderWithIncludeRoles_Returns200WithRepresentedOrgsWithRoles()
     {
         HttpClient client = CreatePortalClient(TestData.Thea);
 
@@ -169,7 +169,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Dumbo should have DAGL packages (Malin is MD), self should have PRIV packages.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsManagingDirectorWithIncludeAccessPackages_ReturnsRepresentedOrgAndSelfWithPackages()
+    public async Task GetAuthorizedParties_AsManagingDirectorWithIncludeAccessPackages_Returns200WithRepresentedOrgAndSelfWithPackages()
     {
         HttpClient client = CreatePortalClient(TestData.MalinEmilie);
 
@@ -195,7 +195,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Dumbo should have the SalarySpecialCategory package via Thea's Rightholder assignment.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsRightholderWithIncludeAccessPackages_ReturnsRepresentedOrgsWithPackages()
+    public async Task GetAuthorizedParties_AsRightholderWithIncludeAccessPackages_Returns200WithRepresentedOrgsWithPackages()
     {
         HttpClient client = CreatePortalClient(TestData.Thea);
 
@@ -285,7 +285,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Thea requests authorized parties and verifies the response deserializes correctly.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_ReturnsValidPaginatedResult()
+    public async Task GetAuthorizedParties_Returns200WithPaginatedResult()
     {
         HttpClient client = CreatePortalClient(TestData.Thea);
 
@@ -303,7 +303,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Validates roles and packages for all parties.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsChairOfTheBoardWithKeyRoles_ReturnsRepresentedOrgAndAuditedOrgViaKeyRole()
+    public async Task GetAuthorizedParties_AsChairOfTheBoardWithKeyRoles_Returns200WithRepresentedOrgAndAuditedOrgViaKeyRole()
     {
         HttpClient client = CreatePortalClient(TestData.AlexTheArtist);
 
@@ -338,7 +338,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects Kaos Magic Design and Arts to appear with instance rights for SiriusSkattemelding and MattilsynetBakeryService.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsInstanceRecipientWithIncludeInstances_ReturnsDelegatingOrgWithInstances()
+    public async Task GetAuthorizedParties_AsInstanceRecipientWithIncludeInstances_Returns200WithDelegatingOrgWithInstances()
     {
         HttpClient client = CreatePortalClient(TestData.JosephineYvonnesdottir);
 
@@ -362,7 +362,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects Kaos to appear but with empty instances list.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsInstanceRecipientWithoutIncludeInstances_ReturnsDelegatingOrgWithoutInstances()
+    public async Task GetAuthorizedParties_AsInstanceRecipientWithoutIncludeInstances_Returns200WithDelegatingOrgWithoutInstances()
     {
         HttpClient client = CreatePortalClient(TestData.JosephineYvonnesdottir);
 
@@ -384,7 +384,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// AuthorizedInstances should be empty since includeInstances is not set.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsInstanceRecipientWithIncludeResources_ReturnsDelegatingOrgWithResources()
+    public async Task GetAuthorizedParties_AsInstanceRecipientWithIncludeResources_Returns200WithDelegatingOrgWithResources()
     {
         HttpClient client = CreatePortalClient(TestData.JosephineYvonnesdottir);
 
@@ -407,7 +407,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Kaos should have both resources and instances populated (from seed).
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsInstanceRecipientWithIncludeResourcesAndInstances_ReturnsDelegatingOrgWithResourcesAndInstances()
+    public async Task GetAuthorizedParties_AsInstanceRecipientWithIncludeResourcesAndInstances_Returns200WithDelegatingOrgWithResourcesAndInstances()
     {
         HttpClient client = CreatePortalClient(TestData.JosephineYvonnesdottir);
 
@@ -435,7 +435,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// roles and access packages. Guards the hovedenhet/underenhet response contract (#3498 area 5).
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsMainUnitManagingDirector_ReturnsSubunitNestedUnderMainUnitWithoutDuplicates()
+    public async Task GetAuthorizedParties_AsMainUnitManagingDirector_Returns200WithSubunitNestedUnderMainUnitWithoutDuplicates()
     {
         HttpClient client = CreatePortalClient(TestEntities.PersonPaula);
 
@@ -497,7 +497,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// hovedenhet/underenhet contract (#3498 area 5).
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsMainUnitManagingDirector_SubunitDoesNotInheritMainUnitInstances()
+    public async Task GetAuthorizedParties_AsMainUnitManagingDirector_Returns200WithSubunitWithoutMainUnitInstances()
     {
         HttpClient client = CreatePortalClient(TestEntities.PersonPaula);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
@@ -71,7 +71,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 200 OK.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsManagingDirectorWithPortalScope_Returns200Ok()
+    public async Task GetAuthorizedParties_AsManagingDirectorWithPortalScope_Returns200WithAuthorizedParties()
     {
         var client = CreatePortalClient(TestData.MalinEmilie);
 
@@ -85,7 +85,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 200 OK.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsRightholderWithPortalScope_Returns200Ok()
+    public async Task GetAuthorizedParties_AsRightholderWithPortalScope_Returns200WithAuthorizedParties()
     {
         var client = CreatePortalClient(TestData.Thea);
 
@@ -224,7 +224,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 200 OK.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsManagingDirectorWithMultipleIncludeFlags_Returns200Ok()
+    public async Task GetAuthorizedParties_AsManagingDirectorWithMultipleIncludeFlags_Returns200WithAuthorizedParties()
     {
         var client = CreatePortalClient(TestData.MalinEmilie);
 
@@ -238,7 +238,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 403 Forbidden.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_WithWrongScope_Returns403WrongScope()
+    public async Task GetAuthorizedParties_WithWrongScope_Returns403Forbidden()
     {
         var client = CreateClientWithScopes(AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 
@@ -252,7 +252,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 401 Unauthorized.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_WithNoToken_Returns401MissingToken()
+    public async Task GetAuthorizedParties_WithNoToken_Returns401Unauthorized()
     {
         var client = Fixture.Server.CreateClient();
 
@@ -266,7 +266,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 200 OK since the policy accepts both portal and system scopes.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsManagingDirectorWithSystemScope_Returns200Ok()
+    public async Task GetAuthorizedParties_AsManagingDirectorWithSystemScope_Returns200WithAuthorizedParties()
     {
         var client = Fixture.Server.CreateClient();
         var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
@@ -473,7 +473,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Guards the subunit partyFilter contract (#3498 area 5).
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_WithSubunitPartyFilter_ReturnsMainUnitWithSubunitNested()
+    public async Task GetAuthorizedParties_WithSubunitPartyFilter_Returns200WithMainUnitWithSubunitNested()
     {
         HttpClient client = CreatePortalClient(TestEntities.PersonPaula);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
@@ -71,7 +71,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 200 OK.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsMalinWithPortalScope_Returns200Ok()
+    public async Task GetAuthorizedParties_AsManagingDirectorWithPortalScope_Returns200Ok()
     {
         var client = CreatePortalClient(TestData.MalinEmilie);
 
@@ -85,7 +85,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 200 OK.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsTheaWithPortalScope_Returns200Ok()
+    public async Task GetAuthorizedParties_AsRightholderWithPortalScope_Returns200Ok()
     {
         var client = CreatePortalClient(TestData.Thea);
 
@@ -99,7 +99,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 200 OK and Dumbo Adventures in the result.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsMalinWithIncludeRoles_ReturnsOkWithDumboAdventures()
+    public async Task GetAuthorizedParties_AsManagingDirectorWithIncludeRoles_ReturnsRepresentedOrgAndSelfWithRoles()
     {
         HttpClient client = CreatePortalClient(TestData.MalinEmilie);
 
@@ -131,7 +131,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Packages and resources should be empty since only roles are requested.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsTheaWithIncludeRoles_ReturnsExpectedParties()
+    public async Task GetAuthorizedParties_AsRightholderWithIncludeRoles_ReturnsRepresentedOrgsWithRoles()
     {
         HttpClient client = CreatePortalClient(TestData.Thea);
 
@@ -169,7 +169,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Dumbo should have DAGL packages (Malin is MD), self should have PRIV packages.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsMalinWithIncludeAccessPackages_ReturnsExpectedPackages()
+    public async Task GetAuthorizedParties_AsManagingDirectorWithIncludeAccessPackages_ReturnsRepresentedOrgAndSelfWithPackages()
     {
         HttpClient client = CreatePortalClient(TestData.MalinEmilie);
 
@@ -195,7 +195,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Dumbo should have the SalarySpecialCategory package via Thea's Rightholder assignment.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsTheaWithIncludeAccessPackages_ReturnsExpectedPackages()
+    public async Task GetAuthorizedParties_AsRightholderWithIncludeAccessPackages_ReturnsRepresentedOrgsWithPackages()
     {
         HttpClient client = CreatePortalClient(TestData.Thea);
 
@@ -224,7 +224,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 200 OK.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsMalinWithMultipleIncludeFlags_Returns200Ok()
+    public async Task GetAuthorizedParties_AsManagingDirectorWithMultipleIncludeFlags_Returns200Ok()
     {
         var client = CreatePortalClient(TestData.MalinEmilie);
 
@@ -266,7 +266,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects 200 OK since the policy accepts both portal and system scopes.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsMalinWithSystemScope_Returns200Ok()
+    public async Task GetAuthorizedParties_AsManagingDirectorWithSystemScope_Returns200Ok()
     {
         var client = Fixture.Server.CreateClient();
         var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
@@ -285,7 +285,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Thea requests authorized parties and verifies the response deserializes correctly.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsThea_ReturnsValidPaginatedResult()
+    public async Task GetAuthorizedParties_ReturnsValidPaginatedResult()
     {
         HttpClient client = CreatePortalClient(TestData.Thea);
 
@@ -303,7 +303,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Validates roles and packages for all parties.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsAlexWithIncludeRolesAndPackages_ReturnsKaosAndDumboViaKeyRole()
+    public async Task GetAuthorizedParties_AsChairOfTheBoardWithKeyRoles_ReturnsRepresentedOrgAndAuditedOrgViaKeyRole()
     {
         HttpClient client = CreatePortalClient(TestData.AlexTheArtist);
 
@@ -338,7 +338,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects Kaos Magic Design and Arts to appear with instance rights for SiriusSkattemelding and MattilsynetBakeryService.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsJosephineWithIncludeInstances_ReturnsKaosWithInstances()
+    public async Task GetAuthorizedParties_AsInstanceRecipientWithIncludeInstances_ReturnsDelegatingOrgWithInstances()
     {
         HttpClient client = CreatePortalClient(TestData.JosephineYvonnesdottir);
 
@@ -362,7 +362,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Expects Kaos to appear but with empty instances list.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsJosephineWithoutIncludeInstances_ReturnsKaosWithoutInstances()
+    public async Task GetAuthorizedParties_AsInstanceRecipientWithoutIncludeInstances_ReturnsDelegatingOrgWithoutInstances()
     {
         HttpClient client = CreatePortalClient(TestData.JosephineYvonnesdottir);
 
@@ -384,7 +384,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// AuthorizedInstances should be empty since includeInstances is not set.
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsJosephineWithIncludeResources_ReturnsKaosWithResources()
+    public async Task GetAuthorizedParties_AsInstanceRecipientWithIncludeResources_ReturnsDelegatingOrgWithResources()
     {
         HttpClient client = CreatePortalClient(TestData.JosephineYvonnesdottir);
 
@@ -407,7 +407,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// Kaos should have both resources and instances populated (from seed).
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsJosephineWithIncludeResourcesAndInstances_ReturnsKaosWithBothResourcesAndInstances()
+    public async Task GetAuthorizedParties_AsInstanceRecipientWithIncludeResourcesAndInstances_ReturnsDelegatingOrgWithResourcesAndInstances()
     {
         HttpClient client = CreatePortalClient(TestData.JosephineYvonnesdottir);
 
@@ -435,7 +435,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// roles and access packages. Guards the hovedenhet/underenhet response contract (#3498 area 5).
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsPaulaForKarlstad_ReturnsSubunitNestedUnderMainUnitWithoutDuplicates()
+    public async Task GetAuthorizedParties_AsMainUnitManagingDirector_ReturnsSubunitNestedUnderMainUnitWithoutDuplicates()
     {
         HttpClient client = CreatePortalClient(TestEntities.PersonPaula);
 
@@ -497,7 +497,7 @@ public class AuthorizedPartiesControllerTest : IClassFixture<ApiFixture>
     /// hovedenhet/underenhet contract (#3498 area 5).
     /// </summary>
     [Fact]
-    public async Task GetAuthorizedParties_AsPaulaForKarlstad_SubunitDoesNotInheritMainUnitInstances()
+    public async Task GetAuthorizedParties_AsMainUnitManagingDirector_SubunitDoesNotInheritMainUnitInstances()
     {
         HttpClient client = CreatePortalClient(TestEntities.PersonPaula);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddAssignmentPackage.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddAssignmentPackage.cs
@@ -72,7 +72,7 @@ public partial class ConnectionsControllerTest
         /// Then verifies the package appears in GetPackages.
         /// </summary>
         [Fact]
-        public async Task AddAssignmentPackage_AsJinxForKaosToJosephine_ByPackageId_Returns200WithAssignmentPackage()
+        public async Task AddAssignmentPackage_AsManagingDirectorToRightholder_ByPackageId_Returns200WithAssignmentPackage()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 
@@ -106,7 +106,7 @@ public partial class ConnectionsControllerTest
         /// Expects 200 OK.
         /// </summary>
         [Fact]
-        public async Task AddAssignmentPackage_AsJinxForKaosToJosephine_ByPackageUrn_Returns200WithAssignmentPackage()
+        public async Task AddAssignmentPackage_AsManagingDirectorToRightholder_ByPackageUrn_Returns200WithAssignmentPackage()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddInstanceRights.cs
@@ -127,7 +127,7 @@ public partial class ConnectionsControllerTest
         /// - Each rule contains exactly one action
         /// </summary>
         [Fact]
-        public async Task AddInstanceRights_AsMalinForDumboToKaos_WithValidRightKeys_Returns201WithDelegatedInstanceRights()
+        public async Task AddInstanceRights_AsManagingDirectorToOrganization_WithValidRightKeys_Returns201WithDelegatedInstanceRights()
         {
             List<string> rightKeys = await GetDelegatableInstanceRightKeys("app_skd_sirius-skattemelding-v1", SiriusInstanceId);
             Assert.NotEmpty(rightKeys);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddResourceRights.cs
@@ -122,7 +122,7 @@ public partial class ConnectionsControllerTest
         /// Uses valid right keys obtained from delegation check. Expects 201 Created.
         /// </summary>
         [Fact]
-        public async Task AddResourceRights_AsMalinForDumboToMille_WithValidRightKeys_Returns201WithDelegatedResourceRights()
+        public async Task AddResourceRights_AsManagingDirectorToOrganization_WithValidRightKeys_Returns201WithDelegatedResourceRights()
         {
             List<string> rightKeys = await GetDelegatableRightKeys("app_skd_sirius-skattemelding-v1");
             Assert.NotEmpty(rightKeys);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddRightholder.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddRightholder.cs
@@ -78,7 +78,7 @@ public partial class ConnectionsControllerTest
         /// Persons require an existing connection; expects 400 BadRequest with EntityNotExists validation error.
         /// </summary>
         [Fact]
-        public async Task AddRightholder_AsMalinForDumboWithJosephine_ReturnsProblem()
+        public async Task AddRightholder_AsManagingDirectorForUnconnectedPerson_ReturnsProblem()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 
@@ -100,7 +100,7 @@ public partial class ConnectionsControllerTest
         /// Organizations do not require an existing connection; expects OK with AssignmentDto.
         /// </summary>
         [Fact]
-        public async Task AddRightholder_AsMalinForDumboWithMilleHundefrisor_Returns200WithAssignment()
+        public async Task AddRightholder_AsManagingDirectorForOrganization_Returns200WithAssignment()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 
@@ -122,7 +122,7 @@ public partial class ConnectionsControllerTest
         /// The mock UserProfileLookupService resolves Bodil by SSN; expects OK with AssignmentDto.
         /// </summary>
         [Fact]
-        public async Task AddRightholder_AsMalinForDumboWithBodilViaPersonInput_Returns200WithAssignment()
+        public async Task AddRightholder_AsManagingDirectorForPersonViaPersonInput_Returns200WithAssignment()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.CheckInstance.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.CheckInstance.cs
@@ -70,7 +70,7 @@ public partial class ConnectionsControllerTest
         /// instantiate, read, write, confirm across workflow stages).
         /// </summary>
         [Fact]
-        public async Task CheckInstance_AsMalinForDumbo_SiriusSkattemelding_ReturnsOkWithDelegatableRights()
+        public async Task CheckInstance_AsManagingDirector_SiriusSkattemelding_ReturnsOkWithDelegatableRights()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 
@@ -113,7 +113,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with delegatable rights (fewer than SiriusSkattemelding since the resource has fewer actions).
         /// </summary>
         [Fact]
-        public async Task CheckInstance_AsMalinForDumbo_MattilsynetBakery_ReturnsOkWithDelegatableRights()
+        public async Task CheckInstance_AsManagingDirector_MattilsynetBakery_ReturnsOkWithDelegatableRights()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.CheckPackage.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.CheckPackage.cs
@@ -52,7 +52,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with results for the requested packages.
         /// </summary>
         [Fact]
-        public async Task CheckPackage_AsMalinForDumbo_ByPackageIds_ReturnsOkWithResults()
+        public async Task CheckPackage_AsManagingDirector_ByPackageIds_ReturnsOkWithResults()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 
@@ -88,7 +88,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with results.
         /// </summary>
         [Fact]
-        public async Task CheckPackage_AsJinxForKaos_ByPackageUrns_ReturnsOkWithResults()
+        public async Task CheckPackage_AsManagingDirector_ByPackageUrns_ReturnsOkWithResults()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 
@@ -112,7 +112,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with a non-empty list.
         /// </summary>
         [Fact]
-        public async Task CheckPackage_AsMalinForDumbo_NoFilter_ReturnsOkWithAllDelegatablePackages()
+        public async Task CheckPackage_AsManagingDirector_NoFilter_ReturnsOkWithAllDelegatablePackages()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.DelegationCheckRoles.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.DelegationCheckRoles.cs
@@ -52,7 +52,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with role check results.
         /// </summary>
         [Fact]
-        public async Task DelegationCheckRoles_AsMalinForDumbo_ReturnsOkWithResults()
+        public async Task DelegationCheckRoles_AsManagingDirector_ReturnsOkWithResults()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetAvailableUsers.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetAvailableUsers.cs
@@ -76,7 +76,7 @@ public partial class ConnectionsControllerTest
         /// Tests that available users for Dumbo Adventures includes Thea when authenticated as Malin Emilie (managing director).
         /// </summary>
         [Fact]
-        public async Task GetAvailableUsers_AsMalinForDumbo_ContainsThea()
+        public async Task GetAvailableUsers_AsManagingDirector_ContainsRightholder()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstanceRights.cs
@@ -74,7 +74,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with direct rights (read, write from the delegation policy).
         /// </summary>
         [Fact]
-        public async Task GetInstanceRights_AsJinxForKaosToJosephine_SiriusSkattemelding_WithToOthersScope_ReturnsOkWithDirectRights()
+        public async Task GetInstanceRights_AsManagingDirectorToRightholder_SiriusSkattemelding_WithToOthersScope_ReturnsOkWithDirectRights()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -111,7 +111,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with the same direct rights.
         /// </summary>
         [Fact]
-        public async Task GetInstanceRights_AsJosephineFromKaos_SiriusSkattemelding_WithFromOthersScope_ReturnsOkWithDirectRights()
+        public async Task GetInstanceRights_AsRightholderFromOrganization_SiriusSkattemelding_WithFromOthersScope_ReturnsOkWithDirectRights()
         {
             HttpClient client = CreateClient(TestData.JosephineYvonnesdottir.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 
@@ -136,7 +136,7 @@ public partial class ConnectionsControllerTest
         /// The delegation policy grants only read, so fewer rights than SiriusSkattemelding.
         /// </summary>
         [Fact]
-        public async Task GetInstanceRights_AsJinxForKaosToJosephine_MattilsynetBakery_WithToOthersScope_ReturnsOkWithDirectRights()
+        public async Task GetInstanceRights_AsManagingDirectorToRightholder_MattilsynetBakery_WithToOthersScope_ReturnsOkWithDirectRights()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -161,7 +161,7 @@ public partial class ConnectionsControllerTest
         /// Expects 403 Forbidden.
         /// </summary>
         [Fact]
-        public async Task GetInstanceRights_AsJosephineFromKaos_WithToOthersScope_Returns403ForToOthersScopeOnFromOthersDirection()
+        public async Task GetInstanceRights_AsRightholderFromOrganization_WithToOthersScope_Returns403ForToOthersScopeOnFromOthersDirection()
         {
             HttpClient client = CreateClient(TestData.JosephineYvonnesdottir.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -177,7 +177,7 @@ public partial class ConnectionsControllerTest
         /// Expects 403 Forbidden.
         /// </summary>
         [Fact]
-        public async Task GetInstanceRights_AsJinxForKaosToJosephine_WithFromOthersScope_Returns403ForFromOthersScopeOnToOthersDirection()
+        public async Task GetInstanceRights_AsManagingDirectorToRightholder_WithFromOthersScope_Returns403ForFromOthersScopeOnToOthersDirection()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstanceUsers.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstanceUsers.cs
@@ -72,7 +72,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with Josephine listed as a user with access.
         /// </summary>
         [Fact]
-        public async Task GetInstanceUsers_AsJinxForKaos_SiriusSkattemelding_ReturnsJosephine()
+        public async Task GetInstanceUsers_AsManagingDirector_SiriusSkattemelding_ReturnsRightholder()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 
@@ -99,7 +99,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with Josephine listed (same rightholder, different resource instance).
         /// </summary>
         [Fact]
-        public async Task GetInstanceUsers_AsJinxForKaos_MattilsynetBakery_ReturnsJosephine()
+        public async Task GetInstanceUsers_AsManagingDirector_MattilsynetBakery_ReturnsRightholder()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 
@@ -121,7 +121,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with an empty list.
         /// </summary>
         [Fact]
-        public async Task GetInstanceUsers_AsJinxForKaos_NonExistentInstance_ReturnsEmptyList()
+        public async Task GetInstanceUsers_AsManagingDirector_NonExistentInstance_ReturnsEmptyList()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_WRITE);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstances.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetInstances.cs
@@ -69,7 +69,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with both SiriusSkattemelding and MattilsynetBakeryService instances.
         /// </summary>
         [Fact]
-        public async Task GetInstances_AsJinxForKaosToJosephine_WithToOthersScope_Returns200WithDelegatedInstances()
+        public async Task GetInstances_AsManagingDirectorToRightholder_WithToOthersScope_Returns200WithDelegatedInstances()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -91,7 +91,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK (Josephine has no instances delegated toward Kaos, so the list may be empty).
         /// </summary>
         [Fact]
-        public async Task GetInstances_AsJinxForKaosFromJosephine_WithFromOthersScope_Returns200WithEmptyList()
+        public async Task GetInstances_AsManagingDirectorFromRightholder_WithFromOthersScope_Returns200WithEmptyList()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 
@@ -111,7 +111,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with both SiriusSkattemelding and MattilsynetBakeryService instances.
         /// </summary>
         [Fact]
-        public async Task GetInstances_AsJosephineFromKaos_WithFromOthersScope_Returns200WithReceivedInstances()
+        public async Task GetInstances_AsRightholderFromOrganization_WithFromOthersScope_Returns200WithReceivedInstances()
         {
             HttpClient client = CreateClient(TestData.JosephineYvonnesdottir.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 
@@ -133,7 +133,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK (no instances delegated in this direction).
         /// </summary>
         [Fact]
-        public async Task GetInstances_AsJosephineToKaos_WithToOthersScope_Returns200Ok()
+        public async Task GetInstances_AsRightholderToOrganization_WithToOthersScope_Returns200Ok()
         {
             HttpClient client = CreateClient(TestData.JosephineYvonnesdottir.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -148,7 +148,7 @@ public partial class ConnectionsControllerTest
         /// Expects 403 Forbidden.
         /// </summary>
         [Fact]
-        public async Task GetInstances_AsJosephineFromKaos_WithToOthersScope_Returns403ForToOthersScopeOnFromOthersDirection()
+        public async Task GetInstances_AsRightholderFromOrganization_WithToOthersScope_Returns403ForToOthersScopeOnFromOthersDirection()
         {
             HttpClient client = CreateClient(TestData.JosephineYvonnesdottir.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -162,7 +162,7 @@ public partial class ConnectionsControllerTest
         /// Expects 403 Forbidden.
         /// </summary>
         [Fact]
-        public async Task GetInstances_AsJinxForKaosToJosephine_WithFromOthersScope_Returns403ForFromOthersScopeOnToOthersDirection()
+        public async Task GetInstances_AsManagingDirectorToRightholder_WithFromOthersScope_Returns403ForFromOthersScopeOnToOthersDirection()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 
@@ -206,7 +206,7 @@ public partial class ConnectionsControllerTest
         /// Only SiriusSkattemelding instances should be returned, not MattilsynetBakeryService.
         /// </summary>
         [Fact]
-        public async Task GetInstances_AsJinxForKaosToJosephine_FilterByResource_ReturnsOnlyMatchingResource()
+        public async Task GetInstances_AsManagingDirectorToRightholder_FilterByResource_ReturnsOnlyMatchingResource()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetPackages.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetPackages.cs
@@ -63,7 +63,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with the SalarySpecialCategory package.
         /// </summary>
         [Fact]
-        public async Task GetPackages_AsMalinForDumboToThea_WithToOthersScope_ReturnsOkWithPackage()
+        public async Task GetPackages_AsManagingDirectorToRightholder_WithToOthersScope_ReturnsOkWithPackage()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -94,7 +94,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with the same SalarySpecialCategory package.
         /// </summary>
         [Fact]
-        public async Task GetPackages_AsTheaFromDumbo_WithFromOthersScope_ReturnsOkWithPackage()
+        public async Task GetPackages_AsRightholderFromOrganization_WithFromOthersScope_ReturnsOkWithPackage()
         {
             HttpClient client = CreateClient(TestData.Thea.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 
@@ -116,7 +116,7 @@ public partial class ConnectionsControllerTest
         /// No packages are assigned to this connection, so the list should be empty.
         /// </summary>
         [Fact]
-        public async Task GetPackages_AsMalinForDumboToMille_WithToOthersScope_ReturnsOkEmpty()
+        public async Task GetPackages_AsManagingDirectorToOrganization_WithToOthersScope_ReturnsOkEmpty()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -137,7 +137,7 @@ public partial class ConnectionsControllerTest
         /// Expects 403 Forbidden.
         /// </summary>
         [Fact]
-        public async Task GetPackages_AsTheaFromDumbo_WithToOthersScope_Returns403ForToOthersScopeOnFromOthersDirection()
+        public async Task GetPackages_AsRightholderFromOrganization_WithToOthersScope_Returns403ForToOthersScopeOnFromOthersDirection()
         {
             HttpClient client = CreateClient(TestData.Thea.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -153,7 +153,7 @@ public partial class ConnectionsControllerTest
         /// Expects 403 Forbidden.
         /// </summary>
         [Fact]
-        public async Task GetPackages_AsMalinForDumboToThea_WithFromOthersScope_Returns403ForFromOthersScopeOnToOthersDirection()
+        public async Task GetPackages_AsManagingDirectorToRightholder_WithFromOthersScope_Returns403ForFromOthersScopeOnToOthersDirection()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetResourceRights.cs
@@ -96,7 +96,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with a valid response containing the resource.
         /// </summary>
         [Fact]
-        public async Task GetResourceRights_AsMalinForDumboToMille_WithToOthersScope_Returns200WithDirectRights()
+        public async Task GetResourceRights_AsManagingDirectorToOrganization_WithToOthersScope_Returns200WithDirectRights()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -135,7 +135,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with a valid response containing the resource.
         /// </summary>
         [Fact]
-        public async Task GetResourceRights_AsTheaForMilleFromDumbo_WithFromOthersScope_Returns200WithDirectRights()
+        public async Task GetResourceRights_AsManagingDirectorFromOtherOrganization_WithFromOthersScope_Returns200WithDirectRights()
         {
             HttpClient client = CreateClient(TestData.Thea.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 
@@ -176,7 +176,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with 9 IndirectRights (KeyRole reason), no DirectRights.
         /// </summary>
         [Fact]
-        public async Task GetResourceRights_AsMalinForDumboToThea_WithToOthersScope_Returns200WithKeyRoleIndirectRights()
+        public async Task GetResourceRights_AsManagingDirectorToRightholder_WithToOthersScope_Returns200WithKeyRoleIndirectRights()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -216,7 +216,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with 9 IndirectRights (KeyRole reason), no DirectRights.
         /// </summary>
         [Fact]
-        public async Task GetResourceRights_AsMalinForDumboToMilena_WithToOthersScope_Returns200WithKeyRoleIndirectRights()
+        public async Task GetResourceRights_AsManagingDirectorToKeyRolePerson_WithToOthersScope_Returns200WithKeyRoleIndirectRights()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -257,7 +257,7 @@ public partial class ConnectionsControllerTest
         /// Note: method name says "ToOthers" but the query is actually from-others (party=Thea, from=Dumbo, to=Thea).
         /// </summary>
         [Fact]
-        public async Task GetResourceRights_AsTheaForDumboToThea_WithToOthersScope_Returns200WithKeyRoleIndirectRights()
+        public async Task GetResourceRights_AsRightholderViaKeyRoleToSelf_WithToOthersScope_Returns200WithKeyRoleIndirectRights()
         {
             HttpClient client = CreateClient(TestData.Thea.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetResources.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetResources.cs
@@ -94,7 +94,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with both Skattemelding and MVA-melding resources.
         /// </summary>
         [Fact]
-        public async Task GetResources_AsMalinForDumboToMille_WithToOthersScope_Returns200WithDelegatedResources()
+        public async Task GetResources_AsManagingDirectorToOrganization_WithToOthersScope_Returns200WithDelegatedResources()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -116,7 +116,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK (Mille has no resources delegated toward Dumbo, so the list may be empty).
         /// </summary>
         [Fact]
-        public async Task GetResources_AsMalinForDumboFromMille_WithFromOthersScope_Returns200Ok()
+        public async Task GetResources_AsManagingDirectorFromOtherOrganization_WithFromOthersScope_Returns200Ok()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 
@@ -131,7 +131,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with both Skattemelding and MVA-melding resources.
         /// </summary>
         [Fact]
-        public async Task GetResources_AsTheaForMilleFromDumbo_WithFromOthersScope_Returns200WithReceivedResources()
+        public async Task GetResources_AsManagingDirectorFromOtherOrganization_WithFromOthersScope_Returns200WithReceivedResources()
         {
             HttpClient client = CreateClient(TestData.Thea.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 
@@ -153,7 +153,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK (no resources delegated in this direction).
         /// </summary>
         [Fact]
-        public async Task GetResources_AsTheaForMilleToDumbo_WithToOthersScope_Returns200Ok()
+        public async Task GetResources_AsManagingDirectorToOtherOrganization_WithToOthersScope_Returns200Ok()
         {
             HttpClient client = CreateClient(TestData.Thea.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -168,7 +168,7 @@ public partial class ConnectionsControllerTest
         /// Expects 403 Forbidden.
         /// </summary>
         [Fact]
-        public async Task GetResources_AsTheaForMilleFromDumbo_WithToOthersScope_Returns403ForToOthersScopeOnFromOthersDirection()
+        public async Task GetResources_AsManagingDirectorFromOtherOrganization_WithToOthersScope_Returns403ForToOthersScopeOnFromOthersDirection()
         {
             HttpClient client = CreateClient(TestData.Thea.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetRoles.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.GetRoles.cs
@@ -65,7 +65,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with ManagingDirector (DAGL) role and correct permission structure.
         /// </summary>
         [Fact]
-        public async Task GetRoles_AsMalinForDumboToMalin_WithToOthersScope_ReturnsOkWithDaglRole()
+        public async Task GetRoles_AsManagingDirectorToSelf_WithToOthersScope_ReturnsOkWithDaglRole()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -97,7 +97,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with Rightholder role.
         /// </summary>
         [Fact]
-        public async Task GetRoles_AsMalinForDumboToThea_WithToOthersScope_ReturnsOkWithRightholderRole()
+        public async Task GetRoles_AsManagingDirectorToRightholder_WithToOthersScope_ReturnsOkWithRightholderRole()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -121,7 +121,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with Rightholder role.
         /// </summary>
         [Fact]
-        public async Task GetRoles_AsTheaFromDumbo_WithFromOthersScope_ReturnsOkWithRightholderRole()
+        public async Task GetRoles_AsRightholderFromOrganization_WithFromOthersScope_ReturnsOkWithRightholderRole()
         {
             HttpClient client = CreateClient(TestData.Thea.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 
@@ -143,7 +143,7 @@ public partial class ConnectionsControllerTest
         /// Expects OK with Rightholder role.
         /// </summary>
         [Fact]
-        public async Task GetRoles_AsJinxForKaosToJosephine_WithToOthersScope_ReturnsOkWithRightholderRole()
+        public async Task GetRoles_AsManagingDirectorToInheritedRightholder_WithToOthersScope_ReturnsOkWithRightholderRole()
         {
             HttpClient client = CreateClient(TestData.JinxArcane.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -258,7 +258,7 @@ public partial class ConnectionsControllerTest
         /// Expects 403 Forbidden.
         /// </summary>
         [Fact]
-        public async Task GetRoles_AsTheaFromDumbo_WithToOthersScope_Returns403ForToOthersScopeOnFromOthersDirection()
+        public async Task GetRoles_AsRightholderFromOrganization_WithToOthersScope_Returns403ForToOthersScopeOnFromOthersDirection()
         {
             HttpClient client = CreateClient(TestData.Thea.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);
 
@@ -274,7 +274,7 @@ public partial class ConnectionsControllerTest
         /// Expects 403 Forbidden.
         /// </summary>
         [Fact]
-        public async Task GetRoles_AsMalinForDumboToMalin_WithFromOthersScope_Returns403ForFromOthersScopeOnToOthersDirection()
+        public async Task GetRoles_AsManagingDirectorToSelf_WithFromOthersScope_Returns403ForFromOthersScopeOnToOthersDirection()
         {
             HttpClient client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_FROMOTHERS_READ);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemoveAssignment.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemoveAssignment.cs
@@ -126,7 +126,7 @@ public partial class ConnectionsControllerTest
         /// - GetConnections no longer lists BakerJohnsen as a connection from Dumbo
         /// </summary>
         [Fact]
-        public async Task RemoveAssignment_AsMalinFromDumboToBaker_Returns204NoContent()
+        public async Task RemoveAssignment_AsManagingDirectorToConnectedParty_Returns204NoContent()
         {
             // Verify connection exists before removal
             HttpClient readClient = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_CONNECTIONS_TOOTHERS_READ);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemoveInstance.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemoveInstance.cs
@@ -120,7 +120,7 @@ public partial class ConnectionsControllerTest
         /// - Instance is gone after delete (via GetInstances)
         /// </summary>
         [Fact]
-        public async Task RemoveInstance_AsMalinForDumboToKaos_ReturnsNoContentAndRemovesInstance()
+        public async Task RemoveInstance_AsManagingDirectorToOrganization_ReturnsNoContentAndRemovesInstance()
         {
             List<string> rightKeys = await GetDelegatableInstanceRightKeys("app_skd_sirius-skattemelding-v1", SiriusInstanceIdForRemove);
             Assert.NotEmpty(rightKeys);
@@ -164,7 +164,7 @@ public partial class ConnectionsControllerTest
         /// Expects 204 NoContent.
         /// </summary>
         [Fact]
-        public async Task RemoveInstance_AsJinxForKaosFromDumbo_WithFromOthersWriteScope_Returns204NoContent()
+        public async Task RemoveInstance_AsManagingDirectorFromOtherOrganization_WithFromOthersWriteScope_Returns204NoContent()
         {
             List<string> rightKeys = await GetDelegatableInstanceRightKeys("app_mat_mattilsynet-baker-konditorvare", MattilsynetInstanceIdForRemove);
             Assert.NotEmpty(rightKeys);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemovePackages.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemovePackages.cs
@@ -88,7 +88,7 @@ public partial class ConnectionsControllerTest
         /// - Package is gone after removal
         /// </summary>
         [Fact]
-        public async Task RemovePackages_AsJinxByPackageId_ReturnsNoContentAndRemovesPackage()
+        public async Task RemovePackages_AsManagingDirectorByPackageId_ReturnsNoContentAndRemovesPackage()
         {
             Guid packageId = PackageConstants.AccountingAndEconomicReporting.Id;
             await AddPackage(packageId);
@@ -112,7 +112,7 @@ public partial class ConnectionsControllerTest
         /// Expects 204 NoContent.
         /// </summary>
         [Fact]
-        public async Task RemovePackages_AsJosephineByPackageUrn_FromOthersDirection_Returns204NoContent()
+        public async Task RemovePackages_AsRightholderByPackageUrn_FromOthersDirection_Returns204NoContent()
         {
             Guid packageId = PackageConstants.Customs.Id;
             await AddPackage(packageId);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemoveResource.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.RemoveResource.cs
@@ -139,7 +139,7 @@ public partial class ConnectionsControllerTest
         /// First adds the delegation, then removes it. Expects 204 NoContent.
         /// </summary>
         [Fact]
-        public async Task RemoveResource_AsMalinForDumboFromDumboToMille_Returns204NoContent()
+        public async Task RemoveResource_AsManagingDirectorToOrganization_Returns204NoContent()
         {
             List<string> rightKeys = await GetDelegatableRightKeys("nav_sykepenger_sykmelding");
             Assert.NotEmpty(rightKeys);
@@ -160,7 +160,7 @@ public partial class ConnectionsControllerTest
         /// acting as receiver (from-others direction). Expects 204 NoContent.
         /// </summary>
         [Fact]
-        public async Task RemoveResource_AsTheaForMilleFromDumboToMille_Returns204NoContent()
+        public async Task RemoveResource_AsManagingDirectorFromOtherOrganization_Returns204NoContent()
         {
             List<string> rightKeys = await GetDelegatableRightKeys("nav_sykepenger_sykmelding");
             Assert.NotEmpty(rightKeys);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateInstanceRights.cs
@@ -141,7 +141,7 @@ public partial class ConnectionsControllerTest
         /// - Written XACML policy matches the updated right keys
         /// </summary>
         [Fact]
-        public async Task UpdateInstanceRights_AsJinxToThea_WithMoreRightKeys_ReturnsOkAndUpdatesRights()
+        public async Task UpdateInstanceRights_AsManagingDirectorToRecipient_WithMoreRightKeys_ReturnsOkAndUpdatesRights()
         {
             List<string> allRightKeys = await GetDelegatableInstanceRightKeys("app_skd_sirius-skattemelding-v1", SiriusInstanceIdForUpdate);
             Assert.True(allRightKeys.Count >= 2, $"Expected at least 2 delegatable right keys, but got {allRightKeys.Count}");
@@ -303,7 +303,7 @@ public partial class ConnectionsControllerTest
         /// resource to avoid shared state collisions.
         /// </summary>
         [Fact]
-        public async Task UpdateInstanceRights_AsAlexToMilena_ReduceRights_RemovesExcessRights()
+        public async Task UpdateInstanceRights_AsChairOfTheBoardToRecipient_ReduceRights_RemovesExcessRights()
         {
             const string instanceIdForReduce = "urn:altinn:instance-id:50401002/e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8092";
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateResourceRights.cs
@@ -139,7 +139,7 @@ public partial class ConnectionsControllerTest
         /// Uses valid right keys obtained from delegation check. Expects 200 OK.
         /// </summary>
         [Fact]
-        public async Task UpdateResourceRights_AsMalinForDumboToMille_WithValidRightKeys_Returns200WithUpdatedResourceRights()
+        public async Task UpdateResourceRights_AsManagingDirectorToOrganization_WithValidRightKeys_Returns200WithUpdatedResourceRights()
         {
             List<string> rightKeys = await GetDelegatableRightKeys("app_mat_mattilsynet-baker-konditorvare");
             Assert.NotEmpty(rightKeys);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
@@ -53,7 +53,7 @@ public class AuthorizedPartiesControllerTest
         public ApiFixture Fixture { get; }
 
         [Fact]
-        public async Task GetAuthorizedParties_ForDagligLeder_UsingNewRoute_ReturnsOkWithDumboAdventuresAsDagl()
+        public async Task GetAuthorizedParties_ForDagligLeder_UsingNewRoute_ReturnsRepresentedOrgWithDaglRole()
         {
             // Arrange: NAV is a registered tjenesteier asking on behalf of Malin Emilie (DAGL of Dumbo Adventures)
             var client = CreateServiceOwnerClient(Fixture, TestData.NAV.Entity.OrganizationIdentifier);
@@ -85,7 +85,7 @@ public class AuthorizedPartiesControllerTest
         }
 
         [Fact]
-        public async Task GetAuthorizedParties_ForDagligLeder_UsingOldRoute_ReturnsOkWithDumboAdventuresAsDagl()
+        public async Task GetAuthorizedParties_ForDagligLeder_UsingOldRoute_ReturnsRepresentedOrgWithDaglRole()
         {
             // Arrange: NAV is a registered tjenesteier asking on behalf of Malin Emilie (DAGL of Dumbo Adventures)
             var client = CreateServiceOwnerClient(Fixture, TestData.NAV.Entity.OrganizationIdentifier);

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
@@ -53,7 +53,7 @@ public class AuthorizedPartiesControllerTest
         public ApiFixture Fixture { get; }
 
         [Fact]
-        public async Task GetAuthorizedParties_ForDagligLeder_UsingNewRoute_ReturnsRepresentedOrgWithDaglRole()
+        public async Task GetAuthorizedParties_ForDagligLeder_UsingNewRoute_Returns200WithRepresentedOrgWithDaglRole()
         {
             // Arrange: NAV is a registered tjenesteier asking on behalf of Malin Emilie (DAGL of Dumbo Adventures)
             var client = CreateServiceOwnerClient(Fixture, TestData.NAV.Entity.OrganizationIdentifier);
@@ -85,7 +85,7 @@ public class AuthorizedPartiesControllerTest
         }
 
         [Fact]
-        public async Task GetAuthorizedParties_ForDagligLeder_UsingOldRoute_ReturnsRepresentedOrgWithDaglRole()
+        public async Task GetAuthorizedParties_ForDagligLeder_UsingOldRoute_Returns200WithRepresentedOrgWithDaglRole()
         {
             // Arrange: NAV is a registered tjenesteier asking on behalf of Malin Emilie (DAGL of Dumbo Adventures)
             var client = CreateServiceOwnerClient(Fixture, TestData.NAV.Entity.OrganizationIdentifier);


### PR DESCRIPTION
Closes #3573. Part of #3486 (Phase 3).

Many integration tests embed opaque seed-actor names in the method name (Malin, Thea, Jinx, Alex, Josephine, Paula; orgs like Dumbo, Kaos, Mille, Karlstad), which are meaningless without knowing the seed data and make a failing test hard to read.

This renames them to role/scenario-based names per the repo convention (`Method_Condition_Returns{Status}With{Outcome}`): the acting user becomes its role (managing director, rightholder, chair of the board, instance recipient, main-unit managing director) and specific seed entities move out of the name. The seed actors stay in the arrange code and the doc-comments, so the link to the concrete data is preserved.

Done in per-project batches, keeping the suite green:
- [x] AuthorizedParties (Enduser + ServiceOwner)
- [x] ConnectionsController (Enduser)

No behaviour change; method renames only.
