### PR TITLE
chore: bulk-load existing rows in static-data seeding

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestEntityVariantRole.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestEntityVariantRole.cs
@@ -1,6 +1,7 @@
 ﻿using Altinn.AccessMgmt.PersistenceEF.Constants;
 using Altinn.AccessMgmt.PersistenceEF.Contexts;
 using Altinn.AccessMgmt.PersistenceEF.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Data;
 
@@ -387,18 +388,23 @@ public static partial class StaticDataIngest
             new EntityVariantRole() { Id = Guid.Parse("a3719e58-286d-4395-95b0-1a654f2eeafa"), VariantId = EntityVariantConstants.VPFO.Id, RoleId = RoleConstants.ManagingDirector.Id },
         };
 
+        // The table only ever holds this seed set, so a single query keyed on Id finds
+        // what is missing, instead of one existence check per row.
+        var existing = await dbContext.EntityVariantRoles
+            .AsTracking()
+            .ToDictionaryAsync(t => t.Id, cancellationToken);
+
         foreach (var d in data)
         {
             // Verify: Compare on Id or Code?
-            var obj = dbContext.EntityVariantRoles.FirstOrDefault(t => t.Id == d.Id);
-            if (obj == null)
-            {
-                dbContext.EntityVariantRoles.Add(d);
-            }
-            else
+            if (existing.TryGetValue(d.Id, out var obj))
             {
                 obj.VariantId = d.VariantId;
                 obj.RoleId = d.RoleId;
+            }
+            else
+            {
+                dbContext.EntityVariantRoles.Add(d);
             }
         }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestRoleMap.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestRoleMap.cs
@@ -474,13 +474,17 @@ public static partial class StaticDataIngest
             new RoleMap() { HasRoleId = RoleConstants.MainAdministrator.Id, GetRoleId = RoleConstants.AuditorCertifier.Id }
         };
 
-        // Upsert RoleMap data
+        // The table only ever holds this seed set, so a single query for the existing
+        // (HasRoleId, GetRoleId) pairs is enough to find what is missing, instead of one
+        // existence check per row.
+        var existingPairs = await dbContext.RoleMaps
+            .Select(x => new { x.HasRoleId, x.GetRoleId })
+            .ToListAsync(cancellationToken);
+        var existing = existingPairs.Select(x => (x.HasRoleId, x.GetRoleId)).ToHashSet();
+
         foreach (var rm in roleMaps)
         {
-            var existing = await dbContext.RoleMaps
-                .FirstOrDefaultAsync(x => x.HasRoleId == rm.HasRoleId && x.GetRoleId == rm.GetRoleId, cancellationToken);
-
-            if (existing == null)
+            if (!existing.Contains((rm.HasRoleId, rm.GetRoleId)))
             {
                 dbContext.RoleMaps.Add(rm);
             }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestRolePackage.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestRolePackage.cs
@@ -1,6 +1,7 @@
 ﻿using Altinn.AccessMgmt.PersistenceEF.Constants;
 using Altinn.AccessMgmt.PersistenceEF.Contexts;
 using Altinn.AccessMgmt.PersistenceEF.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Data;
 
@@ -1460,14 +1461,16 @@ public static partial class StaticDataIngest
             new RolePackage() { RoleId = RoleConstants.BusinessManager, PackageId = PackageConstants.BusinessAndAccessManagementNUF.Id, EntityVariantId = EntityVariantConstants.NUF.Id, CanDelegate = true, CanAssign = true, HasAccess = true },
         };
 
+        // The table only ever holds this seed set, so a single query keyed on the
+        // (RoleId, PackageId, EntityVariantId) triple finds what is missing or changed,
+        // instead of one existence check per row.
+        var existing = await dbContext.RolePackages
+            .AsTracking()
+            .ToDictionaryAsync(t => (t.RoleId, t.PackageId, t.EntityVariantId), cancellationToken);
+
         foreach (var d in data)
         {
-            var obj = dbContext.RolePackages.FirstOrDefault(t => t.RoleId == d.RoleId && t.PackageId == d.PackageId && t.EntityVariantId == d.EntityVariantId);
-            if (obj == null)
-            {
-                dbContext.RolePackages.Add(d);
-            }
-            else
+            if (existing.TryGetValue((d.RoleId, d.PackageId, d.EntityVariantId), out var obj))
             {
                 if (obj.CanAssign != d.CanAssign || obj.CanDelegate != d.CanDelegate || obj.HasAccess != d.HasAccess)
                 {
@@ -1475,6 +1478,10 @@ public static partial class StaticDataIngest
                     obj.CanDelegate = d.CanDelegate;
                     obj.HasAccess = d.HasAccess;
                 }
+            }
+            else
+            {
+                dbContext.RolePackages.Add(d);
             }
         }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Integration/Data/StaticDataIngestTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Integration/Data/StaticDataIngestTest.cs
@@ -1,0 +1,43 @@
+using Altinn.AccessManagement.TestUtils.Fixtures;
+using Altinn.AccessMgmt.PersistenceEF.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Altinn.AccessMgmt.Core.Tests.Integration.Data;
+
+/// <summary>
+/// Integration tests for <see cref="StaticDataIngest.IngestAll"/>.
+/// </summary>
+[IntegrationTest]
+public class StaticDataIngestTest : IClassFixture<ApiFixture>
+{
+    public ApiFixture Fixture { get; }
+
+    public StaticDataIngestTest(ApiFixture fixture)
+    {
+        Fixture = fixture;
+    }
+
+    /// <summary>
+    /// The fixture's database is cloned from a template that is already migrated and
+    /// seeded (the EF <c>UseAsyncSeeding</c> hook runs <see cref="StaticDataIngest.IngestAll"/>
+    /// during that migration). Running it again here against that already-seeded clone
+    /// reproduces the "second instance starts against an already-seeded database" case
+    /// the batched existence checks and the advisory lock need to keep working.
+    /// </summary>
+    [Fact]
+    public async Task IngestAll_CalledAgainOnSeededDatabase_DoesNotDuplicateRowsOrThrow()
+    {
+        await Fixture.QueryDb(async db =>
+        {
+            var rolePackageCountBefore = await db.RolePackages.CountAsync(TestContext.Current.CancellationToken);
+            var roleMapCountBefore = await db.RoleMaps.CountAsync(TestContext.Current.CancellationToken);
+            var entityVariantRoleCountBefore = await db.EntityVariantRoles.CountAsync(TestContext.Current.CancellationToken);
+
+            await StaticDataIngest.IngestAll(db, TestContext.Current.CancellationToken);
+
+            Assert.Equal(rolePackageCountBefore, await db.RolePackages.CountAsync(TestContext.Current.CancellationToken));
+            Assert.Equal(roleMapCountBefore, await db.RoleMaps.CountAsync(TestContext.Current.CancellationToken));
+            Assert.Equal(entityVariantRoleCountBefore, await db.EntityVariantRoles.CountAsync(TestContext.Current.CancellationToken));
+        });
+    }
+}


### PR DESCRIPTION
## Summary

StaticDataIngest's RoleMap, RolePackage and EntityVariantRole seeding checked whether each seed row already existed with its own SELECT inside a foreach loop, so seeding paid one round trip per row before a single batched insert at the end. The generic `AutoIngest<T>` helper used for the other seeded tables (Provider, Role, Package, etc.) already loads existing rows in one query and only does one insert per table, so it needed no changes.

This loads the existing rows once per table instead, and diffs the seed list against that set in memory. Idempotent behavior is unchanged: rows that already exist get updated if their fields changed, missing rows get added, and the call still runs inside the advisory-lock-protected transaction from #3376.

RolePackage, RoleMap and EntityVariantRole ids are generated in the application layer (`Guid.CreateVersion7()` in each type's constructor) when the seed list literal is built, before any existence check runs. That generation order doesn't depend on how the missing rows are found or inserted, so no table here needed an explicit ordered insert.

## Measured

Seed sizes: RolePackage 1276 rows, RoleMap 304 rows, EntityVariantRole 369 rows. Seeding an empty database previously cost one SELECT per row across these three tables (about 1949 round trips); now it's one SELECT per table (3 round trips) plus the same batched insert as before.

Wall time, using the repo's `FIXTURE_TIMING` harness (`migrate_ms`, which covers the EF migration plus the `UseAsyncSeeding` hook that runs `IngestAll`) on `Altinn.AccessMgmt.Core.Tests`: baseline 10413 ms, after the change 7032 ms and 8603 ms across two separate runs. Schema DDL time is constant between runs, so the difference is the seeding round trips.

## Testing

- `dotnet build src/apps/Altinn.AccessManagement/Altinn.AccessManagement.sln`: 0 errors, 135 warnings, in line with the existing baseline.
- Added `StaticDataIngestTest.IngestAll_CalledAgainOnSeededDatabase_DoesNotDuplicateRowsOrThrow`, which runs `IngestAll` a second time against an already-migrated-and-seeded database and asserts the RoleMap/RolePackage/EntityVariantRole row counts don't change and nothing throws.
- Ran the full `Altinn.AccessMgmt.Core.Tests` project (440 tests) and `AccessMgmt.Tests`'s `MetadataTests` class (22 tests, exercises RolePackages directly): all pass.

Closes #3579
