### PR TITLE
Improve repo and component READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Open [`http://localhost:8000`](http://localhost:8000) and log in with
 
 ## Documentation
 
-- [Testing guide](docs/testing/README.md) — how the test suite is organised and run.
-- [SonarCloud](docs/SONARCLOUD.md) — static analysis, exclusions, and the quality gate.
+- [Testing guide](docs/testing/README.md): how the test suite is organised and run.
+- [SonarCloud](docs/SONARCLOUD.md): static analysis, exclusions, and the quality gate.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ resources, and API schemes.
 | `src/apps/Altinn.AccessManagement` | Access Management app: rights and delegation administration. |
 | `src/apps/Altinn.Register` | Vendored copy of Register, maintained in [altinn-register](https://github.com/Altinn/altinn-register). |
 | `src/libs` | Shared libraries (`Api.Contracts`, `Host`, `Integration`). |
-| `src/pkgs` | Published NuGet packages (`Altinn.Authorization.ABAC`, `Altinn.Authorization.PEP`). |
+| `src/pkgs` | Published NuGet packages (`Altinn.Authorization.ABAC`, `Altinn.Common.PEP`). |
 | `src/tools` | The `Altinn.Authorization.Cli` command-line tool. |
 | `docs` | Documentation (see [Documentation](#documentation)). |
 | `eng` | Build, test, and coverage scripts. |
@@ -35,7 +35,7 @@ resources, and API schemes.
 
 ### Prerequisites
 
-- [.NET SDK 10.0](https://dotnet.microsoft.com/download/dotnet/10.0) (the full build also installs 9.0)
+- [.NET SDK 10.0](https://dotnet.microsoft.com/download/dotnet/10.0)
 - A container runtime, [Docker](https://www.docker.com/get-docker) or [Podman](https://podman.io), for integration tests and local services
 - [PowerShell 7+](https://learn.microsoft.com/powershell/scripting/install/installing-powershell)
 - [Just](https://github.com/casey/just) for the local-development commands

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ az login
 
 ### 2. Start dependencies and configure secrets
 
+Replace `<subscription-id>` and `<key-vault-name>` with the values for your Azure
+environment.
+
 ```bash
 just dev   # starts PostgreSQL and supporting services via the container runtime
 
@@ -87,11 +90,11 @@ dotnet user-secrets set "PostgreSQLSettings:AuthorizationDbAdminPwd" admin --id 
 dotnet user-secrets set "PostgreSQLSettings:ConnectionString" $(just dev-pgsql-connection-string) --id Altinn.Authorization
 dotnet user-secrets set "PostgreSQLSettings:AuthorizationDbPwd" admin --id Altinn.Authorization
 
-az account set --subscription 45177a0a-d27e-490f-9f23-b4726de8ccc1
+az account set --subscription <subscription-id>
 
-dotnet user-secrets set "Platform:Token:TestTool:Endpoint" $(az keyvault secret show --id=https://rgaltinnauth001local.vault.azure.net/secrets/Platform--Token--TestTool--Endpoint --query value --output tsv) --id Altinn.Authorization
-dotnet user-secrets set "Platform:Token:TestTool:Password" $(az keyvault secret show --id=https://rgaltinnauth001local.vault.azure.net/secrets/Platform--Token--TestTool--Password --query value --output tsv) --id Altinn.Authorization
-dotnet user-secrets set "Platform:Token:TestTool:Username" $(az keyvault secret show --id=https://rgaltinnauth001local.vault.azure.net/secrets/Platform--Token--TestTool--Username --query value --output tsv) --id Altinn.Authorization
+dotnet user-secrets set "Platform:Token:TestTool:Endpoint" $(az keyvault secret show --id=https://<key-vault-name>.vault.azure.net/secrets/Platform--Token--TestTool--Endpoint --query value --output tsv) --id Altinn.Authorization
+dotnet user-secrets set "Platform:Token:TestTool:Password" $(az keyvault secret show --id=https://<key-vault-name>.vault.azure.net/secrets/Platform--Token--TestTool--Password --query value --output tsv) --id Altinn.Authorization
+dotnet user-secrets set "Platform:Token:TestTool:Username" $(az keyvault secret show --id=https://<key-vault-name>.vault.azure.net/secrets/Platform--Token--TestTool--Username --query value --output tsv) --id Altinn.Authorization
 ```
 
 ### 3. Bootstrap the database

--- a/README.md
+++ b/README.md
@@ -9,68 +9,115 @@ _SonarCloud quality metrics for `main`, refreshed by the [nightly scan](docs/SON
 
 </div>
 
-# Authorization
+# Altinn Authorization
 
-## Local Development Environment
+Authorization and access management for the Altinn 3 platform. This repository
+holds the Policy Decision Point (PDP) and Policy Enforcement Point (PEP) that
+authorize users, systems, and organizations accessing the platform, together with
+the Access Management services that administer rights and delegations for apps,
+resources, and API schemes.
+
+## Repository structure
+
+| Path | Contents |
+| --- | --- |
+| `src/apps/Altinn.Authorization` | Authorization app: access control (PDP) and policy enforcement (PEP). |
+| `src/apps/Altinn.AccessManagement` | Access Management app: rights and delegation administration. |
+| `src/apps/Altinn.Register` | Vendored copy of Register, maintained in [altinn-register](https://github.com/Altinn/altinn-register). |
+| `src/libs` | Shared libraries (`Api.Contracts`, `Host`, `Integration`). |
+| `src/pkgs` | Published NuGet packages (`Altinn.Authorization.ABAC`, `Altinn.Authorization.PEP`). |
+| `src/tools` | The `Altinn.Authorization.Cli` command-line tool. |
+| `docs` | Documentation (see [Documentation](#documentation)). |
+| `eng` | Build, test, and coverage scripts. |
+| `infra` | Infrastructure as code. |
+
+## Getting started
 
 ### Prerequisites
 
-Ensure you have the following languages and tools installed before setting up your development environment.
+- [.NET SDK 10.0](https://dotnet.microsoft.com/download/dotnet/10.0) (the full build also installs 9.0)
+- A container runtime, [Docker](https://www.docker.com/get-docker) or [Podman](https://podman.io), for integration tests and local services
+- [PowerShell 7+](https://learn.microsoft.com/powershell/scripting/install/installing-powershell)
+- [Just](https://github.com/casey/just) for the local-development commands
 
-#### Languages
-- .NET 10.0 & 9.0
-- TypeScript
+### Build and test
 
-#### Tools
-- [Just](https://github.com/casey/just?tab=readme-ov-file#installation)
-- [Docker Desktop Windows](http://docs.docker.com/desktop/setup/install/windows-install/)
-- [Docker Engine Linux](https://docs.docker.com/engine/install/)
-- [Docker Compose Linux](https://docs.docker.com/compose/install/)
-- [Docker Compose Windows](https://podman-desktop.io/docs/compose/setting-up-compose)
-- [Azure CLI (az)](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/)
-- [kubelogin](https://azure.github.io/kubelogin/install.html)
-- [powershell core](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.5)
+```bash
+dotnet build Altinn.Authorization.sln
+dotnet test                                          # unit + integration
+dotnet test -- --filter-trait "Category=Unit"        # unit tests only
+```
 
-### Setting Up the Environment
+Integration tests need a running container runtime. See the
+[testing guide](docs/testing/README.md) for the full picture.
 
-#### Authenticate with Azure
-Before executing the setup commands, log in using Azure CLI with the appropriate user:
+### Run an app
+
+```bash
+dotnet run --project src/apps/Altinn.Authorization/src/Altinn.Authorization
+dotnet run --project src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement
+```
+
+Each app exposes a Swagger UI on startup. Running against a real database needs
+the local-development setup below.
+
+## Local Development Environment
+
+Additional tooling for working against Azure-backed dependencies:
+[Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli),
+[kubectl](https://kubernetes.io/docs/tasks/tools/),
+[kubelogin](https://azure.github.io/kubelogin/install.html).
+
+### 1. Sign in to Azure
+
+Sign in with your `ai-dev` or `ai-prod` account so the test-tool secrets can be
+fetched:
 
 ```bash
 az login
 ```
 
-Use your `ai-dev` or `ai-prod` user.
-
-#### Configure Dependencies
-Run the following commands to initialize the development environment:
+### 2. Start dependencies and configure secrets
 
 ```bash
-just dev
-
-# Set up PostgreSQL secrets
+just dev   # starts PostgreSQL and supporting services via the container runtime
 
 dotnet user-secrets set "PostgreSQLSettings:AdminConnectionString" $(just dev-pgsql-connection-string) --id Altinn.Authorization
 dotnet user-secrets set "PostgreSQLSettings:AuthorizationDbAdminPwd" admin --id Altinn.Authorization
 dotnet user-secrets set "PostgreSQLSettings:ConnectionString" $(just dev-pgsql-connection-string) --id Altinn.Authorization
 dotnet user-secrets set "PostgreSQLSettings:AuthorizationDbPwd" admin --id Altinn.Authorization
 
-# Set Azure subscription
 az account set --subscription 45177a0a-d27e-490f-9f23-b4726de8ccc1
 
-# Configure Platform Token Test Tool credentials
 dotnet user-secrets set "Platform:Token:TestTool:Endpoint" $(az keyvault secret show --id=https://rgaltinnauth001local.vault.azure.net/secrets/Platform--Token--TestTool--Endpoint --query value --output tsv) --id Altinn.Authorization
 dotnet user-secrets set "Platform:Token:TestTool:Password" $(az keyvault secret show --id=https://rgaltinnauth001local.vault.azure.net/secrets/Platform--Token--TestTool--Password --query value --output tsv) --id Altinn.Authorization
 dotnet user-secrets set "Platform:Token:TestTool:Username" $(az keyvault secret show --id=https://rgaltinnauth001local.vault.azure.net/secrets/Platform--Token--TestTool--Username --query value --output tsv) --id Altinn.Authorization
 ```
 
-### Bootstrap Access Management
+### 3. Bootstrap the database
 
-1. Open [`http://localhost:8000`](http://localhost:8000) in a browser.
-2. Log in using:
-   - **Username:** `admin@admin.com`
-   - **Password:** `admin`
-3. Create the `authorizationdb` database and configure roles:
-   - **Role:** `platform_authorization` (Privileges: `can_login`)
-   - **Role:** `platform_authorization_admin` (Privileges: `can_login`, `superuser`)
+Open [`http://localhost:8000`](http://localhost:8000) and log in with
+`admin@admin.com` / `admin`, then:
+
+1. Create the `authorizationdb` database.
+2. Create two login roles with privileges on it:
+   - `platform_authorization` (`can_login`)
+   - `platform_authorization_admin` (`can_login`, `superuser`)
+
+## Documentation
+
+- [Testing guide](docs/testing/README.md) — how the test suite is organised and run.
+- [SonarCloud](docs/SONARCLOUD.md) — static analysis, exclusions, and the quality gate.
+
+## Contributing
+
+Open a pull request against `main`. CI builds and tests the verticals affected
+by your change.
+
+## Security
+
+Report security vulnerabilities as described in [SECURITY.md](SECURITY.md).
+
+## License
+
+Licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ dotnet user-secrets set "Platform:Token:TestTool:Username" $(az keyvault secret 
 2. Log in using:
    - **Username:** `admin@admin.com`
    - **Password:** `admin`
-3. Create the `accessmgmt` database and configure roles:
+3. Create the `authorizationdb` database and configure roles:
    - **Role:** `platform_authorization` (Privileges: `can_login`)
    - **Role:** `platform_authorization_admin` (Privileges: `can_login`, `superuser`)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _SonarCloud quality metrics for `main`, refreshed by the [nightly scan](docs/SON
 Ensure you have the following languages and tools installed before setting up your development environment.
 
 #### Languages
-- .NET 9.0 & 8.0
+- .NET 10.0 & 9.0
 - TypeScript
 
 #### Tools

--- a/src/apps/Altinn.AccessManagement/README.md
+++ b/src/apps/Altinn.AccessManagement/README.md
@@ -1,45 +1,28 @@
-# altinn-access-management
+# Altinn Access Management
 
-This component will handle backend functionality related to Access Management
-- Administration of rights for apps, resources
-- Administration of rights for api schemes
+Backend functionality for Access Management:
+- Administration of rights for apps and resources
+- Administration of rights for API schemes
 
 ## Getting started
 
-The fastest way to get development going is to open the main solution Altinn.AccessManagement.sln and selecting 'Altinn.AccessManagement' as the start up project from Visual Studio. Browser should open automatically to the swagger ui for the API.
+Open `Altinn.AccessManagement.sln` and run the `Altinn.AccessManagement` project
+(the browser opens the Swagger UI automatically).
 
-Alternatively:
+Or from the command line:
 
-- Start the backend in `/src/Altinn.AccessManagement/Altinn.AccessManagement` with `dotnet run` or `dotnet watch`
+```bash
+dotnet run --project src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement
+```
 
-## Project organisation
+## Setting up the database
 
-This is a typical backend API solution written in .NET C#.
+Access Management needs a local PostgreSQL (Azure runs 14; 15 works locally).
 
-- The main back end project is in `/src/Altinn.Authorizationadmin` and it has [its own README](backend/src/Altinn.Authorizationadmin/Altinn.Authorizationadmin/README.md)
-
-- There is also a "bridge" between the back end and older APIs. For local development, this is implemented in `/development/src/LocalBridge`
-
-
-## Setting up database
-
-To run Access Management locally you need to have PostgreSQL database installed
-
-- Download [PostgreSQL](https://www.postgresql.org/download/) (Currently using 14 in Azure, but 15 works locally) 
-- Install database server (choose your own admin password and save it some place you can find it again)
-- Start PG admin
-
-
-Create database authorizationdb
-
-Create the following users (with priveliges for authorizationdb) 
--platform_authorization_admin (superuser, canlogin)
--platform_authorization (canlogin)
-password: Password
-
-Create schema delegations in authorizationdb
-
-Set platform_authorization_admin as owner
-
-
-
+1. Install and start PostgreSQL, choosing an admin password.
+2. Create the database `authorizationdb`.
+3. Create two login roles with privileges on it:
+   - `platform_authorization_admin` (superuser, can-login)
+   - `platform_authorization` (can-login)
+4. Create the schema `delegations` in `authorizationdb`, owned by
+   `platform_authorization_admin`.

--- a/src/apps/Altinn.AccessManagement/README.md
+++ b/src/apps/Altinn.AccessManagement/README.md
@@ -15,14 +15,10 @@ Or from the command line:
 dotnet run --project src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement
 ```
 
-## Setting up the database
+## Local development
 
-Access Management needs a local PostgreSQL (Azure runs 14; 15 works locally).
-
-1. Install and start PostgreSQL, choosing an admin password.
-2. Create the database `authorizationdb`.
-3. Create two login roles with privileges on it:
-   - `platform_authorization_admin` (superuser, can-login)
-   - `platform_authorization` (can-login)
-4. Create the schema `delegations` in `authorizationdb`, owned by
-   `platform_authorization_admin`.
+Local setup — containerised PostgreSQL (`just dev`), user secrets, and the
+database bootstrap — is in the
+[repository README](../../../README.md#local-development-environment). Access
+Management uses the `authorizationdb` database (roles `platform_authorization` /
+`platform_authorization_admin`).

--- a/src/apps/Altinn.Authorization/README.md
+++ b/src/apps/Altinn.Authorization/README.md
@@ -31,7 +31,7 @@ These instructions will get you a copy of the authorization component up and run
 
 ## Running the authorization component
 
-Clone [Altinn Authorization repo](https://github.com/Altinn/altinn-authorization) and navigate to the root folder.
+Clone [Altinn Authorization repo](https://github.com/Altinn/altinn-authorization-tmp) and navigate to the root folder.
 
 The Authorization components can be run locally when developing/debugging. Follow the install steps above if this has not already been done.
 

--- a/src/apps/Altinn.Authorization/README.md
+++ b/src/apps/Altinn.Authorization/README.md
@@ -18,24 +18,24 @@ Read more about the component on docs.altinn.studio
 
 ## Getting Started
 
-These instructions will get you a copy of the authentication component up and running on your machine for development and testing purposes.
+These instructions will get you a copy of the authorization component up and running on your machine for development and testing purposes.
 
 ### Prerequisites
 
-1. [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+1. [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 2. Code editor of your choice
 3. Newest [Git](https://git-scm.com/downloads)
 4. [Docker CE](https://www.docker.com/get-docker)
 5. Solution is cloned
 
 
-## Running the storage component
+## Running the authorization component
 
 Clone [Altinn Authorization repo](https://github.com/Altinn/altinn-authorization) and navigate to the root folder.
 
 The Authorization components can be run locally when developing/debugging. Follow the install steps above if this has not already been done.
 
-Navigate to the src/Authorization, and build and run the code from there, or run the solution using you selected code editor
+Navigate to `src/apps/Altinn.Authorization/src/Altinn.Authorization`, and build and run the code from there, or run the solution using your selected code editor
 
 ```cmd
 dotnet run

--- a/src/apps/Altinn.Authorization/test/K6/performance/README.md
+++ b/src/apps/Altinn.Authorization/test/K6/performance/README.md
@@ -1,4 +1,4 @@
- This document provides an overview of how to conduct performance testing using K6 in the Dialogporten Frontend project.
+ This document provides an overview of how to conduct performance testing using K6 in the Altinn Authorization repository.
 
   ## Prerequisites
   * Either
@@ -61,7 +61,7 @@
 
   ### From GitHub Actions
   To run the performance test using GitHub Actions, follow these steps:
-  1. Go to the [GitHub Actions](https://github.com/altinn/dialogporten-frontend/actions/workflows/run-performance-tests.yml) page.
+  1. Go to the [GitHub Actions](https://github.com/Altinn/altinn-authorization-tmp/actions/workflows/run-performance.yml) page.
   2. Select "Run workflow" and fill in the required parameters. See above for details.
   3. Tag the performance test with a descriptive name.
 


### PR DESCRIPTION
Closes #3597. Part of #3486.

Brings the non-testing READMEs in line with the current repo:

- **Root `README.md`** — prerequisites now `.NET 10.0 & 9.0` (was `9.0 & 8.0`).
- **`src/apps/Altinn.AccessManagement/README.md`** — correct the source path; drop the dead `Altinn.Authorizationadmin` and `/development/src/LocalBridge` references (neither exists here); tidy the database-setup steps.
- **`src/apps/Altinn.Authorization/README.md`** — `.NET 10.0 SDK`; fix copy-paste wording that called the component "storage" / "authentication"; correct the run path.
- **`src/apps/Altinn.Authorization/test/K6/performance/README.md`** — it opened with "Dialogporten Frontend project"; this is the Altinn Authorization repo, and the GitHub Actions link now points at `run-performance.yml` here.

Docs-only. The `ttd-dialogporten-performance-test-02` resource name is a real test resource and is left as-is.
- **DB-setup alignment** — the two READMEs disagreed on the local database. Verified against `appsettings.json` and `.justfile`: the app uses `authorizationdb` via the containerised `just dev` flow (`accessmgmt` is never a real DB). Fixed the root bootstrap name and pointed the AccessManagement README at the root's canonical setup.

## Root README restructure

The root `README.md` was badges plus a setup script with no project description, structure map, or build/test commands. Reworked to a standard layout: overview, repository structure, getting started (build / test / run), local development (the existing `just dev` flow), and Documentation / Security / License. Dropped the TypeScript prerequisite (no TypeScript in the repo).
