### PR TITLE
chore(#3756): cleanup connectionquery | remove connectionqueryfilter.onlyuniqueresults

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ConnectionService.cs
@@ -88,8 +88,7 @@ public partial class ConnectionService(
                 IncludeInstances = includeInstances,
                 EnrichPackageResources = false,
                 ExcludeDeleted = false,
-                ExcludeRoleIds = includeAgentConnections ? null : [RoleConstants.Agent.Id],
-                OnlyUniqueResults = false
+                ExcludeRoleIds = includeAgentConnections ? null : [RoleConstants.Agent.Id]
             },
             direction,
             cancellationToken
@@ -517,8 +516,7 @@ public partial class ConnectionService(
             IncludePackages = true,
             IncludeResources = false,
             EnrichPackageResources = false,
-            ExcludeDeleted = false,
-            OnlyUniqueResults = false
+            ExcludeDeleted = false
         },
         direction,
         cancellationToken

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -415,13 +415,6 @@ public class ConnectionQuery(AppDbContext db)
                 Reason = ConnectionReason.Hierarchy,
             };
 
-        /*
-        // Gir timeouts i YT        
-        var query = filter.OnlyUniqueResults
-            ? a2.Union(fromChildren).Union(innehaverConnections)
-            : a2.Concat(fromChildren).Concat(innehaverConnections);
-        */
-
         var query = doChildNesting
             ? filter.IncludeSubConnections ? a2.Concat(fromChildren).Concat(innehaverConnections) : a2.Concat(fromChildren)
             : filter.IncludeSubConnections ? a2.Concat(innehaverConnections) : a2;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryFilter.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryFilter.cs
@@ -5,7 +5,7 @@
 /// </summary>
 /// <remarks>This class provides properties to specify different filtering criteria for connection queries, such
 /// as filtering by IDs of entities involved in the connection, roles, packages, and resources. It also includes options
-/// to control the inclusion of additional data and the uniqueness of results.</remarks>
+/// to control the inclusion of additional data.</remarks>
 public sealed class ConnectionQueryFilter
 {
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryFilter.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryFilter.cs
@@ -54,11 +54,6 @@ public sealed class ConnectionQueryFilter
     public IReadOnlyCollection<string> InstanceIds { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether only unique results should be returned.
-    /// </summary>
-    public bool OnlyUniqueResults { get; set; } = false;
-
-    /// <summary>
     /// Gets or sets a value indicating whether to enrich entities with more details.
     /// </summary>
     public bool EnrichEntities { get; init; } = true;

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -57,7 +57,6 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
             IncludeKeyRole = true,
             EnrichEntities = true,
             IncludeDelegation = true,
-            OnlyUniqueResults = false,
             IncludeMainUnitConnections = true,
             IncludeSubConnections = true,
             ExcludeDeleted = false,
@@ -89,7 +88,6 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
             IncludeKeyRole = true,
             EnrichEntities = true,
             IncludeDelegation = true,
-            OnlyUniqueResults = false,
             IncludeMainUnitConnections = true,
             IncludeSubConnections = true,
             ExcludeDeleted = false,
@@ -121,7 +119,6 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
             IncludeKeyRole = true,
             EnrichEntities = true,
             IncludeDelegation = true,
-            OnlyUniqueResults = false,
             IncludeMainUnitConnections = true,
             IncludeSubConnections = true,
             ExcludeDeleted = false,
@@ -146,7 +143,6 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
             IncludeKeyRole = true,
             EnrichEntities = true,
             IncludeDelegation = true,
-            OnlyUniqueResults = false,
             IncludeMainUnitConnections = true,
             IncludeSubConnections = true,
             ExcludeDeleted = false,
@@ -176,7 +172,6 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
             IncludeKeyRole = true,
             EnrichEntities = true,
             IncludeDelegation = true,
-            OnlyUniqueResults = false,
             IncludeMainUnitConnections = true,
             IncludeSubConnections = true,
             ExcludeDeleted = false,
@@ -417,8 +412,7 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
             IncludeResources = flags[3],
             EnrichEntities = flags[4],
             EnrichPackageResources = flags[5],
-            ExcludeDeleted = flags[6],
-            OnlyUniqueResults = flags[7]
+            ExcludeDeleted = flags[6]
         };
 
         // Every flag combination must produce a valid query that runs against the database

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -425,14 +425,14 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
     public static IEnumerable<object[]> GetFilterCombinations()
     {
         var combinations = new List<object[]>();
-        var total = 1 << 8;
+        var total = 1 << 7;
 
         foreach (var useSingle in new[] { true, false })
         {
             for (int i = 0; i < total; i++)
             {
-                var flags = new bool[8];
-                for (int j = 0; j < 8; j++)
+                var flags = new bool[7];
+                for (int j = 0; j < 7; j++)
                 {
                     flags[j] = (i & (1 << j)) != 0;
                 }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Queries/ConnectionQueryFilterTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Queries/ConnectionQueryFilterTest.cs
@@ -1,4 +1,4 @@
-using Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
+﻿using Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
 
 // See: overhaul part-2 step 21
 namespace Altinn.AccessManagement.Tests.Unit.Queries;
@@ -107,7 +107,6 @@ public class ConnectionQueryFilterTest
         // Default flag values are part of the public contract — a regression
         // that flipped any of these would silently change the shape of every
         // unfiltered query.
-        filter.OnlyUniqueResults.Should().BeFalse();
         filter.EnrichEntities.Should().BeTrue();
         filter.IncludePackages.Should().BeFalse();
         filter.IncludeResources.Should().BeFalse();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Queries/ConnectionQueryFilterTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Queries/ConnectionQueryFilterTest.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
+using Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
 
 // See: overhaul part-2 step 21
 namespace Altinn.AccessManagement.Tests.Unit.Queries;

--- a/src/tools/Altinn.AccessMgmt.FFB/src/Altinn.AccessMgmt.FFB/Components/Pages/ConnectionQueryPage.razor
+++ b/src/tools/Altinn.AccessMgmt.FFB/src/Altinn.AccessMgmt.FFB/Components/Pages/ConnectionQueryPage.razor
@@ -1,4 +1,4 @@
-@page "/tools/connection-query"
+﻿@page "/tools/connection-query"
 @using Altinn.AccessMgmt.PersistenceEF.Models
 @using Altinn.AccessMgmt.PersistenceEF.Queries.Connection
 @using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models
@@ -81,7 +81,6 @@
         <MudItem xs="12">
             <MudText Typo="Typo.body2" Class="mb-1 mud-text-secondary">Alternativer</MudText>
             <MudStack Row="true" Wrap="Wrap.Wrap" Spacing="2">
-                <MudCheckBox @bind-Value="_onlyUniqueResults" Label="Bare unike" Color="Color.Default" Dense="true" />
                 <MudCheckBox @bind-Value="_excludeDeleted" Label="Ekskluder slettede" Color="Color.Default" Dense="true" />
                 <MudCheckBox @bind-Value="_enrichPackageResources" Label="Berik pakkeressurser" Color="Color.Default" Dense="true" />
             </MudStack>
@@ -319,7 +318,6 @@
     private bool _includePackages;
     private bool _includeResources;
     private bool _includeInstances;
-    private bool _onlyUniqueResults;
     private bool _excludeDeleted;
     private bool _enrichPackageResources;
 
@@ -411,7 +409,6 @@
                 IncludeKeyRole = _includeKeyRole,
                 IncludeSubConnections = _includeSubConnections,
                 IncludeMainUnitConnections = _includeMainUnitConnections,
-                OnlyUniqueResults = _onlyUniqueResults,
                 ExcludeDeleted = _excludeDeleted,
                 EnrichEntities = true,
                 EnrichPackageResources = _enrichPackageResources,

--- a/src/tools/Altinn.AccessMgmt.FFB/src/Altinn.AccessMgmt.FFB/Components/Pages/ConnectionQueryPage.razor
+++ b/src/tools/Altinn.AccessMgmt.FFB/src/Altinn.AccessMgmt.FFB/Components/Pages/ConnectionQueryPage.razor
@@ -1,4 +1,4 @@
-﻿@page "/tools/connection-query"
+@page "/tools/connection-query"
 @using Altinn.AccessMgmt.PersistenceEF.Models
 @using Altinn.AccessMgmt.PersistenceEF.Queries.Connection
 @using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- connectionqueryfilter.onlyuniqueresults is no longer used and can simply be removed

## Related Issue(s)
- #3756

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
