### PR TITLE
Tuning of GetSearchData

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -198,14 +198,14 @@ public class PackageService : IPackageService
     {
         bool filterResourceProviders = resourceProviderCodes != null && resourceProviderCodes.Any();
 
-        string cacheKey = "psa";
+        string cacheKey = "packageSvcAreas";
         if (!_memoryCache.TryGetValue(cacheKey, out List<Area> areas))
         {
             areas = await DbContext.Areas.AsNoTracking().ToListAsync(cancellationToken);
             _memoryCache.Set(cacheKey, areas, _cacheOptions);
         }
 
-        cacheKey = "psp";
+        cacheKey = "packageSvcPackages";
         if (!_memoryCache.TryGetValue(cacheKey, out List<Package> allPackages))
         {
             allPackages = await DbContext.Packages.AsNoTracking().Include(t => t.EntityType).ToListAsync(cancellationToken);
@@ -216,7 +216,7 @@ public class PackageService : IPackageService
 
         var result = new List<PackageDto>();
 
-        cacheKey = "pspr";
+        cacheKey = "packageSvcPackageResources";
         if (!_memoryCache.TryGetValue(cacheKey, out List<PackageResource> allPackageResources))
         {
             allPackageResources = await DbContext.PackageResources.AsNoTracking()

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -9,6 +9,7 @@ using Altinn.AccessMgmt.PersistenceEF.Utils;
 using Altinn.Authorization.Api.Contracts.AccessManagement;
 using Altinn.Authorization.Api.Contracts.AccessManagement.Request;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Altinn.AccessMgmt.Core.Services;
 
@@ -19,10 +20,17 @@ public class PackageService : IPackageService
 
     public ITranslationService TranslationService { get; set; }
 
-    public PackageService(AppDbContext appDbContext, ITranslationService translationService)
+    private IMemoryCache _memoryCache;
+    private static readonly MemoryCacheEntryOptions _cacheOptions = new()
+    {
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10)
+    };
+
+    public PackageService(AppDbContext appDbContext, ITranslationService translationService, IMemoryCache memoryCache)
     {
         DbContext = appDbContext;
         TranslationService = translationService;
+        _memoryCache = memoryCache;
     }
 
     private const StringComparison Ic = StringComparison.InvariantCultureIgnoreCase;
@@ -190,17 +198,37 @@ public class PackageService : IPackageService
     {
         bool filterResourceProviders = resourceProviderCodes != null && resourceProviderCodes.Any();
 
-        var areas = await DbContext.Areas.AsNoTracking().ToListAsync(cancellationToken);
-        var packages = await DbContext.Packages.AsNoTracking().Include(t => t.EntityType).WhereIf(typeId.HasValue && typeId.Value != Guid.Empty, t => t.EntityTypeId == typeId.Value).ToListAsync(cancellationToken);
+        string cacheKey = "psa";
+        if (!_memoryCache.TryGetValue(cacheKey, out List<Area> areas))
+        {
+            areas = await DbContext.Areas.AsNoTracking().ToListAsync(cancellationToken);
+            _memoryCache.Set(cacheKey, areas, _cacheOptions);
+        }
+
+        cacheKey = "psp";
+        if (!_memoryCache.TryGetValue(cacheKey, out List<Package> allPackages))
+        {
+            allPackages = await DbContext.Packages.AsNoTracking().Include(t => t.EntityType).ToListAsync(cancellationToken);
+            _memoryCache.Set(cacheKey, allPackages, _cacheOptions);
+        }
+
+        var packages = allPackages.Where(p => typeId.HasValue && typeId.Value != Guid.Empty ? p.EntityTypeId == typeId.Value : true);
 
         var result = new List<PackageDto>();
 
-        var packageResources = await DbContext.PackageResources.AsNoTracking()
-            .Include(t => t.Resource)
-            .Include(t => t.Resource).ThenInclude(t => t.Provider)
-            .Include(t => t.Resource).ThenInclude(t => t.Type)
-            .WhereIf(filterResourceProviders, t => resourceProviderCodes.Any(code => EF.Functions.ILike(t.Resource.Provider.Code, "%" + code + "%")))
-            .ToListAsync(cancellationToken);
+        cacheKey = "pspr";
+        if (!_memoryCache.TryGetValue(cacheKey, out List<PackageResource> allPackageResources))
+        {
+            allPackageResources = await DbContext.PackageResources.AsNoTracking()
+                .Include(t => t.Resource)
+                .Include(t => t.Resource).ThenInclude(t => t.Provider)
+                .Include(t => t.Resource).ThenInclude(t => t.Type)
+                .ToListAsync(cancellationToken);
+            _memoryCache.Set(cacheKey, allPackageResources, _cacheOptions);
+        }
+
+        var packageResources = allPackageResources
+            .Where(pr => filterResourceProviders ? resourceProviderCodes.Any(code => pr.Resource.Provider.Code.Contains(code, StringComparison.OrdinalIgnoreCase)) : true);
 
         foreach (var package in packages)
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/PackageService.cs
@@ -228,17 +228,19 @@ public class PackageService : IPackageService
         }
 
         var packageResources = allPackageResources
-            .Where(pr => filterResourceProviders ? resourceProviderCodes.Any(code => pr.Resource.Provider.Code.Contains(code, StringComparison.OrdinalIgnoreCase)) : true);
+            .Where(pr => filterResourceProviders ? resourceProviderCodes.Any(code => pr.Resource?.Provider?.Code?.Contains(code, StringComparison.OrdinalIgnoreCase) == true) : true)
+            .ToList();
+        var resourcesByPackage = packageResources.ToLookup(t => t.PackageId);
 
         foreach (var package in packages)
         {
             // Skip package if the package does not have a valid filtered resource
-            if (filterResourceProviders == true && packageResources.Any(t => t.PackageId == package.Id) == false)
+            if (filterResourceProviders == true && !resourcesByPackage[package.Id].Any())
             {
                 continue;
             }
 
-            result.Add(DtoMapper.Convert(package, areas.First(t => t.Id == package.AreaId), packageResources.Where(t => t.PackageId == package.Id).Select(t => t.Resource)));
+            result.Add(DtoMapper.Convert(package, areas.First(t => t.Id == package.AreaId), resourcesByPackage[package.Id].Select(t => t.Resource)));
         }
 
         foreach (var t in result)

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Metadata/PackagesControllerIntegrationTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Metadata/PackagesControllerIntegrationTests.cs
@@ -96,7 +96,7 @@ public class PackagesControllerIntegrationTests : IClassFixture<EfDatabaseFixtur
         // Fully qualify: the namespace-less Persistence `PackageService` (six-arg
         // ctor) is in the global namespace, so an unqualified `PackageService(_db)`
         // would bind there.
-        _packageService = new Altinn.AccessMgmt.Core.Services.PackageService(_db, _translationService);
+        _packageService = new Altinn.AccessMgmt.Core.Services.PackageService(_db, _translationService, memoryCache);
     }
 
     private PackagesController CreateController(string acceptLanguage = "nb-NO")


### PR DESCRIPTION
## Description

`GetSearchData` read three tables on every package search: `Areas`, `Packages`, and `PackageResources` (the last with three levels of `Include`). These are slow-changing reference tables, so re-querying them on each request was redundant work.

This change caches the three datasets in `IMemoryCache` for 10 minutes and applies the per-request filtering (entity type and resource provider code) in memory over the cached lists instead of in the SQL query. The cache keys do not depend on the filter arguments, so one cached copy serves every caller regardless of `typeId` / `resourceProviderCodes`.

What changed:
- Cache `Areas`, `Packages` (with `EntityType`), and `PackageResources` (with `Resource` -> `Provider` / `Type`) under fixed keys for 10 minutes.
- Filter packages by `typeId` and resources by `resourceProviderCodes` in memory rather than in the database query.
- Inject `IMemoryCache` into `PackageService` (already registered in the host via `AddMemoryCache`).
- Update the `PackageService` constructor call in `PackagesControllerIntegrationTests`.

Trade-off: package/area/resource changes can take up to 10 minutes to surface in search results.

## Related Issue(s)
- No linked issue

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
