### PR TITLE
fix: authorizedparties include-flags honored when orgCode/resource filter is used

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartiesServiceEf.cs
@@ -574,8 +574,8 @@ public class AuthorizedPartiesServiceEf(
         // Only build resource filters if providerCode or anyOfResourceIds filters are specified
         if (filter.ProviderCode != null || filter.AnyOfResourceIds?.Length > 0)
         {
-            // Make sure all include filters are set to true, as we need all access info when filtering on provider/resources
-            filter.IncludeRoles = filter.IncludeAccessPackages = filter.IncludeResources = filter.IncludeInstances = true;
+            // The populated ResourceFilter/PackageFilter drive the connection query and FilterConnections internally.
+            // The caller's Include* flags are left untouched so EnrichWithPartiesWithAccessInfo shapes the response fields per what the caller requested.
 
             // Build cache key. Currently PackageFilter and RoleFilter are always empty when entering this method
             StringBuilder cacheBuilder = new($"pparf:{filter.ProviderCode}:");

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
@@ -177,7 +177,7 @@ public class AuthorizedPartiesControllerTest
             var client = CreateServiceOwnerClient(Fixture, TestData.NAV.Entity.OrganizationIdentifier);
 
             var query = $"{OldRoute}?anyOfResourceIds={TestData.SiriusSkattemelding.RefId}" +
-                        "&includeResources=true&includeInstances=true";
+                        "&includeRoles=true&includeAccessPackages=true&includeResources=true&includeInstances=true";
 
             // Act
             var response = await client.PostAsJsonAsync(query, JosephineSubject, TestContext.Current.CancellationToken);
@@ -202,12 +202,12 @@ public class AuthorizedPartiesControllerTest
             var client = CreateServiceOwnerClient(Fixture, TestData.NAV.Entity.OrganizationIdentifier);
 
             var query = $"{OldRoute}?anyOfResourceIds={TestData.SiriusSkattemelding.RefId}" +
-                        "&includeResources=false&includeInstances=true";
+                        "&includeRoles=false&includeAccessPackages=false&includeResources=false&includeInstances=true";
 
             // Act
             var response = await client.PostAsJsonAsync(query, JosephineSubject, TestContext.Current.CancellationToken);
 
-            // Assert: instances populated, resources still empty.
+            // Assert: only instances populated; roles, access packages and resources stay empty.
             var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -216,6 +216,8 @@ public class AuthorizedPartiesControllerTest
 
             var kaos = parties.FirstOrDefault(p => p.PartyUuid == TestData.KaosMagicDesignAndArts.Id);
             Assert.NotNull(kaos);
+            Assert.Empty(kaos.AuthorizedRoles);
+            Assert.Empty(kaos.AuthorizedAccessPackages);
             Assert.Empty(kaos.AuthorizedResources);
             Assert.NotEmpty(kaos.AuthorizedInstances);
         }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.ServiceOwner.Api.Tests/Integration/Controllers/AuthorizedPartiesControllerTest.cs
@@ -116,4 +116,108 @@ public class AuthorizedPartiesControllerTest
             Assert.Contains("dagl", dumbo.AuthorizedRoles);
         }
     }
+
+    /// <summary>
+    /// A provider/resource filter (orgCode or anyOfResourceIds) narrows which parties are returned,
+    /// but must not change how the returned parties are enriched. The include-flags gate enrichment of
+    /// the response fields (authorizedRoles, authorizedAccessPackages, authorizedResources, authorizedInstances)
+    /// and are honored independently of whether a resource filter is present.
+    /// Josephine is a rightholder on Kaos Magic Design and Arts with resource and instance access to
+    /// SiriusSkattemelding, so a filter on that resource returns Kaos.
+    /// </summary>
+    [IntegrationTest]
+    public class GetAuthorizedPartiesWithResourceFilter : IClassFixture<ApiFixture>
+    {
+        public GetAuthorizedPartiesWithResourceFilter(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.WithEnabledFeatureFlag(FeatureFlags.RightsDelegationApi);
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private static AuthorizedPartyRequestDto JosephineSubject => new()
+        {
+            Type = "urn:altinn:person:uuid",
+            Value = TestData.JosephineYvonnesdottir.Id.ToString(),
+        };
+
+        [Fact]
+        public async Task GetAuthorizedParties_WithResourceFilterAndIncludeFlagsFalse_Returns200WithPartyButNoEnrichment()
+        {
+            // Arrange: NAV asks on behalf of Josephine, filtering on a resource she has access to on Kaos,
+            // while opting out of every enrichment field.
+            var client = CreateServiceOwnerClient(Fixture, TestData.NAV.Entity.OrganizationIdentifier);
+
+            var query = $"{OldRoute}?anyOfResourceIds={TestData.SiriusSkattemelding.RefId}" +
+                        "&includeRoles=false&includeAccessPackages=false&includeResources=false&includeInstances=false";
+
+            // Act
+            var response = await client.PostAsJsonAsync(query, JosephineSubject, TestContext.Current.CancellationToken);
+
+            // Assert: the matching party is still returned, but no enrichment fields are populated.
+            var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var parties = JsonSerializer.Deserialize<List<AuthorizedPartyDto>>(body, JsonOptions);
+            Assert.NotNull(parties);
+
+            var kaos = parties.FirstOrDefault(p => p.PartyUuid == TestData.KaosMagicDesignAndArts.Id);
+            Assert.NotNull(kaos);
+            Assert.Empty(kaos.AuthorizedRoles);
+            Assert.Empty(kaos.AuthorizedAccessPackages);
+            Assert.Empty(kaos.AuthorizedResources);
+            Assert.Empty(kaos.AuthorizedInstances);
+        }
+
+        [Fact]
+        public async Task GetAuthorizedParties_WithResourceFilterAndIncludeFlagsTrue_Returns200WithPartyAndEnrichment()
+        {
+            // Arrange: same filter, but the caller asks for resource and instance enrichment.
+            var client = CreateServiceOwnerClient(Fixture, TestData.NAV.Entity.OrganizationIdentifier);
+
+            var query = $"{OldRoute}?anyOfResourceIds={TestData.SiriusSkattemelding.RefId}" +
+                        "&includeResources=true&includeInstances=true";
+
+            // Act
+            var response = await client.PostAsJsonAsync(query, JosephineSubject, TestContext.Current.CancellationToken);
+
+            // Assert: the party is returned with the requested enrichment populated.
+            var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var parties = JsonSerializer.Deserialize<List<AuthorizedPartyDto>>(body, JsonOptions);
+            Assert.NotNull(parties);
+
+            var kaos = parties.FirstOrDefault(p => p.PartyUuid == TestData.KaosMagicDesignAndArts.Id);
+            Assert.NotNull(kaos);
+            Assert.Contains(TestData.SiriusSkattemelding.RefId, kaos.AuthorizedResources);
+            Assert.NotEmpty(kaos.AuthorizedInstances);
+        }
+
+        [Fact]
+        public async Task GetAuthorizedParties_WithResourceFilterAndOnlyIncludeInstances_Returns200WithInstancesButNoResources()
+        {
+            // Arrange: the include-flags must be honored per field, not collapsed to all-or-nothing.
+            var client = CreateServiceOwnerClient(Fixture, TestData.NAV.Entity.OrganizationIdentifier);
+
+            var query = $"{OldRoute}?anyOfResourceIds={TestData.SiriusSkattemelding.RefId}" +
+                        "&includeResources=false&includeInstances=true";
+
+            // Act
+            var response = await client.PostAsJsonAsync(query, JosephineSubject, TestContext.Current.CancellationToken);
+
+            // Assert: instances populated, resources still empty.
+            var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var parties = JsonSerializer.Deserialize<List<AuthorizedPartyDto>>(body, JsonOptions);
+            Assert.NotNull(parties);
+
+            var kaos = parties.FirstOrDefault(p => p.PartyUuid == TestData.KaosMagicDesignAndArts.Id);
+            Assert.NotNull(kaos);
+            Assert.Empty(kaos.AuthorizedResources);
+            Assert.NotEmpty(kaos.AuthorizedInstances);
+        }
+    }
 }


### PR DESCRIPTION
Closes #2140

## What was wrong

On the ServiceOwner AuthorizedParties endpoint, using a provider filter (`orgCode`) or a resource filter (`anyOfResourceIds`) overwrote every include-flag to `true`, regardless of what the caller sent. `ProcessProviderAndResourceFilters` did:

```
filter.IncludeRoles = filter.IncludeAccessPackages = filter.IncludeResources = filter.IncludeInstances = true;
```

The include-flags are only meant to gate enrichment of the response fields `authorizedRoles`, `authorizedAccessPackages`, `authorizedResources` and `authorizedInstances`. They were never meant to pull extra data into the response. So a caller who passed `includeRoles=false` (or relied on `includeAccessPackages` defaulting to false) together with an `orgCode`/`anyOfResourceIds` filter got those fields populated anyway.

## The change

The forced assignment is removed. The provider/resource filter still narrows which parties are returned. Internally it does not depend on the caller's flags: the populated `ResourceFilter`/`PackageFilter` already force the connection query to fetch resources, instances and packages, and role data is always available on the connections, so `FilterConnections` has everything it needs. The caller's original flags are preserved, so `EnrichWithPartiesWithAccessInfo` shapes the response fields per what the caller actually requested.

For external consumers: a party that matches the `orgCode`/`anyOfResourceIds` filter is still returned. Its enrichment fields are now populated only when the corresponding include-flag is set, exactly as without a filter. No party is dropped from the list, and the flags no longer over-populate.

## Out of scope

The suggestion in the issue to flip the default of `includeAccessPackages` from `false` to `true` is a separate product decision and is not made here. No default is changed.

## Tests

Added integration tests on the ServiceOwner endpoint (Josephine has resource and instance access on Kaos via a rightholder assignment, so a filter on that resource returns Kaos):

- With the filter and all include-flags false, the party is returned but no enrichment fields are populated. This case fails on the old behaviour and passes now.
- With the filter and include-flags true, the party is returned with enrichment populated (guards against under-populating).
- With the filter and only `includeInstances=true`, instances are populated but resources stay empty (flags honored per field).

Full ServiceOwner and Enduser AuthorizedParties integration suites pass unchanged.
