### PR TITLE
fix: exclude expired consent requests in pending requests count endpoint

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
@@ -539,12 +539,13 @@ namespace Altinn.AccessManagement.Persistence.Consent
             string query = /*strpsql*/@$"
                 SELECT COUNT(*)
                 FROM consent.consentrequest
-                WHERE fromPartyUuid = @fromPartyUuid AND status = @status AND portalviewmode = 'show'
+                WHERE fromPartyUuid = @fromPartyUuid AND status = @status AND portalviewmode = 'show' AND validTo > @now
             ";
 
             await using var pgcom = _db.CreateCommand(query);
             pgcom.Parameters.AddWithValue("fromPartyUuid", NpgsqlDbType.Uuid, fromPartyUuid);
             pgcom.Parameters.Add(new NpgsqlParameter<ConsentRequestStatusType>("status", status));
+            pgcom.Parameters.AddWithValue("now", NpgsqlDbType.TimestampTz, _timeProvider.GetUtcNow().ToOffset(TimeSpan.Zero));
 
             var result = await pgcom.ExecuteScalarAsync(cancellationToken);
             return Convert.ToInt32(result);

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Bff/ConsentControllerTestBFF.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/Bff/ConsentControllerTestBFF.cs
@@ -846,6 +846,44 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers.Bff
             Assert.True(count >= 1);
         }
 
+        [Fact]
+        public async Task GetConsentRequestCount_ExpiredRequest_Returns200OkWithZeroCount()
+        {
+            Guid requestId = Guid.Parse("019d7114-413f-7dbd-af65-72caa1c18d04");
+            IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
+            await repositgo.CreateRequest(await GetRequest(requestId, DateTimeOffset.Now.AddDays(-10)), Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181")), TestContext.Current.CancellationToken);
+            HttpClient client = GetTestClient();
+            string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/count/d5b861c8-8e3b-44cd-9952-5315e5990cf5?status=Created", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            int count = JsonSerializer.Deserialize<int>(responseText);
+            Assert.Equal(0, count);
+        }
+
+        [Fact]
+        public async Task GetConsentRequestCount_MixedValidAndExpired_Returns200OkCountingOnlyValid()
+        {
+            IConsentRepository repositgo = _fixture.Services.GetRequiredService<IConsentRepository>();
+            Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn performedBy = Altinn.AccessManagement.Core.Models.Consent.ConsentPartyUrn.PartyUuid.Create(Guid.Parse("8ef5e5fa-94e1-4869-8635-df86b6219181"));
+
+            // Valid (not expired) request
+            await repositgo.CreateRequest(await GetRequest(Guid.Parse("019d7114-413f-7dbd-af65-72caa1c18d04"), DateTimeOffset.Now.AddDays(10)), performedBy, TestContext.Current.CancellationToken);
+
+            // Expired request - should not be counted
+            await repositgo.CreateRequest(await GetRequest(Guid.Parse("e2071c55-6adf-487b-af05-9198a230ed46"), DateTimeOffset.Now.AddDays(-1)), performedBy, TestContext.Current.CancellationToken);
+
+            HttpClient client = GetTestClient();
+            string token = PrincipalUtil.GetToken(20001337, 50003899, 2, Guid.Parse("d5b861c8-8e3b-44cd-9952-5315e5990cf5"), AuthzConstants.SCOPE_PORTAL_ENDUSER);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/bff/consentrequests/count/d5b861c8-8e3b-44cd-9952-5315e5990cf5?status=Created", TestContext.Current.CancellationToken);
+            string responseText = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            int count = JsonSerializer.Deserialize<int>(responseText);
+            Assert.Equal(1, count);
+        }
+
         private HttpClient GetTestClient()
         {
             HttpClient client = _fixture.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConsentRepositoryMock.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Mocks/ConsentRepositoryMock.cs
@@ -65,9 +65,23 @@ namespace Altinn.AccessManagement.Tests.Mocks
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Consent requests seeded by tests. <see cref="GetConsentRequestCountForParty"/> counts the
+        /// ones matching the requested party and status that are shown in the portal and not yet expired.
+        /// </summary>
+        public List<ConsentRequestDetails> ConsentRequests { get; } = new();
+
         public Task<int> GetConsentRequestCountForParty(Guid fromPartyUuid, ConsentRequestStatusType status, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+
+            int count = ConsentRequests.Count(request =>
+                request.From.IsPartyUuid(out Guid partyUuid) && partyUuid == fromPartyUuid
+                && request.ConsentRequestStatus == status
+                && request.PortalViewMode == ConsentPortalViewMode.Show
+                && request.ValidTo > now);
+
+            return Task.FromResult(count);
         }
 
         public Task<Result<List<ConsentStatusChange>>> GetConsentEventsForParty(Guid partyUuid, ConsentEventsQuery query, int pageSize, CancellationToken cancellationToken)


### PR DESCRIPTION
## Description
- use Clause to generate code and tests to exclude expired consent requests in pending requests count endpoint

## Related Issue(s)
- https://github.com/Altinn/altinn-authorization-tmp/issues/2770

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
