### PR TITLE
Skip test assemblies without integration tests in the CI integration lane

### DIFF
--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -210,12 +210,15 @@ jobs:
       #                         files don't overwrite each other
       #   --report-xunit-trx    emit .trx (consumed by Sonar via
       #                         sonar.cs.vstest.reportsPaths = **/*.trx)
-      #   --ignore-exit-code 8  treat "no tests ran" as success — covers both
-      #                         all-[Skip]ped (e.g. Host.Lease without Azurite)
-      #                         AND a lane that selects 0 tests in a
-      #                         single-type vertical (e.g. PEP has no
-      #                         integration tests). Verified: an empty filtered
-      #                         run exits 8, which this flag maps to success.
+      #   --ignore-exit-code 8  treat "no tests ran" as success. The integration
+      #                         lane also passes -p:TestLane=Integration so that
+      #                         assemblies declaring HasIntegrationTests=false are
+      #                         skipped outright (src/testing/IntegrationLaneGate.targets)
+      #                         instead of producing a zero-test run that MTP logs
+      #                         as "Failed! ... Total: 0" — the flag fixes the exit
+      #                         code but not that log line. The flag stays for the
+      #                         cases the gate can't know statically: tests skipped
+      #                         at runtime (e.g. missing Docker locally).
       # Coverage is collected only on the nightly `analyze` run (no dotnet-coverage
       # instrumentation overhead on PR runs); both still emit .trx + FixtureTiming.
       # On the analyze run each lane writes its .coverage file; the Convert steps
@@ -259,7 +262,7 @@ jobs:
           GH_API_TOKEN: ${{ github.token }} # lets report-failed-tests.ps1 deep-link the job summary
         run: |
           set +e
-          test=(dotnet test -c Release --no-build -bl:binlog/test-integration.binlog -- --results-directory TestResults/integration --report-xunit-trx --filter-trait "Category=Integration" --ignore-exit-code 8)
+          test=(dotnet test -c Release --no-build -p:TestLane=Integration -bl:binlog/test-integration.binlog -- --results-directory TestResults/integration --report-xunit-trx --filter-trait "Category=Integration" --ignore-exit-code 8)
           if [[ "${{ inputs.analyze }}" == "true" ]]; then
             dotnet-coverage collect --nologo --settings "$GITHUB_WORKSPACE/eng/testing/coverage.settings" --output TestResults/coverage.integration.coverage --output-format coverage -- "${test[@]}"
           else

--- a/docs/testing/CI.md
+++ b/docs/testing/CI.md
@@ -30,9 +30,13 @@ scan; on PR/main CI they are skipped):
    `.coverage` binary (`coverage.unit.coverage` / `coverage.integration.coverage`);
    **PR runs execute the tests directly, without coverage instrumentation.** The
    integration lane runs even if the unit lane failed (but not if the build
-   failed) so coverage spans the whole suite. A lane that selects 0 tests in a
-   single-type vertical (e.g. `pkg: PEP` has no integration tests) exits 8,
-   which `--ignore-exit-code 8` treats as success.
+   failed) so coverage spans the whole suite. The integration lane also passes
+   `-p:TestLane=Integration`: assemblies that declare
+   `<HasIntegrationTests>false</HasIntegrationTests>` are skipped outright (see
+   [Integration lane gate](#integration-lane-gate) below) instead of producing a
+   zero-test run. For runs that still end up with nothing executed (tests
+   skipped at runtime), MTP exits 8, which `--ignore-exit-code 8` treats as
+   success.
 4. **Convert coverage** *(analyze run only — PR runs produce no `.coverage`, so these self-skip)* — `dotnet-coverage merge` into cobertura for the coverage report, and a second merge into VSCoverage XML for Sonar. No re-running tests.
 5. **SonarCloud end** *(analyze run only, verticals that opt in)* — uploads the analysis. Runs even if tests failed so issues found by the scanner are still posted. See [../SONARCLOUD.md](../SONARCLOUD.md).
 6. **Coverage report** — parses the cobertura XML and reports any assembly below its target as a warning; it never fails on coverage, so it does not gate the job. See [COVERAGE.md](COVERAGE.md).
@@ -53,9 +57,40 @@ xUnit v3 is self-hosted on MTP. A few things the pipeline relies on:
 - MTP exit codes:
   - `0` — all tests passed
   - `8` — no tests ran: either all were `[Skip]`ped, or a `--filter-trait`
-    lane selected 0 tests in a single-type vertical (treated as success via
-    `--ignore-exit-code 8`)
+    lane selected 0 tests (treated as success via `--ignore-exit-code 8`)
   - non-zero — failures
+- MTP's per-assembly summary line prints `Failed!` whenever nothing passed
+  (`TotalFailed > 0 || TotalPassed == 0` in
+  `Microsoft.Testing.Platform.MSBuild`'s `InvokeTestingPlatformTask`), so a
+  zero-test or all-skipped run is logged as
+  `Failed! - Failed: 0, Passed: 0, Skipped: 0, Total: 0` even when the exit
+  code is mapped to success. There is no MTP option to change that display —
+  the integration lane gate below exists to keep such runs from happening.
+
+## Integration lane gate
+
+A test assembly with no integration tests would still be executed by the
+integration lane, match zero tests, and be logged as `Failed! ... Total: 0`
+(see above). To keep the log truthful, such projects declare in their csproj:
+
+```xml
+<HasIntegrationTests>false</HasIntegrationTests>
+```
+
+When the integration lane runs (`dotnet test -p:TestLane=Integration`),
+`src/Directory.Build.targets` imports
+[`src/testing/IntegrationLaneGate.targets`](../../src/testing/IntegrationLaneGate.targets)
+for these projects, which replaces the test invocation with a skip message.
+Unit lanes, plain `dotnet test`, and IDE runs are unaffected — every assembly
+always has unit tests (`TestCategoryGuard` itself is one), so only the
+integration lane can select zero tests.
+
+The declaration cannot go stale: `TestCategoryGuard` (compiled into every test
+assembly, runs in the unit lane) fails when the declared value does not match
+the assembly's actual tests — in both directions. Integration tests that are
+permanently `[Skip]`ped do not count as runnable (an all-skipped run is also
+logged as `Failed!`), which is why `Altinn.Authorization.Host.Lease.Tests`
+declares `false` despite containing (perma-skipped) integration tests.
 
 ## Coverage reporting scope
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -14,6 +14,16 @@
                      tests are actually discovered & executed in CI. -->
                 <TestingPlatformDotnetTestSupport Condition=" '$(IsTestProject)' == 'true' And '$(XUnitVersion)' == 'v3' ">true</TestingPlatformDotnetTestSupport>
 
+                <!-- Whether this assembly has integration tests that can actually run
+                     (at least one [IntegrationTest] not permanently [Skip]ped). Projects
+                     without any set this to false in their csproj so the CI integration
+                     lane skips them instead of running them with zero matching tests —
+                     MTP prints such a run as "Failed! ... Total: 0" and there is no
+                     option to change that display (the job only stays green because of
+                     the "ignore-exit-code 8" option). Enforced against the assembly's
+                     actual tests by TestCategoryGuard, so the declaration can't go stale. -->
+                <HasIntegrationTests Condition=" '$(IsTestProject)' == 'true' And '$(XUnitVersion)' == 'v3' And '$(HasIntegrationTests)' == '' ">true</HasIntegrationTests>
+
                 <!-- Coverage output format for coverlet -->
                 <CoverletOutputFormat>cobertura</CoverletOutputFormat>
             </PropertyGroup>
@@ -55,6 +65,9 @@
                     <Link>Properties\TestCategoryGuard.cs</Link>
                 </Compile>
                 <Using Include="Altinn.Authorization.Testing" />
+                <!-- Exposes the lane declaration to TestCategoryGuard, which fails the
+                     run when it doesn't match the assembly's actual tests. -->
+                <AssemblyMetadata Include="HasIntegrationTests" Value="$(HasIntegrationTests)" />
             </ItemGroup>
 
             <!-- Shared PostgreSQL test engine (template-clone provisioning + the
@@ -138,5 +151,16 @@
             <Link>stylecop.json</Link>
         </AdditionalFiles>
     </ItemGroup>
+
+    <!-- CI lane gate: when the integration test lane runs (`dotnet test -p:TestLane=Integration`),
+         projects that declare <HasIntegrationTests>false</HasIntegrationTests> skip test
+         execution entirely instead of starting a run that matches zero tests (which MTP
+         reports as "Failed!"). Imported here (after the NuGet package targets) so the
+         override in the file wins over Microsoft.Testing.Platform.MSBuild's
+         InvokeTestingPlatform target.
+         Must be conditional on the import — a same-named target with a false Condition
+         would still replace the package's target and just be skipped. -->
+    <Import Project="$(MSBuildThisFileDirectory)testing\IntegrationLaneGate.targets"
+            Condition=" '$(TestLane)' == 'Integration' And '$(IsTestProject)' == 'true' And '$(XUnitVersion)' == 'v3' And '$(HasIntegrationTests)' == 'false' " />
 
 </Project>

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Altinn.AccessManagement.Api.Tests.csproj
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Tests/Altinn.AccessManagement.Api.Tests.csproj
@@ -7,6 +7,9 @@
 		<TargetFrameworks>net10.0</TargetFrameworks>
 		<IsTestProject>true</IsTestProject>
 		<IsPackable>false</IsPackable>
+		<!-- No integration tests: the CI integration lane skips this assembly
+			 (see src/testing/IntegrationLaneGate.targets). -->
+		<HasIntegrationTests>false</HasIntegrationTests>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Altinn.AccessMgmt.PersistenceEF.Tests.csproj
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.PersistenceEF.Tests/Altinn.AccessMgmt.PersistenceEF.Tests.csproj
@@ -7,6 +7,9 @@
     <TargetFrameworks>net10.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
+    <!-- No integration tests: the CI integration lane skips this assembly
+         (see src/testing/IntegrationLaneGate.targets). -->
+    <HasIntegrationTests>false</HasIntegrationTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Lease.Tests/Altinn.Authorization.Host.Lease.Tests.csproj
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Lease.Tests/Altinn.Authorization.Host.Lease.Tests.csproj
@@ -5,6 +5,11 @@
              dotnet test routes to the Microsoft Testing Platform (required for xUnit v3). -->
         <TargetFramework></TargetFramework>
         <TargetFrameworks>net10.0</TargetFrameworks>
+        <!-- The only integration tests here are permanently [Skip]ped (they need a real
+             storage account), so the CI integration lane skips this assembly instead of
+             reporting an all-skipped run as failed
+             (see src/testing/IntegrationLaneGate.targets). -->
+        <HasIntegrationTests>false</HasIntegrationTests>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/Altinn.Authorization.Host.Pipeline.Tests.csproj
+++ b/src/libs/Altinn.Authorization.Host/test/Altinn.Authorization.Host.Pipeline.Tests/Altinn.Authorization.Host.Pipeline.Tests.csproj
@@ -5,6 +5,9 @@
              dotnet test routes to the Microsoft Testing Platform (required for xUnit v3). -->
         <TargetFramework></TargetFramework>
         <TargetFrameworks>net10.0</TargetFrameworks>
+        <!-- No integration tests: the CI integration lane skips this assembly
+             (see src/testing/IntegrationLaneGate.targets). -->
+        <HasIntegrationTests>false</HasIntegrationTests>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Altinn.Authorization.ABAC.Tests.csproj
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Altinn.Authorization.ABAC.Tests.csproj
@@ -3,6 +3,9 @@
     <PropertyGroup>
         <TargetFrameworks>net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
+        <!-- No integration tests: the CI integration lane skips this assembly
+             (see src/testing/IntegrationLaneGate.targets). -->
+        <HasIntegrationTests>false</HasIntegrationTests>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/Altinn.Authorization.PEP.Tests.csproj
+++ b/src/pkgs/Altinn.Authorization.PEP/test/Altinn.Authorization.PEP.Tests/Altinn.Authorization.PEP.Tests.csproj
@@ -3,6 +3,9 @@
     <PropertyGroup>
         <TargetFrameworks>net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
+        <!-- No integration tests: the CI integration lane skips this assembly
+             (see src/testing/IntegrationLaneGate.targets). -->
+        <HasIntegrationTests>false</HasIntegrationTests>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/testing/IntegrationLaneGate.targets
+++ b/src/testing/IntegrationLaneGate.targets
@@ -1,0 +1,25 @@
+<Project>
+
+    <!-- Skips test execution for assemblies that declare
+         <HasIntegrationTests>false</HasIntegrationTests> when the CI integration lane
+         runs (`dotnet test -p:TestLane=Integration`). Running such an assembly would
+         match zero tests, and Microsoft.Testing.Platform's MSBuild integration prints
+         a zero-test run as "Failed! - Failed: 0, Passed: 0, Skipped: 0, Total: 0" with
+         no way to change the display (the summary is Failed! whenever TotalPassed == 0;
+         the "ignore-exit-code 8" option only fixes the exit code, not the log line).
+
+         InvokeTestingPlatform is the target that actually starts the test host, on both
+         `dotnet test` routes: the cross-targeting VSTest target dispatches inner builds
+         straight at it (via InnerVSTestTargets, set by _SetCustomVSTargetForVSTest), and
+         the single-TFM VSTest override reaches it through _BuildAndInvokeTestingPlatform.
+         This same-named target replaces Microsoft.Testing.Platform.MSBuild's because
+         Directory.Build.targets is imported after the NuGet package targets.
+
+         Only imported (from src/Directory.Build.targets) when the project opts out AND
+         the integration lane is running, so every other configuration — unit lane,
+         plain `dotnet test`, IDE runs — is untouched. -->
+    <Target Name="InvokeTestingPlatform">
+        <Message Importance="high" Text="Integration lane: skipping $(MSBuildProjectName) (HasIntegrationTests=false)." />
+    </Target>
+
+</Project>

--- a/src/testing/TestCategoryGuard.cs
+++ b/src/testing/TestCategoryGuard.cs
@@ -22,29 +22,10 @@ public class TestCategoryGuard
     [Fact]
     public void EveryTestMethodHasACategoryTrait()
     {
-        Assembly assembly = typeof(TestCategoryGuard).Assembly;
-
-        Type[] types;
-        try
-        {
-            types = assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            types = ex.Types.OfType<Type>().ToArray();
-        }
-
         var uncategorised = new List<string>();
 
-        foreach (Type type in types)
+        foreach (Type type in TestClasses())
         {
-            // Only concrete classes are discovered as test classes; abstract bases
-            // and open generics are exercised through their concrete subclasses.
-            if (!type.IsClass || type.IsAbstract || type.ContainsGenericParameters)
-            {
-                continue;
-            }
-
             bool classCategorised = HasCategory(type.GetCustomAttributes(inherit: true).Cast<Attribute>());
 
             // Include inherited methods: a concrete class may inherit its tests
@@ -69,6 +50,83 @@ public class TestCategoryGuard
 
         uncategorised.Should().BeEmpty(
             "every test must be marked [UnitTest] or [IntegrationTest] (on the class or the method) so the CI unit/integration lane filters run it; an uncategorised test matches neither lane and is silently skipped");
+    }
+
+    /// <summary>
+    /// Guards the <c>HasIntegrationTests</c> project property (declared in the csproj,
+    /// embedded as assembly metadata via <c>src/Directory.Build.targets</c>). Projects
+    /// that set it to <c>false</c> are skipped by the CI integration lane, so a stale
+    /// declaration either hides integration tests from CI (declared false, tests exist)
+    /// or brings back the misleading zero-test "Failed!" summary the property exists to
+    /// avoid (declared true, no tests). Permanently skipped tests
+    /// (<c>[Fact(Skip = ...)]</c>) don't count as runnable: an all-skipped run is also
+    /// reported as "Failed!", and skipping the assembly changes nothing for them.
+    /// </summary>
+    [Fact]
+    public void HasIntegrationTestsDeclarationMatchesAssembly()
+    {
+        Assembly assembly = typeof(TestCategoryGuard).Assembly;
+
+        bool declared = !string.Equals(
+            assembly.GetCustomAttributes<AssemblyMetadataAttribute>().FirstOrDefault(a => a.Key == "HasIntegrationTests")?.Value,
+            "false",
+            StringComparison.OrdinalIgnoreCase);
+
+        var runnableIntegrationTests = new List<string>();
+
+        foreach (Type type in TestClasses())
+        {
+            bool classIsIntegration = type.GetCustomAttributes(inherit: true).OfType<IntegrationTestAttribute>().Any();
+
+            foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+            {
+                FactAttribute? fact = method.GetCustomAttributes(inherit: true).OfType<FactAttribute>().FirstOrDefault();
+                if (fact is null || fact.Skip is not null)
+                {
+                    continue;
+                }
+
+                bool methodIsIntegration = method.GetCustomAttributes(inherit: true).OfType<IntegrationTestAttribute>().Any();
+
+                if (classIsIntegration || methodIsIntegration)
+                {
+                    runnableIntegrationTests.Add($"{type.FullName}.{method.Name}");
+                }
+            }
+        }
+
+        if (declared)
+        {
+            runnableIntegrationTests.Should().NotBeEmpty(
+                "this assembly has no runnable integration tests, so the CI integration lane would run it with zero matching tests and report the run as \"Failed!\"; declare <HasIntegrationTests>false</HasIntegrationTests> in the csproj so the lane skips it");
+        }
+        else
+        {
+            runnableIntegrationTests.Should().BeEmpty(
+                "this assembly declares <HasIntegrationTests>false</HasIntegrationTests>, so the CI integration lane skips it and these integration tests would never run in CI; remove the property from the csproj");
+        }
+    }
+
+    /// <summary>
+    /// Concrete classes of this assembly — the only ones xUnit discovers as test
+    /// classes; abstract bases and open generics are exercised through their concrete
+    /// subclasses.
+    /// </summary>
+    private static IEnumerable<Type> TestClasses()
+    {
+        Assembly assembly = typeof(TestCategoryGuard).Assembly;
+
+        Type[] types;
+        try
+        {
+            types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types.OfType<Type>().ToArray();
+        }
+
+        return types.Where(t => t.IsClass && !t.IsAbstract && !t.ContainsGenericParameters);
     }
 
     private static bool HasCategory(IEnumerable<Attribute> attributes) =>

--- a/src/tools/Altinn.Authorization.Cli/test/Altinn.Authorization.Cli.Tests/Altinn.Authorization.Cli.Tests.csproj
+++ b/src/tools/Altinn.Authorization.Cli/test/Altinn.Authorization.Cli.Tests/Altinn.Authorization.Cli.Tests.csproj
@@ -1,8 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!-- Clear the singular TargetFramework inherited from src/Directory.Build.props so
+             dotnet test routes to the Microsoft Testing Platform (required for xUnit v3).
+             With it set, dotnet test silently fell back to VSTest, found no tests, and
+             this project's tests never ran in CI. -->
+        <TargetFramework></TargetFramework>
         <TargetFrameworks>net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
+        <!-- No integration tests: the CI integration lane skips this assembly
+             (see src/testing/IntegrationLaneGate.targets). -->
+        <HasIntegrationTests>false</HasIntegrationTests>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The CI integration lane runs every test assembly with `--filter-trait "Category=Integration"`. An assembly with no integration tests matches zero tests, and MTP logs the run as

```
Failed! - Failed: 0, Passed: 0, Skipped: 0, Total: 0, Duration: 1s 048ms - Altinn.AccessManagement.Api.Tests.dll (net10.0|x64)
```

The job stays green (`--ignore-exit-code 8` maps the zero-tests exit code to success), but the log reads as a test failure. The same happens for assemblies whose only integration tests are permanently skipped. The display is hardcoded in Microsoft.Testing.Platform.MSBuild (`Failed!` whenever nothing passed), so the fix is to not start such runs at all.

Changes:

- Test projects with no runnable integration tests declare `<HasIntegrationTests>false</HasIntegrationTests>`. When the integration lane runs (`dotnet test -p:TestLane=Integration`), `src/testing/IntegrationLaneGate.targets` replaces the test invocation for those projects with a one-line skip message. Unit lanes, plain `dotnet test`, and IDE runs are untouched.
- The declaration is embedded as assembly metadata and enforced by a new `TestCategoryGuard` check running in the unit lane: declared `false` with runnable integration tests present fails (they would silently never run in CI), declared `true` with none fails (the misleading log line would come back). Permanently `[Skip]`ped tests do not count as runnable.
- Declared the property in the six unit-only test projects (Host.Pipeline, ABAC, AccessManagement.Api, AccessMgmt.PersistenceEF, Cli, PEP) plus Host.Lease, whose only integration tests are permanently skipped and produced the same log line.
- While verifying, found that `Altinn.Authorization.Cli.Tests` never ran in CI at all: it did not clear the singular `TargetFramework`, so `dotnet test` silently fell back to VSTest and discovered nothing. Fixed with the standard clear; its 16 tests now run in the unit lane.
- Documented the mechanism in `docs/testing/CI.md`.

Verified locally: the PEP and Cli integration lanes now print `Integration lane: skipping <project> (HasIntegrationTests=false).` and exit 0 without starting a test host, the integration lane still executes assemblies with integration tests, and the guard check passes in all 14 test assemblies.

Closes #3683
