### PR TITLE
chore: remove dead MigrationDbEf and IncludeSingleRightsImportedAssignments toggles

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.Development.json
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.Development.json
@@ -21,7 +21,6 @@
     "AccessManagement.Enduser.Connections": true,
     "AccessManagement.Internal.Connections": true,
     "AccessManagement.MigrationDb": false,
-    "AccessManagement.MigrationDbEf": false,
     "AccessMgmt.Core.HostedServices.RegisterSync": false,
     "AccessManagement.AuthorizedParties.UsingConnectionQueryOnly": true
   },

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.json
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/appsettings.json
@@ -66,11 +66,9 @@
   "FeatureManagement": {
     "RightsDelegationApi": false,
     "OpenTelementry": false,
-    "AccessMgmt.Core.Services.IncludeSingleRightsImportedAssignments": false,
     "AccessMgmt.Core.HostedServices.ResourceRegistrySync": false,
     "AccessMgmt.Core.HostedServices.RegisterSync": false,
     "AccessManagement.MigrationDb": false,
-    "AccessManagement.MigrationDbEf": false,
     "AccessManagement.Enduser.Connections": false,
     "UseNewQueryRepo": false,
     "AccessMgmt.Core.HostedServices.ConsentMigration": false,


### PR DESCRIPTION
Related to #2726

Cleanup of feature toggles whose guarded features are permanently live in production. This is the safe, code-only subset. Terraform removal from the hub trails deployment and is not part of this PR, so `infra/main.tf` is left untouched.

## Removed

Both were dead configuration: no code reads either key, and the guarded feature is unconditionally live.

- `AccessManagement.MigrationDbEf` (removed from `appsettings.json` and `appsettings.Development.json`). The EF migration runs unconditionally in `Program.cs`, and no `IFeatureManager` read or config binding references this key anymore. The issue notes it should always be true.
- `AccessMgmt.Core.Services.IncludeSingleRightsImportedAssignments` (removed from `appsettings.json`). The issue lists this as already cleaned up in code. No code reference remains; only the stale appsettings entry was left, which this removes.

## Confirmed already gone from code (no code change needed)

These have no reads and no appsettings entries in this repo; only terraform still lists them, which is out of scope here.

- `AccessManagement.ResourceDelegation.EF`
- `AccessManagement.InstanceDelegation.EF`
- `AccessMgmt.Core.Services.AuthorizedParties.EfEnabled`
- `AccessManagement.HostedServices.RegisterSync` (deprecated)
- `AccessManagement.HostedServices.ResourceRegistrySync` (deprecated)

The deprecated `AccessManagement.HostedServices.*` keys are distinct from the current `AccessMgmt.Core.HostedServices.RegisterSync` and `AccessMgmt.Core.HostedServices.ResourceRegistrySync` keys that `RegisterHostedService` actually reads. Only the deprecated `AccessManagement.`-prefixed variants appear in the codebase, and they exist solely in terraform, so nothing in code is touched and the current toggles are kept.

## Left in place on purpose

- `AccessManagement.MigrationDb`: the Yuniql migration path is still present in AccessManagement (referenced from the csproj and `PersistenceDependencyInjectionExtensions`), so this toggle is not dead.
- `AccessManagement.Enduser.Connections` and `AccessManagement.Internal.Connections`: tied to the systemuser-API and connections cleanup in #3656, which depends on the Authentication team.
- `AccessMgmt.Enduser.Controller.ClientDelegation`: gated on the in-flight client delegation work in #3689, which edits the same controller.

## Verification

- `dotnet build src/apps/Altinn.AccessManagement/Altinn.AccessManagement.sln`: 0 errors, 136 warnings (consistent with the existing baseline).
- Grepped the repo to confirm no remaining code or appsettings reference to the two removed keys.
- No code branch changed, since both features were already unconditionally live, so no test behaviour depends on the removed entries.
