### PR TITLE
feat: link delegation resources to their originating assignment resource

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,5 +1,6 @@
 # Cross platform shebang:
 shebang := if os() == 'windows' { 'pwsh.exe' } else { '/usr/bin/env pwsh'}
+amdir := 'src/apps/Altinn.AccessManagement/src'
 
 # Define the container runtime based on OS
 container-tool := if os() == 'windows' {
@@ -50,6 +51,15 @@ db-cred:
   #!{{shebang}}
   dotnet run --project "./src/tools/Altinn.Authorization.Cli/src/Altinn.Authorization.Cli" -- db cred
 
+am-db-migrate message:
+  dotnet ef migrations add -p {{amdir}}/Altinn.AccessMgmt.PersistenceEF -s {{amdir}}/Altinn.AccessManagement {{message}}
+
+am-db-migrate-remove:
+  dotnet ef migrations remove -p {{amdir}}/Altinn.AccessMgmt.PersistenceEF -s {{amdir}}/Altinn.AccessManagement
+
+am-db-update:
+  dotnet ef database update -p {{amdir}}/Altinn.AccessMgmt.PersistenceEF -s {{amdir}}/Altinn.AccessManagement
+
 # Dispatches a set of containers that's used for local dev
 dev:
   #!{{shebang}}
@@ -60,10 +70,10 @@ dev-pgsql-connection-string:
   #!{{shebang}}
   $port = {{container-tool}} inspect --format='{{"{{(index .NetworkSettings.Ports \"5432/tcp\" 0).HostPort}}"}}' altinn_authorization_postgres
   if ($IsWindows) {
-    Write-Output "Host=host.containers.internal;Port=$port;Username=admin;Password=admin;Database=accessmgmt"
+    Write-Output "Host=host.containers.internal;Port=$port;Username=admin;Password=admin;Database=authorizationdb"
   } else {
     $bridge_ip = ip a | grep docker0 | awk '/inet / {print $2}' | cut -d'/' -f1
-    Write-Output "Host=$bridge_ip;Port=$port;Username=admin;Password=admin;Database=accessmgmt"
+    Write-Output "Host=$bridge_ip;Port=$port;Username=admin;Password=admin;Database=authorizationdb"
   }
 
 # Starts redis shell connected to docker composer redis instance

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@admin.com
       PGADMIN_DEFAULT_PASSWORD: admin
+    networks:
+      - postgres
     volumes:
       - altinn_authorization_data:/pgadmin
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ClientDelegationController.cs
@@ -126,7 +126,7 @@ public class ClientDelegationController(
             return Unauthorized();
         }
 
-        var problem = await clientDelegationService.RemoveAnAgentsClient(provider, from, partyUuid, cascade, cancellationToken);
+        var problem = await clientDelegationService.RemoveClientFromAgent(provider, from, partyUuid, cascade, cancellationToken);
         if (problem is { })
         {
             return problem.ToActionResult();
@@ -288,7 +288,7 @@ public class ClientDelegationController(
         [FromQuery(Name = "cascade")] bool cascade = false,
         CancellationToken cancellationToken = default)
     {
-        var problem = await clientDelegationService.RemoveAnAgentsClient(party, from, to, cascade, cancellationToken);
+        var problem = await clientDelegationService.RemoveClientFromAgent(party, from, to, cascade, cancellationToken);
         if (problem is { })
         {
             return problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -349,7 +349,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
-    public async Task<ValidationProblemInstance?> RemoveAnAgentsClient(Guid partyUuid, Guid fromUuid, Guid toUuid, bool cascade, CancellationToken cancellationToken = default)
+    public async Task<ValidationProblemInstance?> RemoveClientFromAgent(Guid partyUuid, Guid fromUuid, Guid toUuid, bool cascade, CancellationToken cancellationToken = default)
     {
         ValidationErrorBuilder errorBuilder = default;
 
@@ -361,11 +361,27 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 d.From.ToId == partyUuid && d.From.FromId == fromUuid)
             .Include(d => d.DelegationPackages)
             .ThenInclude(d => d.Package)
+            .Include(d => d.DelegationResources)
+            .ThenInclude(d => d.Resource)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (existingDelegation is null)
         {
             return null;
+        }
+
+        foreach (var delegationResource in existingDelegation.DelegationResources)
+        {
+            if (!cascade)
+            {
+                errorBuilder.Add(
+                    ValidationErrors.DelegationHasActiveConnections,
+                    "$QUERY/cascade",
+                    [
+                        new($"{delegationResource.ResourceId}", $"Cannot remove delegation '{delegationResource.DelegationId}' because party '{toUuid}' still has active delegated resources '{delegationResource.Resource?.Name ?? delegationResource.ResourceId.ToString()}' from '{fromUuid}'.")
+                    ]
+                );
+            }
         }
 
         foreach (var delegationPackage in existingDelegation.DelegationPackages)
@@ -420,35 +436,37 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             .AsNoTracking()
             .Where(p => p.ToId == existingAssignment.Id)
             .Include(p => p.DelegationPackages)
-            .Join(db.DelegationPackages, d => d.Id, dp => dp.DelegationId, (d, dp) => new
-            {
-                Delegation = d,
-                DelegationPackage = dp,
-            })
-            .GroupBy(d => d.Delegation.Id)
+            .Include(p => p.DelegationResources)
+            .Where(p => p.DelegationPackages.Any() || p.DelegationResources.Any())
             .ToListAsync(cancellationToken);
 
         foreach (var existingDelegation in existingDelegations)
         {
-            var first = existingDelegation.FirstOrDefault();
-
-            if (first is null)
-            {
-                continue;
-            }
-
-            var pkgs = string.Join(", ", existingDelegation.Select(p => p.DelegationPackage.PackageId));
-            var fromId = first.Delegation.FromId;
-
             if (!cascade)
             {
-                errorBuilder.Add(
-                    ValidationErrors.DelegationHasActiveConnections,
-                    "$QUERY/cascade",
-                    [
-                        new($"{first.Delegation.Id}", $"Cannot remove delegation '{first.Delegation.Id}' because party '{toUuid}' still has active delegated packages <{pkgs}> from party '{fromId}'.")
-                    ]
-                );
+                if (existingDelegation.DelegationPackages.Count > 0)
+                {
+                    var pkgs = string.Join(", ", existingDelegation.DelegationPackages.Select(p => p.PackageId));
+                    errorBuilder.Add(
+                        ValidationErrors.DelegationHasActiveConnections,
+                        "$QUERY/cascade",
+                        [
+                            new($"{existingDelegation.Id}", $"Cannot remove delegation '{existingDelegation.Id}' because party '{toUuid}' still has active delegated packages <{pkgs}> from party '{existingDelegation.FromId}'.")
+                        ]
+                    );
+                }
+
+                if (existingDelegation.DelegationResources.Count > 0)
+                {
+                    var resources = string.Join(", ", existingDelegation.DelegationResources.Select(r => r.ResourceId));
+                    errorBuilder.Add(
+                        ValidationErrors.DelegationHasActiveConnections,
+                        "$QUERY/cascade",
+                        [
+                            new($"{existingDelegation.Id}", $"Cannot remove delegation '{existingDelegation.Id}' because party '{toUuid}' still has active delegated resources <{resources}> from party '{existingDelegation.FromId}'.")
+                        ]
+                    );
+                }
             }
         }
 
@@ -1008,16 +1026,17 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                     Packages = dp,
                     AnyPackages = dp.Any(),
                     DelegationId = d.Id,
+                    HasResources = d.DelegationResources.Any(),
                 }
             )
             .ToListAsync(cancellationToken);
 
-        // Remove delegation if all delegation packages are removed from client.
+        // Remove delegation if all delegation packages are removed from client and no delegated resources remain.
         foreach (var delegation in delegations)
         {
             var scheduledDeletedPackages = result.Where(r => r.Changed).Select(p => p.PackageId).ToHashSet();
             var currentPackages = delegation.Packages.Select(p => p.PackageId).ToHashSet() ?? [];
-            var shouldDeleteDelegation = scheduledDeletedPackages.SetEquals(currentPackages);
+            var shouldDeleteDelegation = !delegation.HasResources && scheduledDeletedPackages.SetEquals(currentPackages);
 
             if (shouldDeleteDelegation)
             {
@@ -1128,7 +1147,7 @@ public interface IClientDelegationService
     /// Removes an a client from an agent.
     /// If <paramref name="cascade"/> is false, removal fails when active delegations exist.
     /// </summary>
-    Task<ValidationProblemInstance?> RemoveAnAgentsClient(Guid partyUuid, Guid fromUuid, Guid toUuid, bool cascade, CancellationToken cancellationToken = default);
+    Task<ValidationProblemInstance?> RemoveClientFromAgent(Guid partyUuid, Guid fromUuid, Guid toUuid, bool cascade, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets packages delegated from a specific client via the party, grouped by agent.

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -363,6 +363,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             .ThenInclude(d => d.Package)
             .Include(d => d.DelegationResources)
             .ThenInclude(d => d.Resource)
+            .AsSplitQuery()
             .FirstOrDefaultAsync(cancellationToken);
 
         if (existingDelegation is null)
@@ -438,6 +439,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             .Include(p => p.DelegationPackages)
             .Include(p => p.DelegationResources)
             .Where(p => p.DelegationPackages.Any() || p.DelegationResources.Any())
+            .AsSplitQuery()
             .ToListAsync(cancellationToken);
 
         foreach (var existingDelegation in existingDelegations)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/Contracts/IDelegationService.cs
@@ -39,12 +39,6 @@ public interface IDelegationService
     Task<bool> AddPackageToDelegation(Guid userId, Guid delegationId, Guid packageId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Adds a resource to the delegation
-    /// </summary>
-    /// <returns></returns>
-    Task<bool> AddResourceToDelegation(Guid userId, Guid delegationId, Guid resourceId, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Create a delegation and required assignments for system agent flow
     /// </summary>
     Task<IEnumerable<CreateDelegationResponseDto>> CreateClientDelegation(CreateSystemDelegationRequestDto request, Guid facilitatorPartyId, CancellationToken cancellationToken = default);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Altinn.AccessMgmt.Core.Services;
 
 /// <inheritdoc/>
-public class DelegationService(AppDbContext db, IAssignmentService assignmentService, IRoleService roleService, IPackageService packageService, IResourceService resourceService, IEntityService entityService) : IDelegationService
+public class DelegationService(AppDbContext db, IAssignmentService assignmentService, IRoleService roleService, IPackageService packageService, IEntityService entityService) : IDelegationService
 {
     /// <inheritdoc/>
     public async Task<IEnumerable<Delegation>> GetDelegations(Guid fromId, Guid toId, CancellationToken cancellationToken = default)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/DelegationService.cs
@@ -99,51 +99,6 @@ public class DelegationService(AppDbContext db, IAssignmentService assignmentSer
     }
 
     /// <inheritdoc/>
-    public async Task<bool> AddResourceToDelegation(Guid userId, Guid delegationId, Guid resourceId, CancellationToken cancellationToken = default)
-    {
-        /*
-        [ ] Check i Package is Delegable (?)
-        [ ] Check i Resource is Delegable
-        */
-
-        /* 
-        [X] Check if user is DelegationAdmin on FromId 
-        [X] Check if assignment has the resource
-        [X] Check if the assignment role has the resource
-        [X] Check if the assignment packages has the resource
-        */
-
-        var resource = await resourceService.GetResource(resourceId, cancellationToken);
-
-        var delegation = await GetDelegation(delegationId, cancellationToken);
-        var fromAssignment = await assignmentService.GetAssignment(delegation.FromId, cancellationToken);
-
-        var assignmentResources = await assignmentService.GetAssignmentResources(fromAssignment.Id, cancellationToken);
-
-        // TODO: Add Assignment Variant to include RoleVariantPackages
-        var roleResources = await roleService.GetRoleResources(fromAssignment.RoleId, variantId: null, includePackageResoures: true, cancellationToken);
-
-        if (assignmentResources.Count(t => t.Id == resourceId) == 0
-            && roleResources.Count(t => t.Id == resourceId) == 0
-            )
-        {
-            throw new InvalidOperationException($"The source assignment does not have the resource '{resource.Name}'");
-        }
-
-        await db.DelegationResources.AddAsync(
-            new DelegationResource()
-            {
-                DelegationId = delegationId,
-                ResourceId = resourceId
-            },
-            cancellationToken
-        );
-        var result = await db.SaveChangesAsync(cancellationToken);
-
-        return result > 0;
-    }
-
-    /// <inheritdoc/>
     public async Task<IEnumerable<CreateDelegationResponseDto>> CreateClientDelegation(CreateSystemDelegationRequestDto request, Guid facilitatorPartyId, CancellationToken cancellationToken)
     {
         // Find Facilitator

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/DelegationConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/DelegationConfiguration.cs
@@ -20,13 +20,6 @@ public class DelegationConfiguration : IEntityTypeConfiguration<Delegation>
         builder.PropertyWithReference(navKey: t => t.To, foreignKey: t => t.ToId, principalKey: t => t.Id, deleteBehavior: DeleteBehavior.Cascade);
         builder.PropertyWithReference(navKey: t => t.Facilitator, foreignKey: t => t.FacilitatorId, principalKey: t => t.Id, deleteBehavior: DeleteBehavior.Cascade);
 
-        builder.CollectionPropertyWithReference(
-            collectionNav: t => t.DelegationPackages,
-            referenceNav: t => t.Delegation,
-            foreignKey: t => t.DelegationId,
-            deleteBehavior: DeleteBehavior.Cascade
-            );
-
         builder.HasIndex(t => new { t.FromId, t.ToId, t.FacilitatorId }).IsUnique();
         builder.HasIndex(t => new { t.ToId }).IncludeProperties(["Id", "FromId"]);
     }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/DelegationResourceConfiguration.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Configurations/DelegationResourceConfiguration.cs
@@ -16,8 +16,9 @@ public class DelegationResourceConfiguration : IEntityTypeConfiguration<Delegati
 
         builder.HasKey(p => p.Id);
 
-        builder.PropertyWithReference(navKey: t => t.Delegation, foreignKey: t => t.DelegationId, principalKey: t => t.Id, deleteBehavior: DeleteBehavior.Cascade);
+        builder.PropertyWithReference(navKey: t => t.Delegation, foreignKey: t => t.DelegationId, principalKey: t => t.Id, withMany: t => t.DelegationResources, deleteBehavior: DeleteBehavior.Cascade);
         builder.PropertyWithReference(navKey: t => t.Resource, foreignKey: t => t.ResourceId, principalKey: t => t.Id, deleteBehavior: DeleteBehavior.Restrict);
+        builder.PropertyWithReference(navKey: t => t.AssignmentResource, foreignKey: t => t.AssignmentResourceId, principalKey: t => t.Id, withMany: t => t.DelegationResources, deleteBehavior: DeleteBehavior.Cascade, required: true);
 
         builder.HasIndex(t => new { t.DelegationId, t.ResourceId }).IsUnique();
     }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Contexts/AppDbDesignTimeContextFactory.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Contexts/AppDbDesignTimeContextFactory.cs
@@ -20,10 +20,15 @@ public sealed class AppDbDesignTimeContextFactory : IDesignTimeDbContextFactory<
             .Build();
 
         var path = "PostgreSQLSettings:AdminConnectionString";
-        if (configuration.GetValue<string>(path) is var cs && string.IsNullOrEmpty(cs))
+        var cs = configuration.GetValue<string>(path);
+        if (string.IsNullOrWhiteSpace(cs))
         {
             Console.WriteLine($"The configuration path '{path}' is missing or empty. Set it through an environment variable or user secrets. Trying default values.");
             cs = "Database=authorizationdb;Host=localhost;Username=platform_authorization_admin;Password=Password;Include Error Detail=true";
+        }
+        else
+        {
+            cs = string.Format(cs, configuration.GetValue<string>("PostgreSQLSettings:AuthorizationDbAdminPwd"));
         }
 
         var options = new DbContextOptionsBuilder<AppDbContext>()

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Contexts/AppDbDesignTimeContextFactory.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Contexts/AppDbDesignTimeContextFactory.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Contexts;
 
@@ -15,15 +14,15 @@ public sealed class AppDbDesignTimeContextFactory : IDesignTimeDbContextFactory<
 {
     public AppDbContext CreateDbContext(string[] args)
     {
-        var connectionString = new ConfigurationBuilder()
+        var configuration = new ConfigurationBuilder()
             .AddEnvironmentVariables()
             .AddUserSecrets<AppDbDesignTimeContextFactory>(optional: true)
             .Build();
 
         var path = "PostgreSQLSettings:AdminConnectionString";
-        if (connectionString.GetValue<string>(path) is var cs && string.IsNullOrEmpty(cs))
+        if (configuration.GetValue<string>(path) is var cs && string.IsNullOrEmpty(cs))
         {
-            Console.WriteLine($"The configuration path '{path}' is missing or empty. Please check your environment variables, User Secrets, or Environment Variables. Trying default values.");
+            Console.WriteLine($"The configuration path '{path}' is missing or empty. Set it through an environment variable or user secrets. Trying default values.");
             cs = "Database=authorizationdb;Host=localhost;Username=platform_authorization_admin;Password=Password;Include Error Detail=true";
         }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Contexts/AppDbDesignTimeContextFactory.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Contexts/AppDbDesignTimeContextFactory.cs
@@ -3,6 +3,8 @@ using Altinn.AccessMgmt.PersistenceEF.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Contexts;
 
@@ -13,7 +15,17 @@ public sealed class AppDbDesignTimeContextFactory : IDesignTimeDbContextFactory<
 {
     public AppDbContext CreateDbContext(string[] args)
     {
-        var cs = Environment.GetEnvironmentVariable("Database:Postgres:MigrationConnectionString") ?? "Database=authorizationdb;Host=localhost;Username=platform_authorization_admin;Password=Password;Include Error Detail=true";
+        var connectionString = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets<AppDbDesignTimeContextFactory>(optional: true)
+            .Build();
+
+        var path = "PostgreSQLSettings:AdminConnectionString";
+        if (connectionString.GetValue<string>(path) is var cs && string.IsNullOrEmpty(cs))
+        {
+            Console.WriteLine($"The configuration path '{path}' is missing or empty. Please check your environment variables, User Secrets, or Environment Variables. Trying default values.");
+            cs = "Database=authorizationdb;Host=localhost;Username=platform_authorization_admin;Password=Password;Include Error Detail=true";
+        }
 
         var options = new DbContextOptionsBuilder<AppDbContext>()
             .UseNpgsql(cs)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Migrations/20260716084804_AddedAssignmentResourceFKToDelegationResourceAndCascadeDelete.Designer.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Migrations/20260716084804_AddedAssignmentResourceFKToDelegationResourceAndCascadeDelete.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Altinn.AccessMgmt.PersistenceEF.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Altinn.AccessMgmt.PersistenceEF.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260716084804_AddedAssignmentResourceFKToDelegationResourceAndCascadeDelete")]
+    partial class AddedAssignmentResourceFKToDelegationResourceAndCascadeDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Migrations/20260716084804_AddedAssignmentResourceFKToDelegationResourceAndCascadeDelete.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Migrations/20260716084804_AddedAssignmentResourceFKToDelegationResourceAndCascadeDelete.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Altinn.AccessMgmt.PersistenceEF.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedAssignmentResourceFKToDelegationResourceAndCascadeDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "assignmentresourceid",
+                schema: "dbo",
+                table: "delegationresource",
+                type: "uuid",
+                nullable: false);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "assignmentresourceid",
+                schema: "dbo_history",
+                table: "auditdelegationresource",
+                type: "uuid",
+                nullable: false);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_delegationresource_assignmentresourceid",
+                schema: "dbo",
+                table: "delegationresource",
+                column: "assignmentresourceid");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_delegationresource_assignmentresource_assignmentresourceid",
+                schema: "dbo",
+                table: "delegationresource",
+                column: "assignmentresourceid",
+                principalSchema: "dbo",
+                principalTable: "assignmentresource",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_delegationresource_assignmentresource_assignmentresourceid",
+                schema: "dbo",
+                table: "delegationresource");
+
+            migrationBuilder.DropIndex(
+                name: "ix_delegationresource_assignmentresourceid",
+                schema: "dbo",
+                table: "delegationresource");
+
+            migrationBuilder.DropColumn(
+                name: "assignmentresourceid",
+                schema: "dbo",
+                table: "delegationresource");
+
+            migrationBuilder.DropColumn(
+                name: "assignmentresourceid",
+                schema: "dbo_history",
+                table: "auditdelegationresource");
+        }
+    }
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/AssignmentResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/AssignmentResource.cs
@@ -17,5 +17,10 @@ public class AssignmentResource : BaseAssignmentResource
     /// </summary>
     public Resource Resource { get; set; }
 
+    /// <summary>
+    /// Delegation Resources
+    /// </summary>
+    public ICollection<DelegationResource> DelegationResources { get; set; } = [];
+
     public Entity? ChangedBy { get; set; }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Base/BaseDelegationResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Base/BaseDelegationResource.cs
@@ -46,4 +46,9 @@ public class BaseDelegationResource : BaseAudit
     /// Resource identifier
     /// </summary>
     public Guid ResourceId { get; set; }
+
+    /// <summary>
+    /// AssignmentResource identifier
+    /// </summary>
+    public Guid AssignmentResourceId { get; set; }
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Delegation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/Delegation.cs
@@ -26,4 +26,9 @@ public class Delegation : BaseDelegation
     /// Delegation Packages
     /// </summary>
     public ICollection<DelegationPackage> DelegationPackages { get; set; } = [];
+
+    /// <summary>
+    /// Delegation Resources
+    /// </summary>
+    public ICollection<DelegationResource> DelegationResources { get; set; } = [];
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/DelegationResource.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Models/DelegationResource.cs
@@ -16,4 +16,9 @@ public class DelegationResource : BaseDelegationResource
     /// Resource
     /// </summary>
     public Resource Resource { get; set; }
+
+    /// <summary>
+    /// AssignmentResource
+    /// </summary>
+    public AssignmentResource AssignmentResource { get; set; }
 }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ClientDelegationControllerTest.cs
@@ -198,7 +198,7 @@ public class ClientDelegationControllerTest
         }
 
         [Fact]
-        public async Task ListMyClients_WithProviderFilterForProviderWithoutDelegationResources_Returns200WithEmptyClients()
+        public async Task ListMyClients_WithProviderFilterForProviderWithoutDelegations_Returns200WithEmptyClients()
         {
             var client = CreateClient();
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ClientDelegationControllerTest.cs
@@ -117,6 +117,21 @@ public class ClientDelegationControllerTest
                     PackageId = PackageConstants.AccountantWithoutSigningRights,
                 };
 
+                var assignmentResourceAccountant = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                var delegationResourceToPaula = new DelegationResource()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceAccountant.Id,
+                };
+
                 db.Assignments.Add(rightholderFromNordisToVerdiq);
                 db.Assignments.Add(accountantFromNordisToVerdiq);
                 db.Assignments.Add(forretningsforerFromOkernBrlToVerdiq);
@@ -136,6 +151,9 @@ public class ClientDelegationControllerTest
                     AssignmentId = rightholderFromNordisToVerdiq.Id,
                     PackageId = PackageConstants.Customs,
                 });
+
+                db.AssignmentResources.Add(assignmentResourceAccountant);
+                db.DelegationResources.Add(delegationResourceToPaula);
 
                 db.SaveChanges();
             });
@@ -177,6 +195,24 @@ public class ClientDelegationControllerTest
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Single(result.Items);
             Assert.Empty(result.Items.FirstOrDefault().Clients);
+        }
+
+        [Fact]
+        public async Task ListMyClients_WithProviderFilterForProviderWithoutDelegationResources_Returns200WithEmptyClients()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/my/clients?provider={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<MyClientDto>>(data);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Single(result.Items);
+
+            var nordis = result.Items.FirstOrDefault(p => p?.Provider?.Id == TestEntities.OrganizationNordisAS);
+            Assert.NotNull(nordis);
+            Assert.Empty(nordis.Clients);
         }
 
         [Fact]
@@ -825,6 +861,114 @@ public class ClientDelegationControllerTest
 
             Assert.Equal(HttpStatusCode.OK, getAgents.StatusCode);
             Assert.Empty(agentResult.Items);
+        }
+    }
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.RemoveAgent(Guid, Guid, bool, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteAgentWithDelegatedResources : IClassFixture<ApiFixture>
+    {
+        public DeleteAgentWithDelegatedResources(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DeleteAgentWithDelegatedResources>(db =>
+            {
+                var accountantFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var delegationToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var assignmentResourceAccountant = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                var delegationResourceToPaula = new DelegationResource()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceAccountant.Id,
+                };
+
+                db.Assignments.Add(accountantFromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.Delegations.Add(delegationToPaula);
+                db.AssignmentResources.Add(assignmentResourceAccountant);
+                db.DelegationResources.Add(delegationResourceToPaula);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task RemoveAgentWithResourceOnlyDelegation_WithCascadeFalse_Returns400WhenDelegationHasActiveConnections()
+        {
+            var client = CreateClient();
+
+            // Delete agent without cascade while a delegation with only resources exists
+            var deleteResponse = await client.DeleteAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}&cascade=false", TestContext.Current.CancellationToken);
+            var deleteResponsePayload = await deleteResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, deleteResponse.StatusCode);
+
+            // Ensure proper error returned
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(deleteResponsePayload);
+            Assert.Single(problem.Errors);
+            Assert.All(problem.Errors, error =>
+            {
+                Assert.Equal(ValidationErrors.DelegationHasActiveConnections.ErrorCode, error.ErrorCode);
+            });
+
+            // Delete with cascade true removes agent, delegation and delegated resources
+            deleteResponse = await client.DeleteAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}&cascade=true", TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegations = await db.Delegations
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id)
+                    .ToListAsync(TestContext.Current.CancellationToken);
+                Assert.Empty(delegations);
+
+                var delegationResources = await db.DelegationResources.ToListAsync(TestContext.Current.CancellationToken);
+                Assert.Empty(delegationResources);
+            });
         }
     }
     #endregion
@@ -1779,6 +1923,132 @@ public class ClientDelegationControllerTest
                 var deleteResult = JsonSerializer.Deserialize<List<DelegationDto>>(deleteResponsePayload);
                 return deleteResult;
             }
+        }
+    }
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DeleteAgentAccessPackage(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteAgentAccessPackageWithDelegationResources : IClassFixture<ApiFixture>
+    {
+        public DeleteAgentAccessPackageWithDelegationResources(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DeleteAgentAccessPackageWithDelegationResources>(db =>
+            {
+                var accountantFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var delegationToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var rolePackage = db.RolePackages.FirstOrDefault(r => r.RoleId == RoleConstants.Accountant && r.PackageId == PackageConstants.AccountantWithSigningRights);
+                var delegationPackageToPaula = new DelegationPackage()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    RolePackageId = rolePackage.Id,
+                    PackageId = PackageConstants.AccountantWithSigningRights,
+                };
+
+                var assignmentResourceAccountant = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                var delegationResourceToPaula = new DelegationResource()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceAccountant.Id,
+                };
+
+                db.Assignments.Add(accountantFromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.Delegations.Add(delegationToPaula);
+                db.DelegationPackages.Add(delegationPackageToPaula);
+                db.AssignmentResources.Add(assignmentResourceAccountant);
+                db.DelegationResources.Add(delegationResourceToPaula);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DeleteLastAccessPackage_WithRemainingDelegationResources_Returns200AndKeepsDelegation()
+        {
+            var client = CreateClient();
+
+            // Delete the only package on the delegation
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}")
+            {
+                Content = JsonContent.Create(new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Accountant.Entity.Code,
+                            Packages = [PackageConstants.AccountantWithSigningRights.Entity.Urn],
+                        }
+                    ]
+                })
+            };
+
+            var deleteResponse = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var deleteResponsePayload = await deleteResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+            var deleteResult = JsonSerializer.Deserialize<List<DelegationDto>>(deleteResponsePayload);
+            Assert.Single(deleteResult, d => d.Changed);
+
+            // The delegation must survive because it still has delegated resources
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegation = await db.Delegations
+                    .Include(d => d.DelegationPackages)
+                    .Include(d => d.DelegationResources)
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id
+                        && d.To.ToId == TestEntities.PersonPaula.Id
+                        && d.From.FromId == TestEntities.OrganizationNordisAS.Id)
+                    .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+                Assert.NotNull(delegation);
+                Assert.Empty(delegation.DelegationPackages);
+                Assert.NotEmpty(delegation.DelegationResources);
+            });
         }
     }
 


### PR DESCRIPTION
Closes #3769

Links `DelegationResource` to the `AssignmentResource` it originates from, as groundwork for client delegation of single resources (#3638).

- Adds a required `AssignmentResourceId` FK on `BaseDelegationResource` with cascade delete configured on the FK side, plus navigations on `DelegationResource`, `AssignmentResource` and `Delegation`. The migration adds the column without a default value, so it fails visibly at deploy if an environment unexpectedly has existing rows
- Guards in the remove flows: `RemoveClientFromAgent` (renamed from `RemoveAnAgentsClient`) and `RemoveAgent` block non cascading removal while the delegation has delegated resources, and `RemoveAgentDelegation` no longer deletes the delegation when the last package is removed while resources remain
- Removes the dead `AddResourceToDelegation` and the unused resource service dependency in `DelegationService`
- Adds Just recipes for running the AccessManagement EF migrations and a configuration based connection string fallback in the design time factory; pgadmin joins the postgres network in docker-compose

No v1 API changes: responses are unchanged, and the guards only fire on database states that cannot be reached before the write side (#3771) exists. Integration tests cover the guard and cascade behaviour.

First of three PRs under #3638: #3770 versions the client delegation API and adds /v2/ endpoints that return delegated resources beside packages, and #3771 adds delegation of single resources to agents in /v2/. This PR merges and deploys safely on its own: nothing can create `delegationresource` rows before #3771 lands and no API surface changes before #3770, so the FK, cascade and guards stay dormant until then.
