### PR TITLE
test: give assertion-less tests real verification

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -421,7 +421,11 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
             OnlyUniqueResults = flags[7]
         };
 
-        await _query.GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers, ct: TestContext.Current.CancellationToken);
+        // Every flag combination must produce a valid query that runs against the database
+        // without the query builder throwing. Any combination that faults is a regression.
+        var exception = await Record.ExceptionAsync(() => _query.GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers, ct: TestContext.Current.CancellationToken));
+
+        Assert.Null(exception);
     }
 
     public static IEnumerable<object[]> GetFilterCombinations()

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/HostedServices/ConsentMigrationHostedServiceTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/HostedServices/ConsentMigrationHostedServiceTests.cs
@@ -60,14 +60,21 @@ public class ConsentMigrationHostedServiceTests : IDisposable
     [Fact]
     public async Task StartAsync_NoConfiguration_StartsWithoutThrowing()
     {
-        // Arrange
+        // Arrange - no feature manager setup, so the flag resolves to disabled.
         var service = CreateService();
 
         // Act
         await service.StartAsync(CancellationToken.None);
 
-        // Assert - no exception thrown
-        Assert.True(true);
+        // Assert - StartAsync launched the background loop, and with the feature off the
+        // loop parks in the feature-disabled delay without acquiring a lease or processing.
+        Assert.NotNull(service.ExecuteTask);
+        _leaseServiceMock.Verify(
+            x => x.TryAcquireNonBlocking(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _syncServiceMock.Verify(
+            x => x.ProcessBatch(It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -357,36 +364,6 @@ public class ConsentMigrationHostedServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ExecuteAsync_CancellationRequested_StopsProcessing()
-    {
-        // Arrange
-        _featureManagerMock
-            .Setup(x => x.IsEnabledAsync(AccessMgmtFeatureFlags.HostedServicesConsentMigration))
-            .ReturnsAsync(true);
-
-        _leaseServiceMock
-            .Setup(x => x.TryAcquireNonBlocking("access_management_consent_migration", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(_leaseMock.Object);
-
-        _syncServiceMock
-            .Setup(x => x.ProcessBatch(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(5);
-
-        var service = CreateService();
-        using var testCts = new CancellationTokenSource();
-
-        // Act
-        var serviceTask = service.StartAsync(testCts.Token);
-        await Task.Delay(10, TestContext.Current.CancellationToken);
-
-        testCts.Cancel();
-        await Task.WhenAny(serviceTask, Task.Delay(1000, TestContext.Current.CancellationToken));
-
-        // Assert - no exception thrown, service stops cleanly
-        Assert.True(true);
-    }
-
-    [Fact]
     public async Task ExecuteAsync_Cancelled_DisposesLeaseAfterProcessing()
     {
         // Arrange
@@ -547,8 +524,11 @@ public class ConsentMigrationHostedServiceTests : IDisposable
         await service.StartAsync(testCts.Token);
         await service.StopAsync(CancellationToken.None);
 
-        // Assert - no exception thrown
-        Assert.True(true);
+        // Assert - StopAsync unwinds the background loop: ExecuteAsync was started and has
+        // run to completion by the time StopAsync returns (it would hang if the loop ignored
+        // the stop signal).
+        Assert.NotNull(service.ExecuteTask);
+        Assert.True(service.ExecuteTask!.IsCompleted, "ExecuteAsync loop should have stopped after StopAsync");
     }
 
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Queries/ConnectionQueryFilterTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Queries/ConnectionQueryFilterTest.cs
@@ -91,7 +91,12 @@ public class ConnectionQueryFilterTest
     public void Validate_AnyFilterSet_DoesNotThrow()
     {
         var filter = new ConnectionQueryFilter { FromIds = [Guid.NewGuid()] };
-        filter.Validate();
+
+        // With at least one narrowing filter set, Validate must accept the filter.
+        // This is the positive counterpart to Validate_NoFilters_ThrowsArgumentException.
+        var exception = Record.Exception(filter.Validate);
+
+        Assert.Null(exception);
     }
 
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Integration/Services/AssignmentServiceClearAssignmentsInAfterLifeTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessMgmt.Core.Tests/Integration/Services/AssignmentServiceClearAssignmentsInAfterLifeTest.cs
@@ -258,6 +258,11 @@ public class AssignmentServiceClearAssignmentsInAfterLifeTest : IClassFixture<Ap
 
         using var scope = Fixture.Services.CreateScope();
         var svc = ResolveService(scope);
-        await svc.ClearAssignmentsInAfterLife(nonExistentPerson, TestAudit, TestContext.Current.CancellationToken);
+
+        // Clearing assignments for a person that has none must be a no-op that completes
+        // without throwing, not an error path.
+        var exception = await Record.ExceptionAsync(() => svc.ClearAssignmentsInAfterLife(nonExistentPerson, TestAudit, TestContext.Current.CancellationToken));
+
+        Assert.Null(exception);
     }
 }


### PR DESCRIPTION
Closes #3381

## What

Tests that pass without checking anything give false confidence. I swept the test projects for that shape and gave each real test a real assertion, or removed it when it was a duplicate.

Two of the four examples the issue names were already fixed in #3588 (ProblemsValidation and ResourceSyncServiceTest), and TranslationMiddlewareTest already asserts on every path, so I left those alone. The rest of the enumeration I did by scanning every test method in the solution rather than trusting the example list.

## Enumeration and outcome

Genuinely assertion-less tests found and changed:

- `AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs` `GetConnectionsAsync_AllFilterFlagCombinations_DoesNotThrow` (512 theory cases) ended in a bare call. Now captures the call with `Record.ExceptionAsync` and asserts no exception, so a flag combination that faults the query builder fails the test.
- `AccessMgmt.Tests/Unit/Queries/ConnectionQueryFilterTest.cs` `Validate_AnyFilterSet_DoesNotThrow` ended in a bare `Validate()`. Now asserts the call produced no exception, the positive counterpart to the existing throws-test.
- `Altinn.AccessMgmt.Core.Tests/Integration/Services/AssignmentServiceClearAssignmentsInAfterLifeTest.cs` `DoesNotThrow_WhenNoAssignmentsExist` ended in a bare call. Same treatment.
- `AccessMgmt.Tests/Unit/HostedServices/ConsentMigrationHostedServiceTests.cs`:
  - `StartAsync_NoConfiguration_StartsWithoutThrowing` asserted `Assert.True(true)`. Now checks the background loop launched and that with the feature off no lease is acquired and no batch is processed.
  - `StopAsync_AfterStart_StopsWithoutThrowing` asserted `Assert.True(true)`. Now checks the loop actually terminates once StopAsync returns.

Deleted:

- `ExecuteAsync_CancellationRequested_StopsProcessing` asserted only `Assert.True(true)`. Its scenario, cancelling during normal processing, is already covered with a real assertion by `ExecuteAsync_Cancelled_DisposesLeaseAfterProcessing`, so it was a duplicate rather than a test worth strengthening.

Checked and left as-is (they assert through helper delegates or a shared assertion utility, so they only looked assertion-less): the XACML and PDP decision suites in Altinn.Authorization.Tests, the Metadata and Altinn2Rights controller tests, the attribute-match asserter and resolver theories, and `AttributeMatcherTest`. `StorageAccountLeaseTest.TestLease` is skipped pending a real storage account and delegates to a base helper, so it is out of scope.

No `Assert.True(false, ...)` (xUnit2020) exists in the test projects.

## Verification

No production defect surfaced: every strengthened assertion is green.

- Build: 0 errors.
- `ConsentMigrationHostedServiceTests`: 15 passed.
- `ConnectionQueryFilterTest`: 13 passed.
- `ConnectionQueryTests`: 530 passed (includes the 512-combo theory now asserting no exception).
- `AssignmentServiceClearAssignmentsInAfterLifeTest`: 10 passed.
