### PR TITLE
test: reduce AccessManagement test sprawl

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/ResourceControllerCollection.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/ResourceControllerCollection.cs
@@ -1,0 +1,13 @@
+namespace Altinn.AccessManagement.Tests.Integration.Controllers;
+
+/// <summary>
+/// Names the collection for the resource controller tests so they run sequentially
+/// rather than in parallel. The collection carries no shared fixture; it only
+/// serializes the member class.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class ResourceControllerCollection
+{
+    /// <summary>Collection name referenced by member classes via <c>[Collection]</c>.</summary>
+    public const string Name = "ResourceController Tests";
+}

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/ResourceControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/ResourceControllerTest.cs
@@ -24,7 +24,7 @@ namespace Altinn.AccessManagement.Tests.Integration.Controllers
     /// Tests for AccessManagmet Resource metadata
     /// </summary>
     [IntegrationTest]
-    [Collection("ResourceController Tests")]
+    [Collection(ResourceControllerCollection.Name)]
     public class ResourceControllerTest : IClassFixture<ApiFixture>
     {
         private readonly HttpClient _client;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/AssignmentModelTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/AssignmentModelTest.cs
@@ -3,7 +3,7 @@
 namespace Altinn.AccessManagement.Tests.Unit.Models
 {
     [UnitTest]
-    [Collection("Models Test")]
+    [Collection(ModelsCollection.Name)]
     public class AssignmentModelTest
     {
         [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Consent/ConsentPartyUrnTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Consent/ConsentPartyUrnTest.cs
@@ -10,7 +10,7 @@ namespace Altinn.AccessManagement.Tests.Unit.Models.Consent;
 /// parse).
 /// </summary>
 [UnitTest]
-[Collection("Models Test")]
+[Collection(ModelsCollection.Name)]
 public class ConsentPartyUrnTest
 {
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/DelegationModelTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/DelegationModelTest.cs
@@ -3,7 +3,7 @@
 namespace Altinn.AccessManagement.Tests.Unit.Models
 {
     [UnitTest]
-    [Collection("Models Test")]
+    [Collection(ModelsCollection.Name)]
     public class DelegationModelTest
     {
         [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/ModelsCollection.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/ModelsCollection.cs
@@ -1,0 +1,13 @@
+namespace Altinn.AccessManagement.Tests.Unit.Models;
+
+/// <summary>
+/// Names the collection that groups the model unit tests so they run sequentially
+/// rather than in parallel. The collection carries no shared fixture; it only
+/// serializes the member classes.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class ModelsCollection
+{
+    /// <summary>Collection name referenced by member classes via <c>[Collection]</c>.</summary>
+    public const string Name = "Models Test";
+}

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Register/OrganizationNumberTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Register/OrganizationNumberTest.cs
@@ -11,7 +11,7 @@ namespace Altinn.AccessManagement.Tests.Unit.Models.Register;
 /// <see cref="OrganizationNumber.CreateUnchecked"/>.
 /// </summary>
 [UnitTest]
-[Collection("Models Test")]
+[Collection(ModelsCollection.Name)]
 public class OrganizationNumberTest
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Urn/OrganizationNumberTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Models/Urn/OrganizationNumberTest.cs
@@ -4,7 +4,7 @@ using Altinn.Authorization.Api.Contracts.Register;
 namespace Altinn.AccessManagement.Tests.Unit.Models.Urn
 {
     [UnitTest]
-    [Collection("Models Test")]
+    [Collection(ModelsCollection.Name)]
     public class OrganizationNumberTest
     {
         private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/PolicyAdministrationPointCollection.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/PolicyAdministrationPointCollection.cs
@@ -1,0 +1,13 @@
+namespace Altinn.AccessManagement.Tests.Unit;
+
+/// <summary>
+/// Names the collection for the policy administration point unit tests so they run
+/// sequentially rather than in parallel. The collection carries no shared fixture;
+/// it only serializes the member class.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class PolicyAdministrationPointCollection
+{
+    /// <summary>Collection name referenced by member classes via <c>[Collection]</c>.</summary>
+    public const string Name = "PolicyAdministrationPointTest";
+}

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/PolicyAdministrationPointTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/PolicyAdministrationPointTest.cs
@@ -19,7 +19,7 @@ namespace Altinn.AccessManagement.Tests.Unit
     /// Test class for <see cref="PolicyAdministrationPoint"></see>
     /// </summary>
     [UnitTest]
-    [Collection("PolicyAdministrationPointTest")]
+    [Collection(PolicyAdministrationPointCollection.Name)]
     public class PolicyAdministrationPointTest
     {
         private readonly IPolicyAdministrationPoint _pap;

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Internal.Tests/Controllers/InternalConnectionsControllerUnitTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Api.Internal.Tests/Controllers/InternalConnectionsControllerUnitTest.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.AccessManagement.Api.Internal.Controllers;
+using Altinn.AccessManagement.Api.Internal.Controllers;
 using Altinn.AccessManagement.Api.Internal.Models;
 using Altinn.AccessMgmt.Core.Services.Contracts;
 using Altinn.AccessMgmt.Core.Validation;
@@ -10,10 +10,10 @@ using Moq;
 using ConnectionOptions = Altinn.AccessMgmt.Core.Services.ConnectionOptions;
 using ValidationErrors = Altinn.AccessMgmt.Core.Utils.Models.ValidationErrors;
 
-namespace Altinn.AccessManagement.Api.Tests.Controllers;
+namespace Altinn.AccessManagement.Api.Internal.Tests.Controllers;
 
 [UnitTest]
-public class InternalConnectionsControllerTest
+public class InternalConnectionsControllerUnitTest
 {
     private static readonly Guid Party = Guid.NewGuid();
     private static readonly Guid To = Guid.NewGuid();

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Integration/PolicyControllerTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Integration/PolicyControllerTest.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 
 namespace Altinn.Authorization.Tests.Integration
 {
-    [Collection("Our Test Collection #1")]
+    [Collection(PolicyTestCollection.Name)]
     [IntegrationTest]
     public class PolicyControllerTest : IClassFixture<AuthorizationApiFixture>
     {

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyAdministrationPointCollection.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyAdministrationPointCollection.cs
@@ -1,0 +1,13 @@
+namespace Altinn.Authorization.Tests;
+
+/// <summary>
+/// Names the collection for the policy administration point unit tests so they run
+/// sequentially rather than in parallel. The collection carries no shared fixture;
+/// it only serializes the member class.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class PolicyAdministrationPointCollection
+{
+    /// <summary>Collection name referenced by member classes via <c>[Collection]</c>.</summary>
+    public const string Name = "PolicyAdministrationPointTest";
+}

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyTestCollection.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/PolicyTestCollection.cs
@@ -1,0 +1,13 @@
+namespace Altinn.Authorization.Tests;
+
+/// <summary>
+/// Names the collection that groups the policy tests so they run sequentially
+/// rather than in parallel. The collection carries no shared fixture; it only
+/// serializes the member classes.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class PolicyTestCollection
+{
+    /// <summary>Collection name referenced by member classes via <c>[Collection]</c>.</summary>
+    public const string Name = "Policy tests";
+}

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/PolicyAdministrationPointTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/PolicyAdministrationPointTest.cs
@@ -15,7 +15,7 @@ using Moq;
 
 namespace Altinn.Authorization.Tests.Unit
 {
-    [Collection("PolicyAdministrationPointTest")]
+    [Collection(PolicyAdministrationPointCollection.Name)]
     [UnitTest]
     public class PolicyAdministrationPointTest
     {

--- a/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/PolicyRetrievalPointTest.cs
+++ b/src/apps/Altinn.Authorization/test/Altinn.Authorization.Tests/Unit/PolicyRetrievalPointTest.cs
@@ -12,7 +12,7 @@ using Moq;
 
 namespace Altinn.Authorization.Tests.Unit
 {
-    [Collection("Our Test Collection #1")]
+    [Collection(PolicyTestCollection.Name)]
     [UnitTest]
     public class PolicyRetrievalPointTest
     {


### PR DESCRIPTION
Finishes the remaining Phase 3 cleanups from #3362. The folder and namespace reorganization was done earlier (#3369, #3370, #3373, #3374); this covers the three non-move items.

## 1. Deduplicate InternalConnectionsControllerTest

Two classes with this name existed in different projects, and they were not copies of the same tests. The one in `Api.Internal.Tests` is the `ApiFixture` integration test for the selfidentifiedusers endpoint (7 tests). The one in `Api.Tests` was a Moq unit test covering the other six controller actions (14 tests). No coverage overlapped.

The controller lives in `Altinn.AccessManagement.Api.Internal`, and the integration tests need `ApiFixture`, which `Api.Tests` cannot host since it is marked `HasIntegrationTests=false`. Both sets belong in `Api.Internal.Tests`, so the Moq unit tests move there as `InternalConnectionsControllerUnitTest`. Nothing was deleted.

## 2. CollectionDefinition consts

Replaced the ad-hoc `[Collection("...")]` strings with `Name` consts on `CollectionDefinition` classes, matching the existing pattern (`ConsentDbCollection` and friends):

- `AccessMgmt.Tests`: "Models Test" (5 classes), "PolicyAdministrationPointTest" (1), "ResourceController Tests" (1)
- `Altinn.Authorization.Tests`: "PolicyAdministrationPointTest" (1), "Our Test Collection #1" (2)

Collections are per assembly, so the two "PolicyAdministrationPointTest" names are independent and each gets its own definition. These groups carry no shared fixture, they only serialize their members, so the new definitions are markers holding a `Name` const. The meaningless "Our Test Collection #1" is renamed to "Policy tests".

## 3. ConnectionsControllerTest breakup: already in place

This item is already implemented on main and needs no change here. `ConnectionsControllerTest` is a partial container that only holds the `Route` const; each of the 26 feature files declares its own nested test class. The read-only features share one `ApiFixture` host through `ConnectionsReadOnlyCollection` (an `ICollectionFixture` cohort), while the features that call `Fixture.ConfigureServices` or seed and mutate rows keep their own `IClassFixture` host because they cannot share safely. `CheckPackageMainAdmin`, for instance, seeds a HanSoloEnterprise to LeiaOrgana assignment that `GetRoles` (a cohort member) makes exact-count assertions about, so it stays isolated on purpose. Pushing the split further would either be churn with no effect on the host-build count or would break that isolation. This landed in #3542.

## Verification

Build: `dotnet build Altinn.AccessManagement.sln`, 0 errors (135 warnings, all pre-existing).

Tests run against Podman (xUnit v3 / Microsoft.Testing.Platform):

- `Api.Tests`: 53 passed (was 67; the 14 moved out).
- `Api.Internal.Tests`: 23 passed (7 integration, 14 moved unit, 2 shared category-guard tests).
- Net test count unchanged, 14 tests relocated, none dropped.
- Collection changes exercised and green: Models, PolicyAdministrationPointTest (30), ResourceControllerTest (7) in `AccessMgmt.Tests`; PolicyAdministrationPointTest with PolicyRetrievalPointTest (36) and PolicyControllerTest (16) in `Altinn.Authorization.Tests`.

Closes #3362
