### PR TITLE
Deny delegation of non-delegable maskinporten resources to suppliers

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
@@ -1002,7 +1002,7 @@ public partial class ConnectionService(
         }
 
         ResourceAccessListMode accessListMode = resourceMetadata.AccessListMode;
-        bool isResourceDelegable = ignoreDelegableFlag || resourceMetadata.Delegable || (allowMaskinportenSchema && isMaskinPortenSchemaResource);
+        bool isResourceDelegable = ignoreDelegableFlag || resourceMetadata.Delegable;
 
         // Decompose policy into resource/tasks
         List<Models.Right> rights = DelegationCheckHelper.DecomposePolicy(policy, resource);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IConnectionService.cs
@@ -198,7 +198,7 @@ public interface IConnectionService
     /// <param name="configureConnection">ConnectionOptions</param>
     /// <param name="languageCode">the requested language code fallback "nb"</param>
     /// <param name="ignoreDelegableFlag">When true, the resource's Delegable flag is ignored and only the user's access is checked. Used for consent scenarios where re-delegation should not be allowed but access verification is still needed.</param>
-    /// <param name="allowMaskinportenSchema">When true, allows delegation of MaskinportenSchema resources even if delegable=false, but still requires valid access rights. Used for Maskinporten scope delegation scenarios.</param>
+    /// <param name="allowMaskinportenSchema">When true, MaskinportenSchema resources are not denied for being MaskinportenSchema. The Delegable flag and access rights still apply. Used by the dedicated Maskinporten scope delegation API.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The result on all the resource/action that is delegable on the resource and a reason behind if the user can or can not delegate a given action</returns>
     Task<Result<ResourceCheckDto>> ResourceDelegationCheck(Guid authenticatedUserUuid, Guid party, string resource, Action<ConnectionOptions> configureConnection = null, string languageCode = "nb", bool ignoreDelegableFlag = false, bool allowMaskinportenSchema = false, CancellationToken cancellationToken = default);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/MaskinportenSupplierService.cs
@@ -9,6 +9,7 @@ using Altinn.AccessMgmt.PersistenceEF.Contexts;
 using Altinn.AccessMgmt.PersistenceEF.Extensions;
 using Altinn.AccessMgmt.PersistenceEF.Models;
 using Altinn.Authorization.Api.Contracts.AccessManagement;
+using Altinn.Authorization.Api.Contracts.AccessManagement.Enums;
 using Altinn.Authorization.ProblemDetails;
 using Microsoft.EntityFrameworkCore;
 
@@ -347,12 +348,11 @@ public class MaskinportenSupplierService(
             return Problems.InvalidResource;
         }
 
-        // Delegate to ConnectionService with allowMaskinportenSchema = true for MaskinportenSchema resources
-        // This allows delegation even if delegable=false in Resource Registry, but still requires valid access rights.
-        // 
-        // Technical note: allowMaskinportenSchema bypasses the MaskinportenSchema denial logic in 
-        // ConnectionService.MapFromInternalToExternalRight, allowing rights to have Result=true
-        // when the caller has proper authorization. This enables AddResource to succeed with delegable rights.
+        // Delegate to ConnectionService with allowMaskinportenSchema = true.
+        // MaskinportenSchema resources are denied in the regular delegation flow because they must be
+        // delegated through this dedicated API; the flag bypasses only that denial. The delegable flag
+        // from the Resource Registry still applies, so non-delegable resources get Result=false with
+        // reason ResourceNotDelegable.
         return await connectionService.ResourceDelegationCheck(
             authenticatedUserUuid,
             consumerId,
@@ -407,6 +407,13 @@ public class MaskinportenSupplierService(
 
         if (!delegableRightKeys.Any())
         {
+            // A resource marked delegable=false in the Resource Registry is a problem with the
+            // resource itself, not the caller's authorization
+            if (delegationCheck.Value.Rights.Any(r => r.ReasonCodes?.Contains(DelegationCheckReasonCode.ResourceNotDelegable) == true))
+            {
+                return Problems.ResourceNotDelegable;
+            }
+
             return Problems.NotAuthorizedForDelegationRequest;
         }
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Data/ResourceRegistryResources/non_delegable_maskinportenschema/resource.json
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Data/ResourceRegistryResources/non_delegable_maskinportenschema/resource.json
@@ -17,10 +17,11 @@
   "validFrom": "2022-09-20T06:46:07.598Z",
   "identifier": "non_delegable_maskinportenschema",
   "isComplete": true,
+  "delegable": false,
   "description": {
-    "en": "A MaskinportenSchema with a RoleRequirement (NOPE) to a role which does not exist and so cannot be delegated",
-    "nb-no": "A MaskinportenSchema with a RoleRequirement (NOPE) to a role which does not exist and so cannot be delegated",
-    "nn-no": "A MaskinportenSchema with a RoleRequirement (NOPE) to a role which does not exist and so cannot be delegated"
+    "en": "A MaskinportenSchema resource with delegable set to false in the Resource Registry",
+    "nb-no": "A MaskinportenSchema resource with delegable set to false in the Resource Registry",
+    "nn-no": "A MaskinportenSchema resource with delegable set to false in the Resource Registry"
   },
   "resourceType": "MaskinportenSchema",
   "thematicArea": "http://publications.europa.eu/resource/authority/eurovoc/2468",

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Data/Xacml/3.0/ResourceRegistry/non_delegable_maskinportenschema/resourcepolicy.xml
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Data/Xacml/3.0/ResourceRegistry/non_delegable_maskinportenschema/resourcepolicy.xml
@@ -1,44 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xacml:Policy xmlns:xsl="http://www.w3.org/2001/XMLSchema-instance" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="urn:altinn:example:maskinportenschema:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides">
-	<xacml:Target/>
-	<xacml:Rule RuleId="urn:altinn:example:ruleid:1" Effect="Permit">
-		<xacml:Description></xacml:Description>
-		<xacml:Target>
-			<xacml:AnyOf>
-				<xacml:AllOf>
-					<xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
-						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">NOPE</xacml:AttributeValue>
-						<xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
-					</xacml:Match>
-				</xacml:AllOf>
-			</xacml:AnyOf>
-			<xacml:AnyOf>
-				<xacml:AllOf>
-					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">non_delegable_maskinportenschema</xacml:AttributeValue>
-						<xacml:AttributeDesignator AttributeId="urn:altinn:resource" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
-					</xacml:Match>
-				</xacml:AllOf>
-			</xacml:AnyOf>
-			<xacml:AnyOf>
-				<xacml:AllOf>
-					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
-						<xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
-					</xacml:Match>
-					<xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-						<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
-						<xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
-					</xacml:Match>
-				</xacml:AllOf>
-			</xacml:AnyOf>
-		</xacml:Target>
-	</xacml:Rule>
-	<xacml:ObligationExpressions>
-		<xacml:ObligationExpression FulfillOn="Permit" ObligationId="urn:altinn:obligation:authenticationLevel1">
-			<xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel">
-				<xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue>
-			</xacml:AttributeAssignmentExpression>
-		</xacml:ObligationExpression>
-	</xacml:ObligationExpressions>
+<xacml:Policy PolicyId="urn:altinn:policyid:1" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" xmlns:xacml="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17">
+  <xacml:Target />
+  <xacml:Rule RuleId="urn:altinn:resource:non_delegable_maskinportenschema:ruleid:1" Effect="Permit">
+    <xacml:Description></xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">knuf</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">loper</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">a0241</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">a0239</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">a0240</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">lonn-personopplysninger-saerlig-kategori</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:accesspackage" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">regnskapsforer-lonn</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:accesspackage" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">non_delegable_maskinportenschema</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:resource" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">read</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:ObligationExpressions>
+    <xacml:ObligationExpression ObligationId="urn:altinn:obligation:authenticationLevel1" FulfillOn="Permit">
+      <xacml:AttributeAssignmentExpression AttributeId="urn:altinn:obligation1-assignment1" Category="urn:altinn:minimum-authenticationlevel">
+        <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#integer">2</xacml:AttributeValue>
+      </xacml:AttributeAssignmentExpression>
+    </xacml:ObligationExpression>
+  </xacml:ObligationExpressions>
 </xacml:Policy>

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/MaskinportenSupplierServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/MaskinportenSupplierServiceTests.cs
@@ -1,3 +1,4 @@
+using Altinn.AccessManagement.Core.Errors;
 using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Services.Interfaces;
 using Altinn.AccessManagement.TestUtils.Fixtures;
@@ -9,6 +10,7 @@ using Altinn.AccessMgmt.PersistenceEF.Contexts;
 using Altinn.AccessMgmt.PersistenceEF.Extensions;
 using Altinn.AccessMgmt.PersistenceEF.Models;
 using Altinn.Authorization.Api.Contracts.AccessManagement;
+using Altinn.Authorization.Api.Contracts.AccessManagement.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -425,7 +427,7 @@ public class MaskinportenSupplierServiceTests : IClassFixture<ApiFixture>
     }
 
     [Fact]
-    public async Task AddResource_WhenDelegationCheckReturnsNoDelegableRights_ReturnsProblem()
+    public async Task AddResource_WhenDelegationCheckReturnsNoDelegableRights_ReturnsNotAuthorizedProblem()
     {
         // Delegation check succeeds but no right is delegable -> not authorized, before any connection check.
         var result = await RunService(
@@ -434,10 +436,25 @@ public class MaskinportenSupplierServiceTests : IClassFixture<ApiFixture>
             audit: AuditAs(Performer));
 
         result.IsProblem.Should().BeTrue();
+        result.Problem.ErrorCode.Should().Be(Problems.NotAuthorizedForDelegationRequest.ErrorCode);
     }
 
     [Fact]
-    public async Task AddResource_WhenNoSupplierConnectionExists_ReturnsProblem()
+    public async Task AddResource_WhenResourceIsNotDelegable_ReturnsResourceNotDelegableProblem()
+    {
+        // The delegation check denies every right with reason ResourceNotDelegable (delegable=false
+        // in the Resource Registry) -> a resource problem, not a missing-authorization problem.
+        var result = await RunService(
+            s => s.AddResource(AddResNoRightsConsumer, AddResNoRightsSupplier, MaskinportenResourceRefId, TestContext.Current.CancellationToken),
+            connection: ConnectionReturning(("scope.read", false, DelegationCheckReasonCode.ResourceNotDelegable)),
+            audit: AuditAs(Performer));
+
+        result.IsProblem.Should().BeTrue();
+        result.Problem.ErrorCode.Should().Be(Problems.ResourceNotDelegable.ErrorCode);
+    }
+
+    [Fact]
+    public async Task AddResource_WhenNoSupplierConnectionExists_ReturnsMissingConnectionProblem()
     {
         // There are delegable rights, but no supplier assignment between the parties.
         var result = await RunService(
@@ -446,10 +463,11 @@ public class MaskinportenSupplierServiceTests : IClassFixture<ApiFixture>
             audit: AuditAs(Performer));
 
         result.IsProblem.Should().BeTrue();
+        result.Problem.ErrorCode.Should().Be(Problems.MissingConnection.ErrorCode);
     }
 
     [Fact]
-    public async Task AddResource_WhenPolicyRuleWriteFails_ReturnsProblem()
+    public async Task AddResource_WhenPolicyRuleWriteFails_ReturnsPolicyWriteFailedProblem()
     {
         var singleRights = new Mock<ISingleRightsService>();
         singleRights
@@ -465,6 +483,7 @@ public class MaskinportenSupplierServiceTests : IClassFixture<ApiFixture>
             audit: AuditAs(Performer));
 
         result.IsProblem.Should().BeTrue();
+        result.Problem.ErrorCode.Should().Be(Problems.DelegationPolicyRuleWriteFailed.ErrorCode);
     }
 
     [Fact]
@@ -488,12 +507,20 @@ public class MaskinportenSupplierServiceTests : IClassFixture<ApiFixture>
     }
 
     private static IConnectionService ConnectionReturning(params (string Key, bool Result)[] rights)
+        => ConnectionReturning(rights.Select(r => (r.Key, r.Result, (DelegationCheckReasonCode?)null)).ToArray());
+
+    private static IConnectionService ConnectionReturning(params (string Key, bool Result, DelegationCheckReasonCode? Reason)[] rights)
     {
         var dto = new ResourceCheckDto
         {
             Resource = new ResourceDto(),
             Rights = rights
-                .Select(r => new RightCheckDto { Right = new RightDto { Key = r.Key }, Result = r.Result })
+                .Select(r => new RightCheckDto
+                {
+                    Right = new RightDto { Key = r.Key },
+                    Result = r.Result,
+                    ReasonCodes = r.Reason is null ? [] : [r.Reason.Value],
+                })
                 .ToList(),
         };
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/MaskinportenSuppliersControllerResourceDelegationTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/MaskinportenSuppliersControllerResourceDelegationTest.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text.Json;
+using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessManagement.Core.Services.Interfaces;
+using Altinn.AccessManagement.TestUtils;
+using Altinn.AccessManagement.TestUtils.Data;
+using Altinn.AccessManagement.TestUtils.Fixtures;
+using Altinn.AccessManagement.TestUtils.Mocks;
+using Altinn.AccessMgmt.Core;
+using Altinn.Authorization.Api.Contracts.AccessManagement;
+using Altinn.Authorization.Api.Contracts.AccessManagement.Enums;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Altinn.AccessManagement.Enduser.Api.Tests.Integration.Controllers;
+
+/// <summary>
+/// HTTP integration tests for the resource delegation endpoints on
+/// <see cref="Altinn.AccessManagement.Api.Enduser.Controllers.MaskinportenSuppliersController"/>,
+/// exercising the full pipeline (routing, scope authorization, real services + database via
+/// <see cref="ApiFixture"/>, resource registry and policy mocks).
+///
+/// The tests cover the Resource Registry delegable flag: a MaskinportenSchema resource with
+/// delegable=false must not be delegated through this API, even though the dedicated maskinporten
+/// API is otherwise allowed to delegate MaskinportenSchema resources. Mirrors the Bruno test
+/// <c>Negative_POST_Delegate_non_Delegable_Maskinporten_resource_To_supplier_Org</c>.
+///
+/// Test data: the resource <c>non_delegable_maskinportenschema</c> is seeded in the database via
+/// <see cref="TestDataSeeds"/> and defined with delegable=false in the resource registry mock data.
+/// Its policy grants the same roles and packages as <c>nav_sykepenger_dialog</c>, so Malin Emilie
+/// (managing director of Dumbo Adventures) has delegable rights on it; the delegable flag is the
+/// only blocker.
+/// </summary>
+[IntegrationTest]
+public class MaskinportenSuppliersControllerResourceDelegationTest : IClassFixture<ApiFixture>
+{
+    private const string Route = "accessmanagement/api/v1/enduser/maskinportensuppliers";
+    private const string NonDelegableResource = "non_delegable_maskinportenschema";
+
+    private static readonly Guid Consumer = TestData.DumboAdventures.Id;
+    private static readonly string SupplierOrgNo = TestData.FredriksonsFabrikk.Entity.OrganizationIdentifier;
+
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    public MaskinportenSuppliersControllerResourceDelegationTest(ApiFixture fixture)
+    {
+        Fixture = fixture;
+        Fixture.WithEnabledFeatureFlag(AccessMgmtFeatureFlags.EnableEnduserMaskinportenAdminApi);
+        Fixture.ConfigureServices(services =>
+        {
+            services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPointMock>();
+        });
+    }
+
+    private ApiFixture Fixture { get; }
+
+    /// <summary>
+    /// Malin (MD of Dumbo Adventures) checks the non-delegable MaskinportenSchema resource.
+    /// She has role and package access, but the resource is delegable=false in the Resource
+    /// Registry, so every right must come back denied with reason ResourceNotDelegable.
+    /// </summary>
+    [Fact]
+    public async Task DelegationCheck_WhenResourceNotDelegable_Returns200WithAllRightsDeniedAsResourceNotDelegable()
+    {
+        var client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_MASKINPORTENSUPPLIERS_READ);
+
+        var response = await client.GetAsync(
+            $"{Route}/resources/delegationcheck?party={Consumer}&resource={NonDelegableResource}", TestContext.Current.CancellationToken);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(response.StatusCode == HttpStatusCode.OK, $"Expected OK but got {response.StatusCode}. Body: {body}");
+
+        var result = JsonSerializer.Deserialize<ResourceCheckDto>(body, JsonOpts);
+        Assert.NotNull(result);
+        Assert.NotEmpty(result.Rights);
+        Assert.All(result.Rights, r => Assert.False(r.Result, $"Right '{r.Right.Name}' must not be delegable"));
+        Assert.All(result.Rights, r => Assert.Contains(DelegationCheckReasonCode.ResourceNotDelegable, r.ReasonCodes));
+    }
+
+    /// <summary>
+    /// Delegating the non-delegable MaskinportenSchema resource to a supplier must fail with
+    /// 400 "The resource is not available for delegation" instead of writing the delegation.
+    /// </summary>
+    [Fact]
+    public async Task AddResource_WhenResourceNotDelegable_Returns400WithResourceNotDelegable()
+    {
+        var client = CreateClient(TestData.MalinEmilie.Id, AuthzConstants.SCOPE_ENDUSER_MASKINPORTENSUPPLIERS_WRITE);
+
+        var response = await client.PostAsync(
+            $"{Route}/resources?party={Consumer}&supplier={SupplierOrgNo}&resource={NonDelegableResource}", null, TestContext.Current.CancellationToken);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.True(response.StatusCode == HttpStatusCode.BadRequest, $"Expected BadRequest but got {response.StatusCode}. Body: {body}");
+
+        using var problem = JsonDocument.Parse(body);
+        Assert.Equal("The resource is not available for delegation", problem.RootElement.GetProperty("detail").GetString());
+    }
+
+    private HttpClient CreateClient(Guid partyUuid, params string[] scopes)
+    {
+        var client = Fixture.Server.CreateClient();
+        var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+        {
+            claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, partyUuid.ToString()));
+            claims.Add(new Claim("scope", string.Join(" ", scopes)));
+        });
+        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+        return client;
+    }
+}

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/RequestControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/RequestControllerTest.cs
@@ -66,12 +66,6 @@ public class RequestControllerTest
             Name = "CreateResourceTestType",
         };
 
-        private static readonly ResourceType TestMaskinportenSchemaResourceType = new()
-        {
-            Id = Guid.Parse("0196c001-0000-7000-8000-000000000002"),
-            Name = "MaskinportenSchema",
-        };
-
         private static readonly Guid TestResourceId = Guid.Parse("0196b001-0000-7000-8000-000000000002");
         private const string TestResourceRefId = "create-resource-test-1";
         private const string TestMaskinportenSchemaResourceRefId = "create-resource-test-2";
@@ -83,7 +77,6 @@ public class RequestControllerTest
             fixture.EnsureSeedOnce<CreateResourceRequest>(db =>
             {
                 db.ResourceTypes.Add(TestResourceType);
-                db.ResourceTypes.Add(TestMaskinportenSchemaResourceType);
 
                 db.SaveChanges();
                 db.Resources.Add(new Resource
@@ -103,7 +96,7 @@ public class RequestControllerTest
                     Description = "Test resource for ServiceOwner API tests",
                     RefId = TestMaskinportenSchemaResourceRefId,
                     ProviderId = TestData.ServiceOwnerNAV,
-                    TypeId = TestMaskinportenSchemaResourceType.Id,
+                    TypeId = TestData.MaskinportenSchemaResourceType.Id,
                 });
 
                 db.SaveChanges();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Integration/Controllers/RequestControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Integration/Controllers/RequestControllerTest.cs
@@ -131,12 +131,6 @@ public class RequestControllerTest
             Name = "ServiceOwnerTestResourceType",
         };
 
-        private static readonly ResourceType TestMaskinportenSchemaResourceType = new()
-        {
-            Id = Guid.Parse("0196c001-0000-7000-8000-000000000002"),
-            Name = "MaskinportenSchema",
-        };
-
         public CreateResourceRequestTest(ApiFixture fixture)
         {
             Fixture = fixture;
@@ -144,7 +138,6 @@ public class RequestControllerTest
             fixture.EnsureSeedOnce<CreateResourceRequestTest>(db =>
             {
                 db.ResourceTypes.Add(TestResourceType);
-                db.ResourceTypes.Add(TestMaskinportenSchemaResourceType);
                 db.SaveChanges();
 
                 db.Resources.Add(new Resource
@@ -164,7 +157,7 @@ public class RequestControllerTest
                     Description = "Test resource for ServiceOwner API tests",
                     RefId = "test-resource-so-maskinporten-1",
                     ProviderId = TestData.ServiceOwnerNAV,
-                    TypeId = TestMaskinportenSchemaResourceType.Id,
+                    TypeId = TestData.MaskinportenSchemaResourceType.Id,
                 });
 
                 db.SaveChanges();

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Data/TestData.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Data/TestData.cs
@@ -25,6 +25,16 @@ public static class TestData
         Name = "CorrespondenceService",
     };
 
+    /// <summary>
+    /// The resource type for MaskinportenSchema resources. The name must match the real
+    /// resource type name, which the maskinporten supplier delegation flow checks against.
+    /// </summary>
+    public static ResourceType MaskinportenSchemaResourceType { get; } = new()
+    {
+        Id = Guid.Parse("019d95d1-95c7-7887-91cc-30fc9af97192"),
+        Name = "MaskinportenSchema",
+    };
+
     #endregion
 
     #region Resources
@@ -37,6 +47,20 @@ public static class TestData
         RefId = "ttd-migratedcorrespondence-4471-1",
         TypeId = TestData.CorrespondenceResourceType.Id,
         ProviderId = ProviderConstants.Altinn2.Id,
+    };
+
+    /// <summary>
+    /// MaskinportenSchema resource marked delegable=false in the resource registry mock data
+    /// (<c>Data/ResourceRegistryResources/non_delegable_maskinportenschema</c>).
+    /// </summary>
+    public static readonly Resource NonDelegableMaskinportenSchema = new()
+    {
+        Id = Guid.Parse("019d95d3-92d5-750f-a594-a8b08e756a4b"),
+        Name = "MaskinportenSchema that cannot be delegated",
+        Description = "MaskinportenSchema resource with delegable set to false in the Resource Registry",
+        RefId = "non_delegable_maskinportenschema",
+        TypeId = TestData.MaskinportenSchemaResourceType.Id,
+        ProviderId = ProviderConstants.ResourceRegistry.Id,
     };
 
     public static readonly Resource MattilsynetBakeryService = new()

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/TestDataSeeds.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/TestDataSeeds.cs
@@ -30,6 +30,7 @@ public static class TestDataSeeds
         #region Resource Types
         db.ResourceTypes.Add(TestData.TestResourceType);
         db.ResourceTypes.Add(TestData.CorrespondenceResourceType);
+        db.ResourceTypes.Add(TestData.MaskinportenSchemaResourceType);
         #endregion
 
         #region Entities
@@ -176,6 +177,7 @@ public static class TestDataSeeds
         db.Resources.Add(TestData.NavSykepengerSykmelding);
         db.Resources.Add(TestData.SkattResource);
         db.Resources.Add(TestData.TestdirektoratetCorrespondenceService);
+        db.Resources.Add(TestData.NonDelegableMaskinportenSchema);
         db.Resources.AddRange(TestData.MvaResource);
 
         #endregion

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Maskinporten/Suppliers_API/Negative_scenarioer/Negative_POST_Delegate_non_Delegable_Maskinporten_resource_To_supplier_Org.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/Maskinporten/Suppliers_API/Negative_scenarioer/Negative_POST_Delegate_non_Delegable_Maskinporten_resource_To_supplier_Org.bru
@@ -41,10 +41,10 @@ script:pre-request {
 tests {
   const testdata = require(`./testdata/maksinporten-delegation/${bru.getEnvVar("tokenEnv")}.js`); 
   
-  test("Delegate maskinporten resource to supplier org", function() {
+  test("Delegating a non-delegable maskinporten resource returns 400", function() {
     const data = res.getBody();
     expect(res.status).to.equal(400);
-     expect(res.getBody().detail).to.equal("The resource is invalid");
+     expect(res.getBody().detail).to.equal("The resource is not available for delegation");
      });
 }
 

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/Problems.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/Errors/Problems.cs
@@ -177,4 +177,8 @@ public static class Problems
     /// <summary>Gets a <see cref="ProblemDescriptor"/>.</summary>
     public static ProblemDescriptor DelegationCheckFailureInvalidPackage { get; }
     = _factory.Create(41, HttpStatusCode.BadRequest, "One or more of the provided packages are either invalid or not eligible for delegation by the type of from-party of the delegation.");
+
+    /// <summary>Gets a <see cref="ProblemDescriptor"/>.</summary>
+    public static ProblemDescriptor ResourceNotDelegable { get; }
+    = _factory.Create(42, HttpStatusCode.BadRequest, "The resource is not available for delegation");
 }


### PR DESCRIPTION
Closes #3703

## What

The enduser maskinporten supplier API accepted delegation of MaskinportenSchema resources marked `delegable=false` in the Resource Registry and returned 200. The `allowMaskinportenSchema` flag in `ConnectionService.ResourceDelegationCheck` was overriding the delegable flag; it now only bypasses the "MaskinportenSchema resources must use the dedicated API" denial.

- `POST /enduser/maskinportensuppliers/resources` returns 400 with a new error, `ResourceNotDelegable` ("The resource is not available for delegation"), when the resource is non-delegable.
- `GET /enduser/maskinportensuppliers/resources/delegationcheck` returns 200 with `Result=false` and reason `ResourceNotDelegable` on every right.
- The Bruno negative test asserts the new message.

## Tests

- New full-pipeline integration tests for both endpoints. The `non_delegable_maskinportenschema` mock resource is reworked to carry `delegable=false` with a policy that grants the acting user role and package access, so the delegable flag is the only blocker.
- Service-level tests cover the new `AddResource` branch, and some existing assertions are strengthened from "any problem" to the specific error code.
- The shared test seed now provides the `MaskinportenSchema` resource type; two request-controller test classes that seeded their own are switched to it to avoid violating the unique name index on resource types.

Note: `UpdateInstanceRights_AsManagingDirectorToRecipient_WithMoreRightKeys_ReturnsOkAndUpdatesRights` fails on main independent of this change (verified on a clean checkout). It is not touched here.
