### PR TITLE
Feature/remilovoll/26/07/3510 keyroles in iks shoud not get rights

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -95,9 +95,10 @@ public class ConnectionQuery(AppDbContext db)
         {
             var keyRoles =
             from a in db.Assignments.AsNoTracking()
-            join k in db.Assignments.AsNoTracking() on a.ToId equals k.FromId
+            join ae in db.Entities.AsNoTracking() on a.FromId equals ae.Id
+            join k in db.Assignments.AsNoTracking() on a.ToId equals k.FromId            
             join kr in db.Roles.AsNoTracking() on k.RoleId equals kr.Id
-            where a.FromId == fromId && kr.IsKeyRole == true && k.ToId == toId
+            where a.FromId == fromId && kr.IsKeyRole == true && k.ToId == toId && (a.RoleId != RoleConstants.ParticipantSharedResponsibility.Id || ae.VariantId != EntityVariantConstants.IKS.Id)
             select 1;
 
             if (await keyRoles.AnyAsync())

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -280,20 +280,29 @@ public class ConnectionQuery(AppDbContext db)
                     db.Assignments,
                     x => x.d.FromId,
                     a2 => a2.ToId,
-                    (x, a2) => new ConnectionQueryBaseRecord
-                    {
-                        AssignmentId = a2.Id,
-                        DelegationId = null,
-                        FromId = a2.FromId,
-                        ToId = x.d.ToId,
-                        RoleId = a2.RoleId,
-                        ViaId = x.d.FromId,
-                        ViaRoleId = x.d.RoleId,
-                        Reason = ConnectionReason.KeyRole,
-                        IsKeyRoleAccess = true,
-                        IsMainUnitAccess = false,
-                        IsRoleMap = false,
-                    });
+                    (x, a2) => new { x, a2 }
+                )
+                .Join(
+                    db.Entities,
+                    y => y.a2.FromId,
+                    e => e.Id,
+                    (y, e) => new { y.x, y.a2, e }
+                )
+                .Where(z => !(z.e.VariantId == EntityVariantConstants.IKS.Id && z.a2.RoleId == RoleConstants.ParticipantSharedResponsibility.Id))
+                .Select(z => new ConnectionQueryBaseRecord
+                {
+                    AssignmentId = z.a2.Id,
+                    DelegationId = null,
+                    FromId = z.a2.FromId,
+                    ToId = z.x.d.ToId,
+                    RoleId = z.a2.RoleId,
+                    ViaId = z.x.d.FromId,
+                    ViaRoleId = z.x.d.RoleId,
+                    Reason = ConnectionReason.KeyRole,
+                    IsKeyRoleAccess = true,
+                    IsMainUnitAccess = false,
+                    IsRoleMap = false,
+                });
 
         var a1 = filter.IncludeKeyRole
             ? direct.Concat(keyrole)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -672,7 +672,7 @@ public class ConnectionQuery(AppDbContext db)
             .RoleIdContains(roleSet);
     }
 
-    public IQueryable<ConnectionQueryBaseRecord> BuildBaseQueryToOthers(AppDbContext db, ConnectionQueryFilter filter)
+    private IQueryable<ConnectionQueryBaseRecord> BuildBaseQueryToOthers(AppDbContext db, ConnectionQueryFilter filter)
     {
         /* Senario: Tilgangsstyrer i Bakerhansen Bergen BEDR (FromId) som er underenhet av Bakerhansen AS
 
@@ -804,9 +804,10 @@ public class ConnectionQuery(AppDbContext db)
         */
         var keyRoleAssignments =
             from all in allAssignments.Concat(roleMapAssignments) // Must include RoleMap assignments
-            join keyRoleAssignment in db.Assignments on all.ToId equals keyRoleAssignment.FromId
+            join fromEntity in db.Entities on all.FromId equals fromEntity.Id
+            join keyRoleAssignment in db.Assignments on all.ToId equals keyRoleAssignment.FromId            
             join role in db.Roles on keyRoleAssignment.RoleId equals role.Id
-            where role.IsKeyRole
+            where role.IsKeyRole && !(fromEntity.VariantId == EntityVariantConstants.IKS.Id && all.RoleId == RoleConstants.ParticipantSharedResponsibility.Id)
             select new ConnectionQueryBaseRecord()
             {
                 AssignmentId = all.AssignmentId,

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -304,6 +304,42 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
             r.Reason == ConnectionReason.KeyRole);
     }
 
+    [Fact]
+    public async Task HasConnection_IksWithDeltakerDeltAnsvarRole_ReturnsFalse()
+    {
+        var fromId = TestDataSet.GetEntity("IKS Selskap").Id;
+        var toId = TestDataSet.GetEntity("Rådmann Kommune").Id;
+
+        var (result, reason) = await _query.HasConnection(fromId, toId, [ConnectionReason.KeyRole]);
+
+        Assert.False(result);
+        Assert.Null(reason);
+    }
+
+    [Fact]
+    public async Task HasConnection_NonIksWithDeltakerDeltAnsvarRole_ReturnsKeyRole()
+    {
+        var fromId = TestDataSet.GetEntity("Non-IKS Selskap").Id;
+        var toId = TestDataSet.GetEntity("Rådmann Kommune").Id;
+
+        var (result, reason) = await _query.HasConnection(fromId, toId, [ConnectionReason.KeyRole]);
+
+        Assert.True(result);
+        Assert.Equal(ConnectionReason.KeyRole, reason);
+    }
+
+    [Fact]
+    public async Task HasConnection_IksWithDifferentRole_ReturnsKeyRole()
+    {
+        var fromId = TestDataSet.GetEntity("IKS Selskap 2").Id;
+        var toId = TestDataSet.GetEntity("Rådmann Kommune").Id;
+
+        var (result, reason) = await _query.HasConnection(fromId, toId, [ConnectionReason.KeyRole]);
+
+        Assert.True(result);
+        Assert.Equal(ConnectionReason.KeyRole, reason);
+    }
+
     [Theory]
     [MemberData(nameof(GetFilterCombinations))]
     public async Task GetConnectionsAsync_AllFilterFlagCombinations_DoesNotThrow(bool[] flags, bool useSingle)

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -340,6 +340,66 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
         Assert.Equal(ConnectionReason.KeyRole, reason);
     }
 
+    [Fact]
+    public async Task KeyRole_ToOthers_IksWithDeltakerDeltAnsvar_IsNotIncluded()
+    {
+        var iksId = TestDataSet.GetEntity("IKS Selskap").Id;
+        var personId = TestDataSet.GetEntity("Rådmann Kommune").Id;
+
+        var filter = new ConnectionQueryFilter
+        {
+            FromIds = new[] { iksId },
+            IncludeKeyRole = true,
+        };
+
+        var dbResult = await _query.GetConnectionsToOthersAsync(filter, true, TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(dbResult, r =>
+            r.ToId == personId &&
+            r.RoleId == RoleConstants.ParticipantSharedResponsibility.Id &&
+            r.Reason == ConnectionReason.KeyRole);
+    }
+
+    [Fact]
+    public async Task KeyRole_ToOthers_NonIksWithDeltakerDeltAnsvar_IsIncluded()
+    {
+        var nonIksId = TestDataSet.GetEntity("Non-IKS Selskap").Id;
+        var personId = TestDataSet.GetEntity("Rådmann Kommune").Id;
+
+        var filter = new ConnectionQueryFilter
+        {
+            FromIds = new[] { nonIksId },
+            IncludeKeyRole = true,
+        };
+
+        var dbResult = await _query.GetConnectionsToOthersAsync(filter, true, TestContext.Current.CancellationToken);
+
+        Assert.Contains(dbResult, r =>
+            r.ToId == personId &&
+            r.RoleId == RoleConstants.ParticipantSharedResponsibility.Id &&
+            r.Reason == ConnectionReason.KeyRole);
+    }
+
+    [Fact]
+    public async Task KeyRole_ToOthers_IksWithDifferentRole_IsIncluded()
+    {
+        var iksId2 = TestDataSet.GetEntity("IKS Selskap 2").Id;
+        var personId = TestDataSet.GetEntity("Rådmann Kommune").Id;
+
+        var filter = new ConnectionQueryFilter
+        {
+            FromIds = new[] { iksId2 },
+            IncludeKeyRole = true,
+        };
+
+        var dbResult = await _query.GetConnectionsToOthersAsync(filter, true, TestContext.Current.CancellationToken);
+
+        Assert.Contains(dbResult, r =>
+            r.ToId == personId &&
+            r.RoleId == RoleConstants.Accountant.Id &&
+            r.Reason == ConnectionReason.KeyRole);
+    }
+
     [Theory]
     [MemberData(nameof(GetFilterCombinations))]
     public async Task GetConnectionsAsync_AllFilterFlagCombinations_DoesNotThrow(bool[] flags, bool useSingle)

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -298,6 +298,7 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
 
         Assert.Contains(dbResult, r =>
             r.FromId == iksId &&
+            r.RoleId == RoleConstants.Accountant.Id &&
             r.ViaRoleId == RoleConstants.ManagingDirector.Id &&
             r.Reason == ConnectionReason.KeyRole);
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -278,6 +278,7 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
 
         Assert.Contains(dbResult, r =>
             r.FromId == nonIksId &&
+            r.RoleId == RoleConstants.ParticipantSharedResponsibility.Id &&
             r.ViaRoleId == RoleConstants.ManagingDirector.Id &&
             r.Reason == ConnectionReason.KeyRole);
     }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -259,9 +259,7 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
         var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true, TestContext.Current.CancellationToken);
 
         Assert.DoesNotContain(dbResult, r =>
-            r.FromId == iksId /*&&
-            r.ViaRoleId == RoleConstants.ParticipantSharedResponsibility.Id &&
-            r.Reason == ConnectionReason.KeyRole*/);
+            r.FromId == iksId);
     }
 
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -4,6 +4,7 @@ using Altinn.AccessMgmt.PersistenceEF.Constants;
 using Altinn.AccessMgmt.PersistenceEF.Contexts;
 using Altinn.AccessMgmt.PersistenceEF.Models;
 using Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
+using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
 using Altinn.Authorization.Api.Contracts.AccessManagement;
 using Microsoft.EntityFrameworkCore;
 using DelegationPackage = Altinn.AccessMgmt.PersistenceEF.Models.DelegationPackage;
@@ -243,6 +244,66 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
         Assert.Equal("Organisasjon", orgType.Name);
     }
 
+    [Fact]
+    public async Task KeyRole_IksWithDeltakerDeltAnsvar_IsNotIncluded()
+    {
+        var personId = TestDataSet.GetEntity("Rådmann Kommune").Id;
+        var iksId = TestDataSet.GetEntity("IKS Selskap").Id;
+
+        var filter = new ConnectionQueryFilter
+        {
+            ToIds = new[] { personId },
+            IncludeKeyRole = true,
+        };
+
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true, TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(dbResult, r =>
+            r.FromId == iksId /*&&
+            r.ViaRoleId == RoleConstants.ParticipantSharedResponsibility.Id &&
+            r.Reason == ConnectionReason.KeyRole*/);
+    }
+
+    [Fact]
+    public async Task KeyRole_NonIksWithDeltakerDeltAnsvar_IsIncluded()
+    {
+        var personId = TestDataSet.GetEntity("Rådmann Kommune").Id;
+        var nonIksId = TestDataSet.GetEntity("Non-IKS Selskap").Id;
+
+        var filter = new ConnectionQueryFilter
+        {
+            ToIds = new[] { personId },
+            IncludeKeyRole = true,
+        };
+
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true, TestContext.Current.CancellationToken);
+
+        Assert.Contains(dbResult, r =>
+            r.FromId == nonIksId &&
+            r.ViaRoleId == RoleConstants.ManagingDirector.Id &&
+            r.Reason == ConnectionReason.KeyRole);
+    }
+
+    [Fact]
+    public async Task KeyRole_IksWithDifferentKeyRole_IsIncluded()
+    {
+        var personId = TestDataSet.GetEntity("Rådmann Kommune").Id;
+        var iksId = TestDataSet.GetEntity("IKS Selskap 2").Id;
+
+        var filter = new ConnectionQueryFilter
+        {
+            ToIds = new[] { personId },
+            IncludeKeyRole = true,
+        };
+
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, true, TestContext.Current.CancellationToken);
+
+        Assert.Contains(dbResult, r =>
+            r.FromId == iksId &&
+            r.ViaRoleId == RoleConstants.ManagingDirector.Id &&
+            r.Reason == ConnectionReason.KeyRole);
+    }
+
     [Theory]
     [MemberData(nameof(GetFilterCombinations))]
     public async Task GetConnectionsAsync_AllFilterFlagCombinations_DoesNotThrow(bool[] flags, bool useSingle)
@@ -327,6 +388,13 @@ internal static class TestDataSet
 
         new Entity() { Id = Guid.Parse("0195efb8-7c80-7a01-8001-000000000003"), Name = "Siri", TypeId = EntityTypeConstants.Person, VariantId = EntityVariantConstants.Person, PersonIdentifier = "07018412345", RefId = "07018412345", DateOfBirth = DateOnly.Parse("1984-01-07") },
         new Entity() { Id = Guid.Parse("0195efb8-7c80-7a01-8001-000000000004"), Name = "Lars", TypeId = EntityTypeConstants.Person, VariantId = EntityVariantConstants.Person, PersonIdentifier = "08018412345", RefId = "08018412345", DateOfBirth = DateOnly.Parse("1984-01-08") },
+
+        // IKS keyrole test entities
+        new Entity() { Id = Guid.Parse("0195efb8-7c80-7839-8b2a-8794bf7a929d"), Name = "Rådmann Kommune", TypeId = EntityTypeConstants.Person, VariantId = EntityVariantConstants.Person, PersonIdentifier = "09018412345", RefId = "09018412345", DateOfBirth = DateOnly.Parse("1984-01-09") },
+        new Entity() { Id = Guid.Parse("0195efb8-7c80-7e40-9ea1-4362ea2aefa5"), Name = "Kommune", TypeId = EntityTypeConstants.Organization, VariantId = EntityVariantConstants.KOMM, OrganizationIdentifier = "605001750", ParentId = null, RefId = "605001750" },
+        new Entity() { Id = Guid.Parse("0195efb8-7c80-76ee-a7d9-f2d76ac7187b"), Name = "IKS Selskap", TypeId = EntityTypeConstants.Organization, VariantId = EntityVariantConstants.IKS, OrganizationIdentifier = "605001769", ParentId = null, RefId = "605001769" },
+        new Entity() { Id = Guid.Parse("019f21f7-aa45-75ce-a26f-a4a06f238604"), Name = "IKS Selskap 2", TypeId = EntityTypeConstants.Organization, VariantId = EntityVariantConstants.IKS, OrganizationIdentifier = "605001785", ParentId = null, RefId = "605001785" },
+        new Entity() { Id = Guid.Parse("0195efb8-7c80-7a77-8203-e7ca159053d0"), Name = "Non-IKS Selskap", TypeId = EntityTypeConstants.Organization, VariantId = EntityVariantConstants.AS, OrganizationIdentifier = "605001777", ParentId = null, RefId = "605001777" },
     };
 
 #pragma warning disable SA1401 // Fields should be private
@@ -346,6 +414,12 @@ internal static class TestDataSet
         new Assignment() { Id = Guid.Parse("0195efb8-7c80-7a01-8001-000000000011"), FromId = Entities.First(t => t.Name == "Non-NUF Client AS").Id, ToId = Entities.First(t => t.Name == "Regnskaperne").Id, RoleId = RoleConstants.BusinessManager }, // Forretningsfører from non-NUF client
         new Assignment() { Id = Guid.Parse("0195efb8-7c80-7a01-8001-000000000012"), FromId = Entities.First(t => t.Name == "NUF International Corp").Id, ToId = Entities.First(t => t.Name == "Siri").Id, RoleId = RoleConstants.ContactPersonNUF }, // Kontaktperson NUF
         new Assignment() { Id = Guid.Parse("0195efb8-7c80-7a01-8001-000000000013"), FromId = Entities.First(t => t.Name == "NUF International Corp").Id, ToId = Entities.First(t => t.Name == "Lars").Id, RoleId = RoleConstants.NorwegianRepresentativeForeignEntity }, // Norsk representant for utenlandsk foretak
+
+        // IKS keyrole test assignments
+        new Assignment() { Id = Guid.Parse("0195efb8-7c80-7604-8518-2ddb45c89645"), FromId = Entities.First(t => t.Name == "Kommune").Id, ToId = Entities.First(t => t.Name == "Rådmann Kommune").Id, RoleId = RoleConstants.ManagingDirector }, // daglig-leder (different keyrole)
+        new Assignment() { Id = Guid.Parse("0195efb8-7c80-7532-9427-433385e63908"), FromId = Entities.First(t => t.Name == "IKS Selskap").Id, ToId = Entities.First(t => t.Name == "Kommune").Id, RoleId = RoleConstants.ParticipantSharedResponsibility }, // deltaker-delt-ansvar (keyrole) for IKS Selskap
+        new Assignment() { Id = Guid.Parse("0195efb8-7c80-7b15-bfc8-4d596bc18d01"), FromId = Entities.First(t => t.Name == "IKS Selskap 2").Id, ToId = Entities.First(t => t.Name == "Kommune").Id, RoleId = RoleConstants.Accountant }, // Regnskapsfører  (not deltaker-delt-ansvar) for IKS Selskap
+        new Assignment() { Id = Guid.Parse("0195efb8-7c80-7d79-87ce-f1dcdf1bba79"), FromId = Entities.First(t => t.Name == "Non-IKS Selskap").Id, ToId = Entities.First(t => t.Name == "Kommune").Id, RoleId = RoleConstants.ParticipantSharedResponsibility }, // deltaker-delt-ansvar (keyrole) for Non IKS Selskap
     };
 
     internal static Assignment GetAssignment(string fromName, string toName, Guid roleId)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed key role inheritance when the role inherited is deltaker-delt-ansvar and the entity the role is for is of variant IKS this prevents key role holders in eier-kommuner to gain access to any IKS they own. 

## Related Issue(s)
- #3510

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
