### PR TITLE
Select written policies by path instead of Last() in connections tests

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.AddInstanceRights.cs
@@ -146,7 +146,11 @@ public partial class ConnectionsControllerTest
             Assert.NotNull(policyFactory);
             Assert.NotEmpty(policyFactory.WrittenPolicies);
 
-            var (policyPath, content) = policyFactory.WrittenPolicies.Last();
+            // WrittenPolicies is shared by all tests in the class and is unordered,
+            // so select this delegation's policy by its blob path.
+            byte[] content = Assert.Single(
+                policyFactory.WrittenPolicies,
+                p => p.Key.Contains("app_skd_sirius-skattemelding-v1") && p.Key.Contains($"to_{TestData.KaosMagicDesignAndArts.Id}")).Value;
             XacmlPolicy policy;
             using (XmlReader reader = XmlReader.Create(new MemoryStream(content)))
             {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateInstanceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateInstanceRights.cs
@@ -213,9 +213,12 @@ public partial class ConnectionsControllerTest
             // Step 5: Verify the written XACML policy
             var policyFactory = Fixture.Server.Services.GetRequiredService<IPolicyFactory>() as PolicyFactoryMock;
             Assert.NotNull(policyFactory);
-            Assert.NotEmpty(policyFactory.WrittenPolicies);
 
-            var (_, content) = policyFactory.WrittenPolicies.Last();
+            // WrittenPolicies is shared by all tests in the class and is unordered,
+            // so select this delegation's policy by its blob path.
+            byte[] content = Assert.Single(
+                policyFactory.WrittenPolicies,
+                p => p.Key.Contains("app_skd_sirius-skattemelding-v1") && p.Key.Contains($"to_{TestData.Thea.Id}")).Value;
             XacmlPolicy policy;
             using (XmlReader reader = XmlReader.Create(new MemoryStream(content)))
             {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateResourceRights.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ConnectionsControllerTest.UpdateResourceRights.cs
@@ -162,7 +162,11 @@ public partial class ConnectionsControllerTest
             Assert.NotNull(policyFactory);
             Assert.NotEmpty(policyFactory.WrittenPolicies);
 
-            var (path, content) = policyFactory.WrittenPolicies.Last();
+            // WrittenPolicies is shared by all tests in the class and is unordered,
+            // so select this delegation's policy by its blob path.
+            byte[] content = Assert.Single(
+                policyFactory.WrittenPolicies,
+                p => p.Key.Contains("mattilsynet-baker-konditorvare")).Value;
             XacmlPolicy policy;
             using (XmlReader reader = XmlReader.Create(new MemoryStream(content)))
             {


### PR DESCRIPTION
`UpdateInstanceRights_AsManagingDirectorToRecipient_WithMoreRightKeys_ReturnsOkAndUpdatesRights` fails intermittently with "expected 3, actual 1" on the written-policy rule count. The test picks the policy to verify with `PolicyFactoryMock.WrittenPolicies.Last()`, but `WrittenPolicies` is a `ConcurrentDictionary` shared by all tests in the class, and its enumeration order depends on the process' randomized string hash seed. When the 1-rule policy written by the reduce-rights test in the same class happens to enumerate last, the assertion reads the wrong policy. The endpoint itself behaves correctly: in the failing run the GET after the update returned all three rights, and the updated policy blob contained all three rules.

The fix selects the written policy by its blob path (resource and to-party) instead of `Last()`, in `UpdateInstanceRights` and in the two other classes using the same pattern (`AddInstanceRights`, `UpdateResourceRights`).

Closes #3701
