### PR TITLE
chore: always show pass/fail/skip tally in CI test job summary

### DIFF
--- a/.github/workflows/tpl-vertical-ci.yml
+++ b/.github/workflows/tpl-vertical-ci.yml
@@ -222,9 +222,10 @@ jobs:
       # Coverage is collected only on the nightly `analyze` run (no dotnet-coverage
       # instrumentation overhead on PR runs); both still emit .trx + FixtureTiming.
       # On the analyze run each lane writes its .coverage file; the Convert steps
-      # below merge them for Sonar + the coverage report. On a non-zero exit the lane
-      # prints its own failing tests inline via eng/testing/report-failed-tests.ps1,
-      # then re-raises the exit code so the failures show on the step that ran them.
+      # below merge them for Sonar + the coverage report. Every run, pass or fail,
+      # reports the lane's pass/fail/skip tally via eng/testing/report-failed-tests.ps1
+      # (on a non-zero exit it also prints the failing tests inline), then
+      # re-raises the exit code so the failures show on the step that ran them.
       - name: Test - unit lane (coverage on analyze run)
         id: test_unit
         shell: bash
@@ -241,10 +242,9 @@ jobs:
           fi
           code=$?
           set -e
-          # Surface the failing tests on this step, then re-raise the real exit code.
-          if [ "$code" -ne 0 ]; then
-            pwsh -NoProfile -File "$GITHUB_WORKSPACE/eng/testing/report-failed-tests.ps1" -ResultsDirectory TestResults/unit
-          fi
+          # Report the tally (and, on failure, the per-test detail), then re-raise
+          # the real exit code.
+          pwsh -NoProfile -File "$GITHUB_WORKSPACE/eng/testing/report-failed-tests.ps1" -ResultsDirectory TestResults/unit
           exit "$code"
 
       - name: Test - integration lane (coverage on analyze run)
@@ -270,10 +270,9 @@ jobs:
           fi
           code=$?
           set -e
-          # Surface the failing tests on this step, then re-raise the real exit code.
-          if [ "$code" -ne 0 ]; then
-            pwsh -NoProfile -File "$GITHUB_WORKSPACE/eng/testing/report-failed-tests.ps1" -ResultsDirectory TestResults/integration
-          fi
+          # Report the tally (and, on failure, the per-test detail), then re-raise
+          # the real exit code.
+          pwsh -NoProfile -File "$GITHUB_WORKSPACE/eng/testing/report-failed-tests.ps1" -ResultsDirectory TestResults/integration
           exit "$code"
 
       - name: Setup-timing breakdown (FixtureTiming)

--- a/eng/testing/report-failed-tests.ps1
+++ b/eng/testing/report-failed-tests.ps1
@@ -1,7 +1,8 @@
 #!/usr/bin/env pwsh
-# Surfaces failing tests from a test lane in two places: a human-readable block in
-# that lane's own step log, and a Markdown list appended to the GitHub job summary
-# ($GITHUB_STEP_SUMMARY) so the failures also show on the run's summary page.
+# Reports on a test lane in two places: a human-readable failure block in that
+# lane's own step log, and a pass/fail/skip tally (plus, on failure, the failing
+# projects) appended to the GitHub job summary ($GITHUB_STEP_SUMMARY) so the
+# result is visible without opening the step log.
 #
 # The xUnit-v3 / Microsoft-Testing-Platform per-project log
 # (`<Project>_<tfm>_<arch>.log`, UTF-16) carries the test-level detail that the
@@ -13,8 +14,17 @@
 #             at <stack frame>
 #             at <... in /path/File.cs:line>
 #
-# Called from the test lane after `dotnet test`; the lane keeps and propagates the
-# real test exit code, so this script is best-effort and always exits 0.
+# and the run closes with a per-project summary block:
+#
+#     Test run summary: Passed!
+#       total: 3
+#       failed: 0
+#       succeeded: 2
+#       skipped: 1
+#
+# Called from the test lane after every `dotnet test`, pass or fail; the lane
+# keeps and propagates the real test exit code, so this script is best-effort
+# and always exits 0.
 [CmdletBinding()]
 param(
     # The relative results directory the lane passed to `--results-directory`
@@ -108,6 +118,12 @@ $totalFailures = 0
 $lanePassed = 0
 $laneFailed = 0
 $laneSkipped = 0
+# Whether any log actually reached its "Test run summary" block. A project whose
+# host crashed mid-run (or was killed) leaves a log with no such block; without
+# this guard its silent zero contribution would be indistinguishable from a real
+# all-zero result, and a lane where every log crashed would render a tally of
+# "0 passed, 0 failed, 0 skipped" as if nothing had run rather than not reporting.
+$foundAnySummary = $false
 
 foreach ($log in $logs) {
     # PS7 Get-Content auto-detects the UTF-16 BOM these logs carry.
@@ -119,7 +135,7 @@ foreach ($log in $logs) {
     $inSummary = $false
     foreach ($raw in $lines) {
         $line = $raw -replace "`r", ''
-        if ($line -match '^\s*Test run summary') { $inSummary = $true; continue }
+        if ($line -match '^\s*Test run summary') { $inSummary = $true; $foundAnySummary = $true; continue }
         if (-not $inSummary) { continue }
         if ($line -match '^\s*succeeded:\s*(\d+)') { $lanePassed += [int]$Matches[1] }
         elseif ($line -match '^\s*failed:\s*(\d+)') { $laneFailed += [int]$Matches[1] }
@@ -253,20 +269,27 @@ foreach ($log in $logs) {
     }
 }
 
-# Job summary: a terse count per project plus a link to this run, where the test
-# step above shows the full detail. Deliberately does not repeat the per-test
-# names/messages/sources.
-if ($totalFailures -gt 0 -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+# Job summary: always a one-line pass/fail/skip tally for the lane, so a green
+# run is as visible at a glance as a red one; on failure it also lists the
+# failing projects and links to the job log. Deliberately does not repeat the
+# per-test names/messages/sources — those stay in the step log above.
+if ($foundAnySummary -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+    $headerIcon = if ($laneFailed -gt 0) { '❌' } else { '✅' }
+    $headerText = if ($laneFailed -gt 0) { 'Failed tests' } else { 'Tests passed' }
+
     $sb = [System.Text.StringBuilder]::new()
-    [void]$sb.AppendLine(('### ❌ Failed tests ({0} lane)' -f $lane))
+    [void]$sb.AppendLine(('### {0} {1} ({2} lane)' -f $headerIcon, $headerText, $lane))
     [void]$sb.AppendLine('')
     [void]$sb.AppendLine(('✅ {0} passed · ❌ {1} failed · ⚠️ {2} skipped' -f $lanePassed, $laneFailed, $laneSkipped))
-    [void]$sb.AppendLine('')
-    [void]$sb.AppendLine(('Failing: {0}.' -f ($projectSummaries -join ', ')))
+    if ($totalFailures -gt 0) {
+        [void]$sb.AppendLine('')
+        [void]$sb.AppendLine(('Failing: {0}.' -f ($projectSummaries -join ', ')))
+    }
     [void]$sb.AppendLine('')
     $jobUrl = Get-JobUrl
     if ($jobUrl) {
-        [void]$sb.AppendLine(('[See the failing tests in this job''s log]({0})' -f $jobUrl))
+        $linkText = if ($totalFailures -gt 0) { 'See the failing tests in this job''s log' } else { 'See this job''s log' }
+        [void]$sb.AppendLine(('[{0}]({1})' -f $linkText, $jobUrl))
     }
     Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $sb.ToString()
 }


### PR DESCRIPTION
Closes #3572

The job summary only got an entry when a lane had failures, so a fully passing run showed nothing at all next to the job. There was no at-a-glance total of how many tests passed, failed and were skipped.

`eng/testing/report-failed-tests.ps1` now runs after every `dotnet test`, not just on a non-zero exit, and the job-summary block it writes no longer gates on failure count. Every lane gets a one-line tally with icons, and on failure it still lists the failing projects and links to the job log:

```
### ✅ Tests passed (unit lane)

✅ 279 passed · ❌ 0 failed · ⚠️ 0 skipped

[See this job's log](https://github.com/.../actions/runs/123)
```

```
### ❌ Failed tests (unit lane)

✅ 4 passed · ❌ 2 failed · ⚠️ 2 skipped

Failing: **Sample.Failing.Tests** (2).

[See the failing tests in this job's log](https://github.com/.../actions/runs/123)
```

A lane whose log never reaches its "Test run summary" block (crashed host, or no matching logs at all, e.g. skipped assemblies in the integration lane) still emits nothing to the summary, so a crash can't render as a false "0 passed, 0 failed, 0 skipped" line.

Validated the workflow with actionlint and dry-ran the PowerShell parsing against synthetic MTP-format logs covering a mixed pass/fail lane, an all-passing lane with one crashed sibling log, an all-crashed lane, and a lane with no logs at all.