### PR TITLE
fix: stop flaky 206 in instance delegation integration tests

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/DelegationMetadataRepositoryMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/DelegationMetadataRepositoryMock.cs
@@ -120,7 +120,6 @@ public class DelegationMetadataRepositoryMock : IDelegationMetadataRepository
 
     public Task<InstanceDelegationChange> InsertInstanceDelegation(InstanceDelegationChange instanceDelegationChange, CancellationToken cancellationToken = default)
     {
-        Random random = new();
         string path = GetDelegationPolicyPathFromInstanceRule(instanceDelegationChange);
         string instanceIdSuffix = ExtractInstanceIdSuffix(instanceDelegationChange.InstanceId);
         InstanceDelegationChange result = instanceIdSuffix switch
@@ -128,7 +127,9 @@ public class DelegationMetadataRepositoryMock : IDelegationMetadataRepository
             "00000000-0000-0000-0000-000000000002" => null,
             _ => new InstanceDelegationChange
                 {
-                    InstanceDelegationChangeId = random.Next(0, 1000),
+                    // PolicyAdministrationPoint treats a change id <= 0 as a failed insert,
+                    // so a mocked successful insert must always return a positive id.
+                    InstanceDelegationChangeId = 1337,
                     DelegationChangeType = instanceDelegationChange.DelegationChangeType,
                     InstanceDelegationMode = instanceDelegationChange.InstanceDelegationMode,
                     InstanceDelegationSource = instanceDelegationChange.InstanceDelegationSource,


### PR DESCRIPTION
InsertInstanceDelegation in DelegationMetadataRepositoryMock returned random.Next(0, 1000) as the change id. The lower bound is inclusive, so one run in a thousand got id 0, which PolicyAdministrationPoint treats as a failed policy write and the controller reports as 206 PartialContent. That matches the observed failure rate of roughly 1 in 972.

The mock now returns the fixed success id 1337, matching the rest of the file. Hardcoding id 0 reproduced the CI failure signature deterministically; 20 consecutive runs pass after the fix.

Fixes #3583
