### PR TITLE
chore: add DI extension and package metadata to ABAC

### DIFF
--- a/src/pkgs/Altinn.Authorization.ABAC/Directory.Packages.props
+++ b/src/pkgs/Altinn.Authorization.ABAC/Directory.Packages.props
@@ -3,6 +3,11 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
     <ItemGroup>
+        <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
         <PackageVersion Include="coverlet.collector" Version="6.0.4" />
         <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
         <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.csproj
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <!-- NuGet package properties -->
@@ -9,5 +9,18 @@
             See details at https://docs.altinn.studio.
         </Description>
     </PropertyGroup>
+
+    <PropertyGroup Label="Deterministic build and SourceLink">
+        <Deterministic>true</Deterministic>
+        <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    </ItemGroup>
 
 </Project>

--- a/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/DependencyInjection/PolicyDecisionPointServiceCollectionExtensions.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/src/Altinn.Authorization.ABAC/DependencyInjection/PolicyDecisionPointServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Altinn.Authorization.ABAC;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for registering the <see cref="PolicyDecisionPoint"/> with an <see cref="IServiceCollection"/>.
+    /// </summary>
+    public static class PolicyDecisionPointServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers the <see cref="PolicyDecisionPoint"/> as a singleton so consumers can resolve it from dependency injection
+        /// instead of constructing it directly.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the Policy Decision Point to.</param>
+        /// <returns>The same <paramref name="services"/> instance so calls can be chained.</returns>
+        public static IServiceCollection AddPolicyDecisionPoint(this IServiceCollection services)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            services.TryAddSingleton<PolicyDecisionPoint>();
+
+            return services;
+        }
+    }
+}

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Altinn.Authorization.ABAC.Tests.csproj
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/Altinn.Authorization.ABAC.Tests.csproj
@@ -13,6 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Content Include="xunit.runner.json" CopyToOutputDirectory="Always" />
     </ItemGroup>
 

--- a/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointServiceCollectionExtensionsTest.cs
+++ b/src/pkgs/Altinn.Authorization.ABAC/test/Altinn.Authorization.ABAC.Tests/PolicyDecisionPointServiceCollectionExtensionsTest.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Altinn.Authorization.ABAC.Tests;
+
+/// <summary>
+/// Tests for the <c>AddPolicyDecisionPoint</c> dependency injection extension: it must
+/// register a resolvable <see cref="PolicyDecisionPoint"/> as a singleton and stay
+/// idempotent when called more than once.
+/// </summary>
+[UnitTest]
+public class PolicyDecisionPointServiceCollectionExtensionsTest
+{
+    [Fact]
+    public void AddPolicyDecisionPoint_RegistersResolvableSingleton()
+    {
+        ServiceProvider provider = new ServiceCollection()
+            .AddPolicyDecisionPoint()
+            .BuildServiceProvider();
+
+        PolicyDecisionPoint first = provider.GetRequiredService<PolicyDecisionPoint>();
+        PolicyDecisionPoint second = provider.GetRequiredService<PolicyDecisionPoint>();
+
+        first.Should().NotBeNull();
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void AddPolicyDecisionPoint_CalledTwice_RegistersSingleDescriptor()
+    {
+        IServiceCollection services = new ServiceCollection()
+            .AddPolicyDecisionPoint()
+            .AddPolicyDecisionPoint();
+
+        services.Count(descriptor => descriptor.ServiceType == typeof(PolicyDecisionPoint)).Should().Be(1);
+    }
+}


### PR DESCRIPTION
Related to #3132

This is the safe, non-behavioural slice of the ABAC audit. It changes no decision logic: no combining algorithm, no `AttributeMatcher`, no evaluation path, and no public API signature is touched. The PDP produces exactly the same Permit/Deny/NotApplicable/Indeterminate results as before.

## Done

- **CODE-13** Added an `AddPolicyDecisionPoint` `IServiceCollection` extension so consumers can resolve the PDP from dependency injection instead of `new PolicyDecisionPoint()`. Existing hand-wiring keeps working. The PDP holds no mutable instance state, so it registers as a singleton. Covered by two tests (resolvable singleton, idempotent registration).
- **CODE-15** Added the safe modern package metadata: deterministic-build properties and SourceLink. This matches the `Microsoft.SourceLink.GitHub` convention already used in the main `src` tree, which the ABAC package's isolated build did not inherit.

## Left out on purpose

- **CODE-10** (remove dead `_lockObject` in `XacmlPolicy.cs`): not dead. The field backs the double-checked locking in `GetAttributeDictionaryByCategory`. Left as is.
- **CODE-9** (rename `attributeAssigments` parameter): binary-breaking. Belongs in the v2 API pass.
- **CODE-12** (add `CancellationToken` to `IContextHandler.Enrich`): public interface signature change. Belongs in the v2 API pass.
- **CODE-14** (flat `Xacml/` folder reorg): a 50-file move is review noise and conflicts with any in-flight ABAC work. Its own PR if wanted.
- **CODE-15** `<Nullable>enable</Nullable>` and `<IsAotCompatible>`: the library is not nullable-aware and would produce a wall of new warnings, so these are left for a dedicated follow-up.

## Verification

- ABAC package builds clean for net9.0 and net10.0: 0 warnings, 0 errors.
- AccessManagement and Authorization solutions build: 0 errors.
- `Altinn.Authorization.ABAC.Tests`: 99 passed before, 101 passed after (the 99 unchanged plus 2 new DI tests), 67 skipped unchanged, 0 failed.
- `Altinn.Authorization.PEP.Tests`: 94 passed before and after, unchanged.
