### PR TITLE
chore: replace AutoMapper with Mapperly in Altinn.Authorization

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -114,6 +114,7 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version=" 1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="Riok.Mapperly" Version="4.3.1" />
     <PackageVersion Include="Spectre.Console" Version="0.57.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Altinn.Authorization.csproj
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Altinn.Authorization.csproj
@@ -16,7 +16,6 @@
         <PackageReference Include="Altinn.Swashbuckle" />
         <PackageReference Include="Altinn.Urn" />
         <PackageReference Include="Altinn.Urn.Swashbuckle" />
-        <PackageReference Include="AutoMapper" />
         <PackageReference Include="Azure.Identity" />
         <PackageReference Include="Azure.Security.KeyVault.Secrets" />
         <PackageReference Include="Azure.Storage.Queues" />
@@ -43,6 +42,7 @@
         <PackageReference Include="Npgsql" />
         <PackageReference Include="Npgsql.DependencyInjection" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+        <PackageReference Include="Riok.Mapperly" />
         <PackageReference Include="Swashbuckle.AspNetCore" />
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" />

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
@@ -23,7 +23,6 @@ using Altinn.Platform.Authorization.Services.Interfaces;
 using Altinn.Platform.Authorization.Telemetry;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
-using AutoMapper;
 using Azure.Core;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -52,7 +51,6 @@ namespace Altinn.Platform.Authorization.Controllers
         private readonly IRegisterService _registerService;
         private readonly IAccessListAuthorization _accessListAuthorization;
         private readonly DecisionTelemetry _decisionTelemetry;
-        private readonly IMapper _mapper;
 
         private readonly SortedDictionary<string, AuthInfo> _appInstanceInfo = new();
 
@@ -79,7 +77,6 @@ namespace Altinn.Platform.Authorization.Controllers
         /// <param name="eventLog">the authorization event logger</param>
         /// <param name="featureManager">the feature manager</param>
         /// <param name="decisionTelemetry">PDP decision metric recorder</param>
-        /// <param name="mapper">The model mapper</param>
         public DecisionController(
             IAccessManagementWrapper accessManagement,
             IResourceRegistry resourceRegistry,
@@ -93,8 +90,7 @@ namespace Altinn.Platform.Authorization.Controllers
             IMemoryCache memoryCache,
             IEventLog eventLog,
             IFeatureManager featureManager,
-            DecisionTelemetry decisionTelemetry,
-            IMapper mapper)
+            DecisionTelemetry decisionTelemetry)
         {
             _pdp = new PolicyDecisionPoint();
             _prp = policyRetrievalPoint;
@@ -109,7 +105,6 @@ namespace Altinn.Platform.Authorization.Controllers
             _registerService = registerService;
             _accessListAuthorization = accessListAuthorization;
             _decisionTelemetry = decisionTelemetry;
-            _mapper = mapper;
         }
 
         /// <summary>
@@ -193,9 +188,9 @@ namespace Altinn.Platform.Authorization.Controllers
         {
             try
             {
-                XacmlJsonRequestRoot jsonRequest = _mapper.Map<XacmlJsonRequestRoot>(authorizationRequest);
+                XacmlJsonRequestRoot jsonRequest = RequestMapper.ToInternal(authorizationRequest);
                 XacmlJsonResponse xacmlResponse = await Authorize(jsonRequest.Request, true, cancellationToken);
-                return _mapper.Map<XacmlJsonResponseExternal>(xacmlResponse);
+                return RequestMapper.ToExternal(xacmlResponse);
             }
             catch (Exception ex)
             {
@@ -223,7 +218,7 @@ namespace Altinn.Platform.Authorization.Controllers
                 {
                     try
                     {
-                        List<XacmlContextRequest> requestList = GetRequestForLog(_mapper.Map<XacmlJsonRequestRoot>(authorizationRequest).Request);
+                        List<XacmlContextRequest> requestList = GetRequestForLog(RequestMapper.ToInternal(authorizationRequest).Request);
                         if (requestList.Count == 1 && logSingleRequest)
                         {
                             await _eventLog.CreateAuthorizationEvent(_featureManager, requestList[0], HttpContext, xacmlContextResponse, cancellationToken);
@@ -242,7 +237,7 @@ namespace Altinn.Platform.Authorization.Controllers
                     }
                 }
 
-                return _mapper.Map<XacmlJsonResponseExternal>(jsonResult);
+                return RequestMapper.ToExternal(jsonResult);
             }
         }
 

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs
@@ -188,9 +188,9 @@ namespace Altinn.Platform.Authorization.Controllers
         {
             try
             {
-                XacmlJsonRequestRoot jsonRequest = RequestMapper.ToInternal(authorizationRequest);
+                XacmlJsonRequestRoot jsonRequest = authorizationRequest.ToInternal();
                 XacmlJsonResponse xacmlResponse = await Authorize(jsonRequest.Request, true, cancellationToken);
-                return RequestMapper.ToExternal(xacmlResponse);
+                return xacmlResponse.ToExternal();
             }
             catch (Exception ex)
             {
@@ -218,7 +218,7 @@ namespace Altinn.Platform.Authorization.Controllers
                 {
                     try
                     {
-                        List<XacmlContextRequest> requestList = GetRequestForLog(RequestMapper.ToInternal(authorizationRequest).Request);
+                        List<XacmlContextRequest> requestList = GetRequestForLog(authorizationRequest.ToInternal().Request);
                         if (requestList.Count == 1 && logSingleRequest)
                         {
                             await _eventLog.CreateAuthorizationEvent(_featureManager, requestList[0], HttpContext, xacmlContextResponse, cancellationToken);
@@ -237,7 +237,7 @@ namespace Altinn.Platform.Authorization.Controllers
                     }
                 }
 
-                return RequestMapper.ToExternal(jsonResult);
+                return jsonResult.ToExternal();
             }
         }
 

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/External/RequestMapper.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/External/RequestMapper.cs
@@ -1,44 +1,31 @@
-﻿using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+using Riok.Mapperly.Abstractions;
 
 namespace Altinn.Platform.Authorization.Models.External
 {
     /// <summary>
-    /// A class that hold access managment mapping
+    /// Maps between the external XACML JSON models exposed by the authorize endpoint
+    /// and the internal XACML JSON profile models.
     /// </summary>
-    public class RequestMapper : AutoMapper.Profile
+    [Mapper(UseDeepCloning = true)]
+    public static partial class RequestMapper
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RequestMapper"/> class.
+        /// Maps an external XACML JSON request to the internal representation.
         /// </summary>
-        public RequestMapper()
-        {
-            AllowNullCollections = true;
-            CreateMap<XacmlJsonAttributeExternal, XacmlJsonAttribute>();
+        /// <param name="request">The external request root.</param>
+        /// <returns>The internal request root.</returns>
+        public static partial XacmlJsonRequestRoot ToInternal(XacmlJsonRequestRootExternal request);
 
-            CreateMap<XacmlJsonIdReferenceExternal, XacmlJsonIdReference>();
-            CreateMap<XacmlJsonMultiRequestsExternal, XacmlJsonMultiRequests>();
+        /// <summary>
+        /// Maps an internal XACML JSON response to the external representation.
+        /// </summary>
+        /// <param name="response">The internal response.</param>
+        /// <returns>The external response.</returns>
+        public static partial XacmlJsonResponseExternal ToExternal(XacmlJsonResponse response);
 
-            CreateMap<XacmlJsonPolicyIdentifierListExternal, XacmlJsonPolicyIdentifierList>();
-            CreateMap<XacmlJsonRequestExternal, XacmlJsonRequest>();
-            CreateMap<XacmlJsonRequestReferenceExternal, XacmlJsonRequestReference>();
-            CreateMap<XacmlJsonRequestRootExternal, XacmlJsonRequestRoot>();
-            CreateMap<XacmlJsonRequestExternal, XacmlJsonRequest>();
-            CreateMap<XacmlJsonObligationOrAdviceExternal, XacmlJsonObligationOrAdvice>();
-            CreateMap<XacmlJsonCategoryExternal, XacmlJsonCategory>();
-            CreateMap<XacmlJsonStatusCodeExternal, XacmlJsonStatusCode>();
-            CreateMap<XacmlJsonStatusExternal, XacmlJsonStatus>();
-
-            CreateMap<XacmlJsonResponse, XacmlJsonResponseExternal>();
-            CreateMap<XacmlJsonResult, XacmlJsonResultExternal>();
-
-            CreateMap<XacmlJsonObligationOrAdvice, XacmlJsonObligationOrAdviceExternal>();
-            CreateMap<XacmlJsonCategory, XacmlJsonCategoryExternal>();
-            CreateMap<XacmlJsonStatus, XacmlJsonStatusExternal>();
-            CreateMap<XacmlJsonStatusCode, XacmlJsonStatusCodeExternal>();
-            CreateMap<XacmlJsonPolicyIdentifierList, XacmlJsonPolicyIdentifierListExternal>();
-            CreateMap<XacmlJsonAttribute, XacmlJsonAttributeExternal>();
-            CreateMap<XacmlJsonIdReference, XacmlJsonIdReferenceExternal>();
-            CreateMap<XacmlJsonAttributeAssignment, XacmlJsonAttributeAssignmentExternal>();
-        }
+        // XForwardedForHeader is enrichment set from the incoming HTTP request, never part of the request body.
+        [MapperIgnoreTarget(nameof(XacmlJsonRequest.XForwardedForHeader))]
+        private static partial XacmlJsonRequest ToInternal(XacmlJsonRequestExternal request);
     }
 }

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/External/RequestMapper.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Models/External/RequestMapper.cs
@@ -15,17 +15,17 @@ namespace Altinn.Platform.Authorization.Models.External
         /// </summary>
         /// <param name="request">The external request root.</param>
         /// <returns>The internal request root.</returns>
-        public static partial XacmlJsonRequestRoot ToInternal(XacmlJsonRequestRootExternal request);
+        public static partial XacmlJsonRequestRoot ToInternal(this XacmlJsonRequestRootExternal request);
 
         /// <summary>
         /// Maps an internal XACML JSON response to the external representation.
         /// </summary>
         /// <param name="response">The internal response.</param>
         /// <returns>The external response.</returns>
-        public static partial XacmlJsonResponseExternal ToExternal(XacmlJsonResponse response);
+        public static partial XacmlJsonResponseExternal ToExternal(this XacmlJsonResponse response);
 
         // XForwardedForHeader is enrichment set from the incoming HTTP request, never part of the request body.
         [MapperIgnoreTarget(nameof(XacmlJsonRequest.XForwardedForHeader))]
-        private static partial XacmlJsonRequest ToInternal(XacmlJsonRequestExternal request);
+        private static partial XacmlJsonRequest ToInternal(this XacmlJsonRequestExternal request);
     }
 }

--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/Program.cs
@@ -190,7 +190,6 @@ async Task ConnectToKeyVaultAndSetApplicationInsights(ConfigurationManager confi
 void ConfigureServices(IServiceCollection services, IConfiguration config)
 {
     logger.LogInformation("Startup // ConfigureServices");
-    services.AddAutoMapper(typeof(Program));
     services.AddControllers().AddXmlSerializerFormatters();
     services.AddHealthChecks().AddCheck<HealthCheck>("authorization_health_check");
     services.AddSingleton(config);

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/RequestMapperTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/RequestMapperTest.cs
@@ -1,0 +1,249 @@
+using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+using Altinn.Platform.Authorization.Models.External;
+
+namespace Altinn.Authorization.Tests.Unit;
+
+[UnitTest]
+public class RequestMapperTest
+{
+    [Fact]
+    public void ToInternal_FullyPopulatedRequest_ReturnsRequestWithAllFieldsMapped()
+    {
+        XacmlJsonRequestRootExternal external = new()
+        {
+            Request = new XacmlJsonRequestExternal
+            {
+                ReturnPolicyIdList = true,
+                CombinedDecision = true,
+                XPathVersion = "http://www.w3.org/TR/1999/REC-xpath-19991116",
+                Category = [CreateExternalCategory("c1")],
+                Resource = [CreateExternalCategory("r1"), CreateExternalCategory("r2")],
+                Action = [CreateExternalCategory("a1")],
+                AccessSubject = [CreateExternalCategory("s1")],
+                RecipientSubject = [CreateExternalCategory("rs1")],
+                IntermediarySubject = [CreateExternalCategory("is1")],
+                RequestingMachine = [CreateExternalCategory("rm1")],
+                MultiRequests = new XacmlJsonMultiRequestsExternal
+                {
+                    RequestReference =
+                    [
+                        new XacmlJsonRequestReferenceExternal { ReferenceId = ["r1", "s1", "a1"] },
+                        new XacmlJsonRequestReferenceExternal { ReferenceId = ["r2", "s1", "a1"] },
+                    ],
+                },
+            },
+        };
+
+        XacmlJsonRequestRoot result = RequestMapper.ToInternal(external);
+
+        // The internal and external models share member names, so structural
+        // equivalence against the external source verifies every mapped member.
+        result.Request.Should().BeEquivalentTo(external.Request);
+    }
+
+    [Fact]
+    public void ToInternal_NullCollectionsAndMultiRequests_ReturnsRequestWithNullMembers()
+    {
+        XacmlJsonRequestRootExternal external = new()
+        {
+            Request = new XacmlJsonRequestExternal
+            {
+                XPathVersion = null,
+                Category = null,
+                Resource = null,
+                Action = null,
+                AccessSubject = null,
+                RecipientSubject = null,
+                IntermediarySubject = null,
+                RequestingMachine = null,
+                MultiRequests = null,
+            },
+        };
+
+        XacmlJsonRequestRoot result = RequestMapper.ToInternal(external);
+
+        result.Request.XPathVersion.Should().BeNull();
+        result.Request.Category.Should().BeNull();
+        result.Request.Resource.Should().BeNull();
+        result.Request.Action.Should().BeNull();
+        result.Request.AccessSubject.Should().BeNull();
+        result.Request.RecipientSubject.Should().BeNull();
+        result.Request.IntermediarySubject.Should().BeNull();
+        result.Request.RequestingMachine.Should().BeNull();
+        result.Request.MultiRequests.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToInternal_AnyRequest_LeavesXForwardedForHeaderNull()
+    {
+        XacmlJsonRequestRootExternal external = new()
+        {
+            Request = new XacmlJsonRequestExternal
+            {
+                Resource = [CreateExternalCategory("r1")],
+            },
+        };
+
+        XacmlJsonRequestRoot result = RequestMapper.ToInternal(external);
+
+        result.Request.XForwardedForHeader.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToExternal_FullyPopulatedResponse_ReturnsResponseWithAllFieldsMapped()
+    {
+        XacmlJsonResponse response = new()
+        {
+            Response =
+            [
+                new XacmlJsonResult
+                {
+                    Decision = "Permit",
+                    Status = new XacmlJsonStatus
+                    {
+                        StatusMessage = "ok",
+                        StatusDetails = ["detail1", "detail2"],
+                        StatusCode = new XacmlJsonStatusCode
+                        {
+                            Value = "urn:oasis:names:tc:xacml:1.0:status:ok",
+                            StatusCode = new XacmlJsonStatusCode
+                            {
+                                Value = "urn:oasis:names:tc:xacml:1.0:status:nested",
+                            },
+                        },
+                    },
+                    Obligations =
+                    [
+                        new XacmlJsonObligationOrAdvice
+                        {
+                            Id = "urn:altinn:obligation:authenticationLevel1",
+                            AttributeAssignment =
+                            [
+                                new XacmlJsonAttributeAssignment
+                                {
+                                    AttributeId = "urn:altinn:obligation1-assignment1",
+                                    Value = "2",
+                                    Category = "urn:altinn:minimum-authenticationlevel",
+                                    DataType = "http://www.w3.org/2001/XMLSchema#integer",
+                                    Issuer = "altinn",
+                                },
+                            ],
+                        },
+                    ],
+                    AssociateAdvice =
+                    [
+                        new XacmlJsonObligationOrAdvice { Id = "urn:altinn:advice1" },
+                    ],
+                    Category =
+                    [
+                        new XacmlJsonCategory
+                        {
+                            CategoryId = "urn:oasis:names:tc:xacml:1.0:subject-category:access-subject",
+                            Id = "s1",
+                            Content = "<content />",
+                            Attribute =
+                            [
+                                new XacmlJsonAttribute
+                                {
+                                    AttributeId = "urn:altinn:userid",
+                                    Value = "1337",
+                                    Issuer = "altinn",
+                                    DataType = "http://www.w3.org/2001/XMLSchema#string",
+                                    IncludeInResult = true,
+                                },
+                            ],
+                        },
+                    ],
+                    PolicyIdentifierList = new XacmlJsonPolicyIdentifierList
+                    {
+                        PolicyIdReference = [new XacmlJsonIdReference { Id = "policy1", Version = "1.0" }],
+                        PolicySetIdReference = [new XacmlJsonIdReference { Id = "policyset1", Version = "2.0" }],
+                    },
+                },
+            ],
+        };
+
+        XacmlJsonResponseExternal result = RequestMapper.ToExternal(response);
+
+        result.Should().BeEquivalentTo(response);
+    }
+
+    [Fact]
+    public void ToExternal_PopulatedStatusDetails_ReturnsCopiedListInstance()
+    {
+        XacmlJsonResponse response = new()
+        {
+            Response =
+            [
+                new XacmlJsonResult
+                {
+                    Decision = "Deny",
+                    Status = new XacmlJsonStatus { StatusDetails = ["detail1"] },
+                },
+            ],
+        };
+
+        XacmlJsonResponseExternal result = RequestMapper.ToExternal(response);
+
+        result.Response[0].Status.StatusDetails.Should().NotBeSameAs(response.Response[0].Status.StatusDetails);
+        result.Response[0].Status.StatusDetails.Should().Equal("detail1");
+    }
+
+    [Fact]
+    public void ToExternal_NullStatusAndCollections_ReturnsResultWithNullMembers()
+    {
+        XacmlJsonResponse response = new()
+        {
+            Response =
+            [
+                new XacmlJsonResult
+                {
+                    Decision = "NotApplicable",
+                    Status = null,
+                    Obligations = null,
+                    AssociateAdvice = null,
+                    Category = null,
+                    PolicyIdentifierList = null,
+                },
+            ],
+        };
+
+        XacmlJsonResponseExternal result = RequestMapper.ToExternal(response);
+
+        XacmlJsonResultExternal mapped = result.Response.Should().ContainSingle().Which;
+        mapped.Decision.Should().Be("NotApplicable");
+        mapped.Status.Should().BeNull();
+        mapped.Obligations.Should().BeNull();
+        mapped.AssociateAdvice.Should().BeNull();
+        mapped.Category.Should().BeNull();
+        mapped.PolicyIdentifierList.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToExternal_NullResponseList_ReturnsNullResponseList()
+    {
+        XacmlJsonResponse response = new() { Response = null };
+
+        XacmlJsonResponseExternal result = RequestMapper.ToExternal(response);
+
+        result.Response.Should().BeNull();
+    }
+
+    private static XacmlJsonCategoryExternal CreateExternalCategory(string id) => new()
+    {
+        CategoryId = $"urn:category:{id}",
+        Id = id,
+        Content = $"<content id=\"{id}\" />",
+        Attribute =
+        [
+            new XacmlJsonAttributeExternal
+            {
+                AttributeId = $"urn:attribute:{id}",
+                Value = $"value-{id}",
+                Issuer = "altinn",
+                DataType = "http://www.w3.org/2001/XMLSchema#string",
+                IncludeInResult = true,
+            },
+        ],
+    };
+}

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/RequestMapperTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/RequestMapperTest.cs
@@ -34,7 +34,7 @@ public class RequestMapperTest
             },
         };
 
-        XacmlJsonRequestRoot result = RequestMapper.ToInternal(external);
+        XacmlJsonRequestRoot result = external.ToInternal();
 
         // The internal and external models share member names, so structural
         // equivalence against the external source verifies every mapped member.
@@ -60,7 +60,7 @@ public class RequestMapperTest
             },
         };
 
-        XacmlJsonRequestRoot result = RequestMapper.ToInternal(external);
+        XacmlJsonRequestRoot result = external.ToInternal();
 
         result.Request.XPathVersion.Should().BeNull();
         result.Request.Category.Should().BeNull();
@@ -84,7 +84,7 @@ public class RequestMapperTest
             },
         };
 
-        XacmlJsonRequestRoot result = RequestMapper.ToInternal(external);
+        XacmlJsonRequestRoot result = external.ToInternal();
 
         result.Request.XForwardedForHeader.Should().BeNull();
     }
@@ -163,7 +163,7 @@ public class RequestMapperTest
             ],
         };
 
-        XacmlJsonResponseExternal result = RequestMapper.ToExternal(response);
+        XacmlJsonResponseExternal result = response.ToExternal();
 
         result.Should().BeEquivalentTo(response);
     }
@@ -183,7 +183,7 @@ public class RequestMapperTest
             ],
         };
 
-        XacmlJsonResponseExternal result = RequestMapper.ToExternal(response);
+        XacmlJsonResponseExternal result = response.ToExternal();
 
         result.Response[0].Status.StatusDetails.Should().NotBeSameAs(response.Response[0].Status.StatusDetails);
         result.Response[0].Status.StatusDetails.Should().Equal("detail1");
@@ -208,7 +208,7 @@ public class RequestMapperTest
             ],
         };
 
-        XacmlJsonResponseExternal result = RequestMapper.ToExternal(response);
+        XacmlJsonResponseExternal result = response.ToExternal();
 
         XacmlJsonResultExternal mapped = result.Response.Should().ContainSingle().Which;
         mapped.Decision.Should().Be("NotApplicable");
@@ -224,7 +224,7 @@ public class RequestMapperTest
     {
         XacmlJsonResponse response = new() { Response = null };
 
-        XacmlJsonResponseExternal result = RequestMapper.ToExternal(response);
+        XacmlJsonResponseExternal result = response.ToExternal();
 
         result.Response.Should().BeNull();
     }


### PR DESCRIPTION
Migrates the Altinn.Authorization app's request and response mapping from AutoMapper to Mapperly. First slice of the AutoMapper removal; AccessManagement still uses it, so the central package pins stay.

- RequestMapper is now a static Mapperly mapper generating the two directions DecisionController uses, exposed as extension methods (request.ToInternal(), response.ToExternal()). UseDeepCloning keeps AutoMapper's list copy behavior, and null collections still map to null.
- AutoMapper package reference and the AddAutoMapper registration removed from the app.
- New unit tests pin mapping equivalence in both directions, null handling and the list copy semantics.

Updates #3681
