### PR TITLE
fix: reject persisting derived Expired consent status and event type

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Consent/ConsentRepository.cs
@@ -97,9 +97,36 @@ namespace Altinn.AccessManagement.Persistence.Consent
             await tx.CommitAsync(cancellationToken);
         }
 
+        /// <summary>
+        /// Rejects any attempt to persist the <c>Expired</c> status or event type. <c>Expired</c> is derived at read time
+        /// from the consent's valid-to date and has no matching label in the <c>consent.status_type</c> or
+        /// <c>consent.event_type</c> PostgreSQL enums. Passing it through would otherwise surface as an opaque Npgsql
+        /// enum error deeper in the write.
+        /// </summary>
+        private static void GuardAgainstExpired(ConsentRequest consentRequest)
+        {
+            if (consentRequest.ConsentRequestStatus == ConsentRequestStatusType.Expired)
+            {
+                throw new InvalidOperationException($"Consent request status '{ConsentRequestStatusType.Expired}' is derived at read time and cannot be persisted.");
+            }
+
+            if (consentRequest.ConsentRequestEvents is not null)
+            {
+                foreach (ConsentRequestEvent consentEvent in consentRequest.ConsentRequestEvents)
+                {
+                    if (consentEvent.EventType == ConsentRequestEventType.Expired)
+                    {
+                        throw new InvalidOperationException($"Consent event type '{ConsentRequestEventType.Expired}' is derived at read time and cannot be persisted.");
+                    }
+                }
+            }
+        }
+
         /// <inheritdoc/>
         public async Task<ConsentRequestDetails> CreateRequest(ConsentRequest consentRequest, ConsentPartyUrn performedByParty, CancellationToken cancellationToken = default)
         {
+            GuardAgainstExpired(consentRequest);
+
             DateTimeOffset createdTime = DateTime.UtcNow;
 
             string consentRquestQuery = /*strpsql*/$@"

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Extensions/PersistenceDependencyInjectionExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Persistence/Extensions/PersistenceDependencyInjectionExtensions.cs
@@ -145,6 +145,9 @@ public static class PersistenceDependencyInjectionExtensions
                 ConsentRequestStatusType.Created => "created",
                 ConsentRequestStatusType.Revoked => "revoked",
                 ConsentRequestStatusType.Deleted => "deleted",
+
+                // Expired is derived at read time and never persisted; consent.status_type has no matching label.
+                // ConsentRepository rejects it before it reaches Postgres. The arm keeps the translator total, which the mapping requires.
                 ConsentRequestStatusType.Expired => "expired",
                 _ => null,
             }))
@@ -155,6 +158,9 @@ public static class PersistenceDependencyInjectionExtensions
                 ConsentRequestEventType.Created => "created",
                 ConsentRequestEventType.Revoked => "revoked",
                 ConsentRequestEventType.Deleted => "deleted",
+
+                // Expired is derived at read time and never persisted; consent.event_type has no matching label.
+                // ConsentRepository rejects it before it reaches Postgres. The arm keeps the translator total, which the mapping requires.
                 ConsentRequestEventType.Expired => "expired",
                 ConsentRequestEventType.Used => "used",
                 _ => null,

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Persistence/ConsentRepositoryExpiredGuardTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Persistence/ConsentRepositoryExpiredGuardTests.cs
@@ -1,0 +1,92 @@
+using Altinn.AccessManagement.Core.Models.Consent;
+using Altinn.AccessManagement.Persistence.Configuration;
+using Altinn.AccessManagement.Persistence.Consent;
+using Microsoft.Extensions.Options;
+using Npgsql;
+
+namespace Altinn.AccessManagement.Tests.Unit.Persistence;
+
+/// <summary>
+/// Verifies that <see cref="ConsentRepository.CreateRequest"/> refuses to persist the derived <c>Expired</c>
+/// status or event type. Neither the <c>consent.status_type</c> nor the <c>consent.event_type</c> PostgreSQL enum
+/// defines an <c>expired</c> label, so an attempt to write it must fail with a clear exception before it reaches
+/// the database rather than surfacing as an opaque Npgsql enum error.
+/// </summary>
+[UnitTest]
+public class ConsentRepositoryExpiredGuardTests
+{
+    private static ConsentRepository CreateRepository()
+    {
+        // The guard runs before any connection is opened, so an unreachable data source is never contacted.
+        NpgsqlDataSource dataSource = NpgsqlDataSource.Create("Host=localhost;Port=1;Database=none;Username=none;Password=none;Timeout=1;Command Timeout=1");
+        IOptions<PostgreSQLSettings> settings = Options.Create(new PostgreSQLSettings());
+        return new ConsentRepository(dataSource, settings, TimeProvider.System);
+    }
+
+    private static ConsentRequest CreateRequest(ConsentRequestStatusType status, params ConsentRequestEventType[] eventTypes)
+    {
+        ConsentPartyUrn party = ConsentPartyUrn.PartyUuid.Create(Guid.NewGuid());
+
+        return new ConsentRequest
+        {
+            Id = Guid.NewGuid(),
+            From = party,
+            To = party,
+            ValidTo = DateTimeOffset.UtcNow.AddDays(1),
+            ConsentRights = [],
+            RedirectUrl = string.Empty,
+            ConsentRequestStatus = status,
+            ConsentRequestEvents = [.. eventTypes.Select(type => new ConsentRequestEvent
+            {
+                EventType = type,
+                Created = DateTimeOffset.UtcNow,
+                PerformedBy = party,
+            })],
+        };
+    }
+
+    [Fact]
+    public async Task CreateRequest_ExpiredStatus_ThrowsBeforePersisting()
+    {
+        ConsentRepository repository = CreateRepository();
+        ConsentRequest request = CreateRequest(ConsentRequestStatusType.Expired);
+
+        Func<Task> act = () => repository.CreateRequest(request, ConsentPartyUrn.PartyUuid.Create(Guid.NewGuid()));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .Where(ex => ex.Message.Contains("Expired") && ex.Message.Contains("cannot be persisted"));
+    }
+
+    [Fact]
+    public async Task CreateRequest_ExpiredEventInList_ThrowsBeforePersisting()
+    {
+        ConsentRepository repository = CreateRepository();
+
+        // A valid event precedes the derived one to prove the whole list is scanned.
+        ConsentRequest request = CreateRequest(ConsentRequestStatusType.Created, ConsentRequestEventType.Created, ConsentRequestEventType.Expired);
+
+        Func<Task> act = () => repository.CreateRequest(request, ConsentPartyUrn.PartyUuid.Create(Guid.NewGuid()));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .Where(ex => ex.Message.Contains("Expired") && ex.Message.Contains("cannot be persisted"));
+    }
+
+    [Theory]
+    [InlineData(ConsentRequestStatusType.Created)]
+    [InlineData(ConsentRequestStatusType.Accepted)]
+    [InlineData(ConsentRequestStatusType.Rejected)]
+    [InlineData(ConsentRequestStatusType.Revoked)]
+    [InlineData(ConsentRequestStatusType.Deleted)]
+    public async Task CreateRequest_PersistableStatus_DoesNotTripExpiredGuard(ConsentRequestStatusType status)
+    {
+        ConsentRepository repository = CreateRepository();
+        ConsentRequest request = CreateRequest(status, ConsentRequestEventType.Created);
+
+        // Persistable values pass the guard and reach the unreachable data source, which fails to connect.
+        // The guard's InvalidOperationException must not be what surfaces.
+        Exception thrown = await Record.ExceptionAsync(() => repository.CreateRequest(request, ConsentPartyUrn.PartyUuid.Create(Guid.NewGuid())));
+
+        thrown.Should().NotBeNull();
+        (thrown is InvalidOperationException invalid && invalid.Message.Contains("cannot be persisted")).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Problem

The consent enum name translator mapped `ConsentRequestStatusType.Expired` and `ConsentRequestEventType.Expired` to an `expired` label, but neither PostgreSQL enum defines it:

- `consent.status_type` = (unopened, opened, accepted, rejected, deleted, created, revoked)
- `consent.event_type` = (accepted, rejected, deleted, created, revoked, used)

`Expired` is derived at read time from the consent's valid-to date (`AddExpiredEventIfConsentIsExpired`) and is never a stored state. Any attempt to write it failed deep inside the insert with an opaque Npgsql enum error instead of a clear message.

The one path that can carry `Expired` into the repository write is the Altinn2 migration (`GetAndStoreAltinn2Consent` maps a consent from Altinn2 and parses the status and event types straight from the Altinn2 strings). If Altinn2 sends an expired status or event, that value reaches `CreateRequest`.

## Fix

`ConsentRepository.CreateRequest` now rejects an `Expired` status or event type up front with a clear `InvalidOperationException`, before a connection is opened. This turns an opaque database error into an early, legible failure.

The translator arms are kept, because the translator has to cover every enum member and Npgsql builds a label for each member when the converter materializes. Removing the arm would make the translator constructor throw at startup, and making it throw for `Expired` would break the converter build for all consent operations. A comment on each arm records why the label has no database counterpart.

Added focused unit tests that assert the guard rejects `Expired` status and `Expired` events with a clear message, and that persistable statuses do not trip it. Existing consent integration tests still pass, including the ones that derive an `Expired` event at read time without persisting it.

Closes #3632
