### PR TITLE
feat: version the client delegation API and read delegated resources in v2

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Altinn.Swashbuckle" Version="2.4.1" />
     <PackageVersion Include="Altinn.Urn.Swashbuckle" Version="2.7.0" />
     <PackageVersion Include="Altinn.Urn" Version="3.0.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageVersion Include="AutoMapper" Version="14.0.0" />

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Altinn.AccessManagement.Api.Enduser.csproj
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Altinn.AccessManagement.Api.Enduser.csproj
@@ -7,6 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="Altinn.Authorization.ProblemDetails" />
 		<PackageReference Include="Altinn.Authorization.ProblemDetails.Abstractions" />
+        <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
         <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" />
         <PackageReference Include="Swashbuckle.AspNetCore" />
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
@@ -1,0 +1,396 @@
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mime;
+using Altinn.AccessManagement.Api.Enduser.Models;
+using Altinn.AccessManagement.Api.Enduser.Validation;
+using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessManagement.Core.Helpers;
+using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessMgmt.Core.Audit;
+using Altinn.AccessMgmt.Core.Services;
+using Altinn.AccessMgmt.PersistenceEF.Constants;
+using Altinn.AccessMgmt.PersistenceEF.Utils;
+using Altinn.Authorization.Api.Contracts.AccessManagement;
+using Altinn.Authorization.ProblemDetails;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using ContractsV2 = Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+namespace Altinn.AccessManagement.Api.Enduser.Controllers.V2;
+
+[ApiController]
+[ApiVersion(2.0)]
+[Route("accessmanagement/api/v{version:apiVersion}/enduser/clientdelegations")]
+[Tags("Client Delegation")]
+public class ClientDelegationController(
+    IHttpContextAccessor httpContextAccessor,
+    IInputValidation inputValidation,
+    IClientDelegationService clientDelegationService) : ControllerBase
+{
+    #region My
+
+    [HttpGet("my/clients")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_READ)]
+    [ProducesResponseType<PaginatedResult<ContractsV2.MyClientDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetMyClients(
+        [FromQuery(Name = "provider")] List<Guid>? provider,
+        [FromQuery, FromHeader] PagingInput paging,
+        CancellationToken cancellationToken = default)
+    {
+        var partyUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (partyUuid == Guid.Empty)
+        {
+            return Unauthorized();
+        }
+
+        var result = await clientDelegationService.GetMyClientsV2(partyUuid, provider, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(PaginatedResult.Create(result.Value, null));
+    }
+
+    [HttpGet("my/clientproviders")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_READ)]
+    [ProducesResponseType<PaginatedResult<ContractsV2.AgentDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetMyClientProviders(CancellationToken cancellationToken = default)
+    {
+        var partyUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (partyUuid == Guid.Empty)
+        {
+            return Unauthorized();
+        }
+
+        var result = await clientDelegationService.GetMyProvidersV2(partyUuid, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(PaginatedResult.Create(result.Value, null));
+    }
+
+    [HttpDelete("my/clientproviders")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DeleteMyAgentViaParty(
+        [FromQuery(Name = "provider")][Required] Guid provider,
+        CancellationToken cancellationToken = default)
+    {
+        var partyUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (partyUuid == Guid.Empty)
+        {
+            return Unauthorized();
+        }
+
+        var result = await clientDelegationService.DeleteMyProvider(partyUuid, provider, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return NoContent();
+    }
+
+    [HttpDelete("my/clients")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType<List<DelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DeleteMyClientViaProvider(
+        [FromQuery(Name = "provider")][Required] Guid provider,
+        [FromQuery(Name = "from")][Required] Guid from,
+        [FromBody] DelegationBatchInputDto payload,
+        [FromQuery(Name = "cascade")] bool cascade = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (!cascade && payload is { })
+        {
+            return await DeleteMyPackagesToClientViaProvider(provider, from, payload, cancellationToken);
+        }
+
+        var partyUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (partyUuid == Guid.Empty)
+        {
+            return Unauthorized();
+        }
+
+        var problem = await clientDelegationService.RemoveClientFromAgent(provider, from, partyUuid, cascade, cancellationToken);
+        if (problem is { })
+        {
+            return problem.ToActionResult();
+        }
+
+        return NoContent();
+    }
+
+    [HttpDelete("my/clients/accesspackages")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType<List<DelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DeleteMyPackagesToClientViaProvider(
+        [FromQuery(Name = "provider")][Required] Guid provider,
+        [FromQuery(Name = "from")][Required] Guid from,
+        [FromBody][Required] DelegationBatchInputDto payload,
+        CancellationToken cancellationToken = default)
+    {
+        var partyUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (partyUuid == Guid.Empty)
+        {
+            return Unauthorized();
+        }
+
+        var result = await clientDelegationService.DeleteMyClient(partyUuid, provider, from, payload, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    #endregion
+
+    #region Provider
+
+    [HttpGet("clients")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_READ)]
+    [ProducesResponseType<PaginatedResult<ContractsV2.ClientDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetClients(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "roles")] List<string>? roles,
+        [FromQuery(Name = "packages")] List<string>? packages,
+        [FromQuery, FromHeader] PagingInput paging,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await clientDelegationService.GetClientsV2(party, roles, packages, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(PaginatedResult.Create(result.Value, null));
+    }
+
+    [HttpGet("agents")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_READ)]
+    [ProducesResponseType<PaginatedResult<ContractsV2.AgentDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetAgents(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery, FromHeader] PagingInput paging,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await clientDelegationService.GetAgentsV2(party, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(PaginatedResult.Create(result.Value, null));
+    }
+
+    [HttpPost("agents")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType<AssignmentDto>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> AddAgent(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "to")] Guid? to,
+        [FromBody] PersonInput? person,
+        CancellationToken cancellationToken = default)
+    {
+        var entity = await inputValidation.SanitizeToInput(
+            party,
+            to,
+            person,
+            options =>
+            {
+                options.AllowedToEntityTypes = [EntityTypeConstants.Person, EntityTypeConstants.SystemUser];
+                options.EntitiesToValidateForAnyConnections = [EntityTypeConstants.Person];
+            },
+            cancellationToken);
+
+        if (entity.IsProblem)
+        {
+            return entity.Problem.ToActionResult();
+        }
+
+        var result = await clientDelegationService.AddAgent(party, entity.Value.Id, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpDelete("agents")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> RemoveAgent(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "to")][Required] Guid to,
+        [FromQuery(Name = "cascade")] bool cascade = false,
+        CancellationToken cancellationToken = default)
+    {
+        var problem = await clientDelegationService.RemoveAgent(party, to, cascade, cancellationToken);
+        if (problem is { })
+        {
+            return problem.ToActionResult();
+        }
+
+        return NoContent();
+    }
+
+    [HttpDelete("agents/clients")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> RemoveAgentsClient(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "from")][Required] Guid from,
+        [FromQuery(Name = "to")][Required] Guid to,
+        [FromQuery(Name = "cascade")] bool cascade = false,
+        CancellationToken cancellationToken = default)
+    {
+        var problem = await clientDelegationService.RemoveClientFromAgent(party, from, to, cascade, cancellationToken);
+        if (problem is { })
+        {
+            return problem.ToActionResult();
+        }
+
+        return NoContent();
+    }
+
+    [HttpGet("agents/accesspackages")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_READ)]
+    [ProducesResponseType<PaginatedResult<ContractsV2.ClientPackagesDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetDelegatedAccessPackagesToAgentsViaPartyAsync(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "to")][Required] Guid to,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await clientDelegationService.GetDelegatedAccessPackagesToAgentsViaPartyV2(party, to, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(PaginatedResult.Create(result.Value, null));
+    }
+
+    [HttpGet("clients/accesspackages")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_READ)]
+    [ProducesResponseType<PaginatedResult<ContractsV2.AgentPackagesDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetDelegatedAccessPackagesFromClientsViaParty(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "from")][Required] Guid from,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = await clientDelegationService.GetDelegatedAccessPackagesFromClientsViaPartyV2(party, from, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(PaginatedResult.Create(result.Value, null));
+    }
+
+    [HttpPost("agents/accesspackages")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType<List<DelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DelegateAccessPackageToAgent(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "from")][Required] Guid from,
+        [FromQuery(Name = "to")][Required] Guid to,
+        [FromBody][Required] DelegationBatchInputDto payload,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await clientDelegationService.DelegateAccessPackageToAgent(party, from, to, payload, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpDelete("agents/accesspackages")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType<List<DelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DeleteAgentAccessPackage(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "from")][Required] Guid from,
+        [FromQuery(Name = "to")][Required] Guid to,
+        [FromBody][Required] DelegationBatchInputDto payload,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = await clientDelegationService.RemoveAgentDelegation(party, from, to, payload, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    #endregion
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
@@ -40,13 +40,13 @@ public class ClientDelegationController(
         [FromQuery, FromHeader] PagingInput paging,
         CancellationToken cancellationToken = default)
     {
-        var partyUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
-        if (partyUuid == Guid.Empty)
+        var authenticatedUser = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (authenticatedUser == Guid.Empty)
         {
             return Unauthorized();
         }
 
-        var result = await clientDelegationService.GetMyClientsV2(partyUuid, provider, cancellationToken);
+        var result = await clientDelegationService.GetMyClientsV2(authenticatedUser, provider, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -57,19 +57,19 @@ public class ClientDelegationController(
 
     [HttpGet("my/clientproviders")]
     [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_READ)]
-    [ProducesResponseType<PaginatedResult<ContractsV2.AgentDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<PaginatedResult<ContractsV2.MyClientProviderDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetMyClientProviders(CancellationToken cancellationToken = default)
     {
-        var partyUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
-        if (partyUuid == Guid.Empty)
+        var authenticatedUser = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (authenticatedUser == Guid.Empty)
         {
             return Unauthorized();
         }
 
-        var result = await clientDelegationService.GetMyProvidersV2(partyUuid, cancellationToken);
+        var result = await clientDelegationService.GetMyProvidersV2(authenticatedUser, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -89,13 +89,13 @@ public class ClientDelegationController(
         [FromQuery(Name = "provider")][Required] Guid provider,
         CancellationToken cancellationToken = default)
     {
-        var partyUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
-        if (partyUuid == Guid.Empty)
+        var authenticatedUser = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (authenticatedUser == Guid.Empty)
         {
             return Unauthorized();
         }
 
-        var result = await clientDelegationService.DeleteMyProvider(partyUuid, provider, cancellationToken);
+        var result = await clientDelegationService.DeleteMyProvider(authenticatedUser, provider, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -107,30 +107,23 @@ public class ClientDelegationController(
     [HttpDelete("my/clients")]
     [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
-    [ProducesResponseType<List<DelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> DeleteMyClientViaProvider(
         [FromQuery(Name = "provider")][Required] Guid provider,
-        [FromQuery(Name = "from")][Required] Guid from,
-        [FromBody] DelegationBatchInputDto payload,
+        [FromQuery(Name = "client")][Required] Guid client,
         [FromQuery(Name = "cascade")] bool cascade = false,
         CancellationToken cancellationToken = default)
     {
-        if (!cascade && payload is { })
-        {
-            return await DeleteMyPackagesToClientViaProvider(provider, from, payload, cancellationToken);
-        }
-
-        var partyUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
-        if (partyUuid == Guid.Empty)
+        var authenticatedUser = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (authenticatedUser == Guid.Empty)
         {
             return Unauthorized();
         }
 
-        var problem = await clientDelegationService.RemoveClientFromAgent(provider, from, partyUuid, cascade, cancellationToken);
+        var problem = await clientDelegationService.RemoveClientFromAgent(provider, client, authenticatedUser, cascade, cancellationToken);
         if (problem is { })
         {
             return problem.ToActionResult();
@@ -148,17 +141,17 @@ public class ClientDelegationController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> DeleteMyPackagesToClientViaProvider(
         [FromQuery(Name = "provider")][Required] Guid provider,
-        [FromQuery(Name = "from")][Required] Guid from,
+        [FromQuery(Name = "client")][Required] Guid client,
         [FromBody][Required] DelegationBatchInputDto payload,
         CancellationToken cancellationToken = default)
     {
-        var partyUuid = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
-        if (partyUuid == Guid.Empty)
+        var authenticatedUser = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (authenticatedUser == Guid.Empty)
         {
             return Unauthorized();
         }
 
-        var result = await clientDelegationService.DeleteMyClient(partyUuid, provider, from, payload, cancellationToken);
+        var result = await clientDelegationService.DeleteMyClient(authenticatedUser, provider, client, payload, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -225,13 +218,13 @@ public class ClientDelegationController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> AddAgent(
         [FromQuery(Name = "party")][Required] Guid party,
-        [FromQuery(Name = "to")] Guid? to,
+        [FromQuery(Name = "agent")] Guid? agent,
         [FromBody] PersonInput? person,
         CancellationToken cancellationToken = default)
     {
         var entity = await inputValidation.SanitizeToInput(
             party,
-            to,
+            agent,
             person,
             options =>
             {
@@ -264,11 +257,11 @@ public class ClientDelegationController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> RemoveAgent(
         [FromQuery(Name = "party")][Required] Guid party,
-        [FromQuery(Name = "to")][Required] Guid to,
+        [FromQuery(Name = "agent")][Required] Guid agent,
         [FromQuery(Name = "cascade")] bool cascade = false,
         CancellationToken cancellationToken = default)
     {
-        var problem = await clientDelegationService.RemoveAgent(party, to, cascade, cancellationToken);
+        var problem = await clientDelegationService.RemoveAgent(party, agent, cascade, cancellationToken);
         if (problem is { })
         {
             return problem.ToActionResult();
@@ -287,12 +280,12 @@ public class ClientDelegationController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> RemoveAgentsClient(
         [FromQuery(Name = "party")][Required] Guid party,
-        [FromQuery(Name = "from")][Required] Guid from,
-        [FromQuery(Name = "to")][Required] Guid to,
+        [FromQuery(Name = "client")][Required] Guid client,
+        [FromQuery(Name = "agent")][Required] Guid agent,
         [FromQuery(Name = "cascade")] bool cascade = false,
         CancellationToken cancellationToken = default)
     {
-        var problem = await clientDelegationService.RemoveClientFromAgent(party, from, to, cascade, cancellationToken);
+        var problem = await clientDelegationService.RemoveClientFromAgent(party, client, agent, cascade, cancellationToken);
         if (problem is { })
         {
             return problem.ToActionResult();
@@ -310,10 +303,10 @@ public class ClientDelegationController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetDelegatedAccessPackagesToAgentsViaPartyAsync(
         [FromQuery(Name = "party")][Required] Guid party,
-        [FromQuery(Name = "to")][Required] Guid to,
+        [FromQuery(Name = "agent")][Required] Guid agent,
         CancellationToken cancellationToken = default)
     {
-        var result = await clientDelegationService.GetDelegatedAccessPackagesToAgentsViaPartyV2(party, to, cancellationToken);
+        var result = await clientDelegationService.GetDelegatedAccessPackagesToAgentsViaPartyV2(party, agent, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -331,11 +324,11 @@ public class ClientDelegationController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetDelegatedAccessPackagesFromClientsViaParty(
         [FromQuery(Name = "party")][Required] Guid party,
-        [FromQuery(Name = "from")][Required] Guid from,
+        [FromQuery(Name = "client")][Required] Guid client,
         CancellationToken cancellationToken = default
     )
     {
-        var result = await clientDelegationService.GetDelegatedAccessPackagesFromClientsViaPartyV2(party, from, cancellationToken);
+        var result = await clientDelegationService.GetDelegatedAccessPackagesFromClientsViaPartyV2(party, client, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -354,12 +347,12 @@ public class ClientDelegationController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> DelegateAccessPackageToAgent(
         [FromQuery(Name = "party")][Required] Guid party,
-        [FromQuery(Name = "from")][Required] Guid from,
-        [FromQuery(Name = "to")][Required] Guid to,
+        [FromQuery(Name = "client")][Required] Guid client,
+        [FromQuery(Name = "agent")][Required] Guid agent,
         [FromBody][Required] DelegationBatchInputDto payload,
         CancellationToken cancellationToken = default)
     {
-        var result = await clientDelegationService.DelegateAccessPackageToAgent(party, from, to, payload, cancellationToken);
+        var result = await clientDelegationService.DelegateAccessPackageToAgent(party, client, agent, payload, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -378,13 +371,13 @@ public class ClientDelegationController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> DeleteAgentAccessPackage(
         [FromQuery(Name = "party")][Required] Guid party,
-        [FromQuery(Name = "from")][Required] Guid from,
-        [FromQuery(Name = "to")][Required] Guid to,
+        [FromQuery(Name = "client")][Required] Guid client,
+        [FromQuery(Name = "agent")][Required] Guid agent,
         [FromBody][Required] DelegationBatchInputDto payload,
         CancellationToken cancellationToken = default
     )
     {
-        var result = await clientDelegationService.RemoveAgentDelegation(party, from, to, payload, cancellationToken);
+        var result = await clientDelegationService.RemoveAgentDelegation(party, client, agent, payload, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
@@ -108,6 +108,7 @@ public class ClientDelegationController(
     [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
     [ProducesResponseType<List<DelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
@@ -36,6 +36,8 @@ using Altinn.Common.PEP.Clients;
 using Altinn.Common.PEP.Implementation;
 using Altinn.Common.PEP.Interfaces;
 using AltinnCore.Authentication.JwtCookie;
+using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.FeatureManagement;
@@ -46,6 +48,7 @@ using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Swashbuckle.AspNetCore.Filters;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Altinn.AccessManagement;
 
@@ -233,9 +236,44 @@ internal static partial class AccessManagementHost
 
     private static void ConfigureOpenAPI(this WebApplicationBuilder builder)
     {
+        builder.Services.AddApiVersioning(options =>
+        {
+            // Existing routes carry a literal "v1" segment and no api version attribute,
+            // so unspecified requests must keep resolving to 1.0. The url segment reader
+            // keeps ?api-version=... query parameters inert on those routes.
+            options.DefaultApiVersion = new ApiVersion(1.0);
+            options.AssumeDefaultVersionWhenUnspecified = true;
+            options.ApiVersionReader = new UrlSegmentApiVersionReader();
+        })
+        .AddMvc()
+        .AddApiExplorer(options =>
+        {
+            // Formats the version as "'v'major[.minor][-status]" so group names
+            // line up with the swagger document names ("v1", "v2", ...).
+            options.GroupNameFormat = "'v'VVV";
+            options.SubstituteApiVersionInUrl = true;
+        });
+
         builder.Services.AddEndpointsApiExplorer();
+
+        var applicationName = builder.Environment.ApplicationName;
+        builder.Services.AddOptions<SwaggerGenOptions>()
+            .Configure((SwaggerGenOptions options, IApiVersionDescriptionProvider provider) =>
+            {
+                // One swagger document per discovered api version. The v1 document keeps
+                // the name and URL of the previous single document, which external APIM
+                // extraction depends on.
+                foreach (var description in provider.ApiVersionDescriptions)
+                {
+                    options.SwaggerDoc(description.GroupName, new OpenApiInfo { Title = applicationName, Version = description.ApiVersion.ToString() });
+                }
+            });
+
         builder.Services.AddSwaggerGen(options =>
         {
+            // Endpoints without a version group (minimal endpoints) belong to the v1 document.
+            options.DocInclusionPredicate((documentName, apiDescription) => (apiDescription.GroupName ?? "v1") == documentName);
+
             options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
             {
                 Description = "Standard Authorization header using the Bearer scheme. Example: \"bearer {token}\"",

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Altinn.AccessManagement.csproj
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Altinn.AccessManagement.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="Altinn.Authorization.ServiceDefaults" />
         <PackageReference Include="Altinn.Common.AccessToken" />
         <PackageReference Include="Altinn.Urn.Swashbuckle" />
+        <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
         <PackageReference Include="AutoMapper" />
         <PackageReference Include="Azure.Identity" />
         <PackageReference Include="JWTCookieAuthentication" />

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Program.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Program.cs
@@ -32,9 +32,15 @@ if (app.Environment.IsDevelopment())
     // Enable higher level of detail in exceptions related to JWT validation
     IdentityModelEventSource.ShowPII = true;
 
-    // Enable Swagger
+    // Enable Swagger with an endpoint per discovered API version
     app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseSwaggerUI(options =>
+    {
+        foreach (var description in app.DescribeApiVersions())
+        {
+            options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json", description.GroupName.ToUpperInvariant());
+        }
+    });
 }
 
 app.UseAuthentication();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -847,6 +847,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 x.Delegation.To.To,
                 x.Delegation.From.Role,
                 x.DelegationPackage.Package,
+                AgentAddedAt = x.Delegation.To.Audit_ValidFrom,
             })
             .GroupBy(x => x.To.Id)
             .ToListAsync(cancellationToken);
@@ -856,7 +857,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             new ContractsV2.AgentPackagesDto()
             {
                 Agent = DtoMapper.Convert(e.First().To),
-                AgentAddedAt = e.First().To.Audit_ValidFrom,
+                AgentAddedAt = e.First().AgentAddedAt,
                 Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.AgentPackagesDto.RoleAccess
                 {
                     Role = DtoMapper.ConvertCompactRole(r.First().Role),

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -460,11 +460,12 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             return new List<ContractsV2.ClientDto>();
         }
 
-        var query = await db.Assignments
+        var clientAssignments = db.Assignments
             .AsNoTracking()
             .Where(a => a.ToId == partyUuid && !ExcludeClientRoles.Contains(a.RoleId))
-            .WhereIf(roleFilter.Count > 0, r => roleFilter.Contains(r.RoleId))
-            .Include(a => a.From)
+            .WhereIf(roleFilter.Count > 0, r => roleFilter.Contains(r.RoleId));
+
+        var packageRows = await clientAssignments
             .GroupJoin(
                 db.AssignmentPackages,
                 a => a.Id,
@@ -476,40 +477,46 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 (x, ap) => new { x.Assignment, AssignmentPackage = ap }
             )
             .GroupJoin(
-                db.AssignmentResources,
-                x => x.Assignment.Id,
-                ar => ar.AssignmentId,
-                (x, ar) => new { x.Assignment, x.AssignmentPackage, AssignmentResources = ar }
-            )
-            .SelectMany(
-                x => x.AssignmentResources.DefaultIfEmpty(),
-                (x, ar) => new { x.Assignment, x.AssignmentPackage, AssignmentResource = ar }
-            )
-            .GroupJoin(
                 db.RolePackages,
                 x => x.Assignment.RoleId,
                 rp => rp.RoleId,
-                (x, rps) => new { x.Assignment, x.AssignmentPackage, x.AssignmentResource, RolePackages = rps }
+                (x, rps) => new { x.Assignment, x.AssignmentPackage, RolePackages = rps }
             )
             .SelectMany(
                 x => x.RolePackages.DefaultIfEmpty(),
                 (x, rp) => new
                 {
-                    x.Assignment.To,
                     x.Assignment.From,
                     x.Assignment.Role,
-                    x.AssignmentResource,
-                    x.AssignmentResource.Resource,
                     AssignmentPackage = x.AssignmentPackage.Package,
                     RolePackage = rp.Package,
                     RolePackageEntityVariantId = rp.EntityVariantId
                 }
             )
-            .Where(x => x.RolePackage != null || x.AssignmentPackage != null || x.AssignmentResource != null)
-            .WhereIf(roleFilter.Count > 0, x => roleFilter.Contains(x.Role.Id))
+            .Where(x => x.RolePackage != null || x.AssignmentPackage != null)
             .WhereIf(packageFilter.Count > 0, x => (x.RolePackage != null && packageFilter.Contains(x.RolePackage.Id)) || (x.AssignmentPackage != null && packageFilter.Contains(x.AssignmentPackage.Id)))
-            .GroupBy(x => x.From.Id)
             .ToListAsync(cancellationToken);
+
+        // Resources are fetched as their own row set to avoid a packages x resources product per
+        // assignment. Under a package filter an assignment's resources are only included when the
+        // assignment also has a matching package, which mirrors the row survival in the package set.
+        var resourceRows = await clientAssignments
+            .WhereIf(packageFilter.Count > 0, a =>
+                db.AssignmentPackages.Any(ap => ap.AssignmentId == a.Id && packageFilter.Contains(ap.PackageId)) ||
+                db.RolePackages.Any(rp => rp.RoleId == a.RoleId && packageFilter.Contains(rp.PackageId)))
+            .Join(
+                db.AssignmentResources,
+                a => a.Id,
+                ar => ar.AssignmentId,
+                (a, ar) => new { a.From, a.Role, ar.Resource }
+            )
+            .ToListAsync(cancellationToken);
+
+        var query = packageRows
+            .Select(x => new { x.From, x.Role, x.AssignmentPackage, x.RolePackage, x.RolePackageEntityVariantId, Resource = (Resource)null })
+            .Concat(resourceRows.Select(x => new { x.From, x.Role, AssignmentPackage = (Package)null, RolePackage = (Package)null, RolePackageEntityVariantId = (Guid?)null, x.Resource }))
+            .GroupBy(x => x.From.Id)
+            .ToList();
 
         return query
             .Select(access =>
@@ -529,7 +536,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                             .DistinctBy(p => p.Id),
                     ],
                     Resources = [
-                        .. r.Where(p => p.AssignmentResource is { }).Select(p => DtoMapper.ConvertCompactResource(p.Resource)).DistinctBy(x => x.Id)
+                        .. r.Where(p => p.Resource is { }).Select(p => DtoMapper.ConvertCompactResource(p.Resource)).DistinctBy(x => x.Id)
                     ]
                 }).ToList(),
             }).ToList();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -201,20 +201,24 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             .GroupBy(x => x.Provider.Id)
             .ToList();
 
-        var packageIds = executedQuery.SelectMany(q => q).Select(q => q.PackageId).Distinct().ToList();
-        var packagesRaw = await db.Packages.AsNoTracking()
-            .Where(p => packageIds.Contains(p.Id))
-            .ToListAsync(cancellationToken);
+        var packageIds = executedQuery.SelectMany(q => q).Select(q => q.PackageId).Where(id => id != Guid.Empty).Distinct().ToList();
+        List<Package> packagesRaw = packageIds.Count > 0
+            ? await db.Packages.AsNoTracking()
+                .Where(p => packageIds.Contains(p.Id))
+                .ToListAsync(cancellationToken)
+            : [];
         SortedList<Guid, CompactPackageDto> packages = new SortedList<Guid, CompactPackageDto>(packagesRaw.Count);
         foreach (var package in packagesRaw)
         {
             packages.Add(package.Id, DtoMapper.ConvertCompactPackage(package));
         }
 
-        var resourceIds = executedQuery.SelectMany(q => q).Select(q => q.ResourceId).Distinct().ToList();
-        var resourcesRaw = await db.Resources.AsNoTracking()
-            .Where(r => resourceIds.Contains(r.Id))
-            .ToListAsync(cancellationToken);
+        var resourceIds = executedQuery.SelectMany(q => q).Select(q => q.ResourceId).Where(id => id != Guid.Empty).Distinct().ToList();
+        List<Resource> resourcesRaw = resourceIds.Count > 0
+            ? await db.Resources.AsNoTracking()
+                .Where(r => resourceIds.Contains(r.Id))
+                .ToListAsync(cancellationToken)
+            : [];
         SortedList<Guid, CompactResourceDto> resourcesMap = new(resourcesRaw.Count);
         foreach (var resource in resourcesRaw)
         {
@@ -557,6 +561,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     public async Task<Result<List<ContractsV2.AgentDto>>> GetAgentsV2(Guid partyUuid, CancellationToken cancellationToken = default)
     {
         var query = await db.Assignments
+            .AsNoTracking()
             .Where(a => a.FromId == partyUuid && a.RoleId == RoleConstants.Agent)
             .Include(a => a.To)
             .ToListAsync(cancellationToken);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -138,12 +138,12 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
-    public async Task<Result<List<ContractsV2.MyClientDto>>> GetMyClientsV2(Guid partyUuid, List<Guid> providerUuids, CancellationToken cancellationToken = default)
+    public async Task<Result<List<ContractsV2.MyClientDto>>> GetMyClientsV2(Guid agentUuid, List<Guid> providerUuids, CancellationToken cancellationToken = default)
     {
         providerUuids ??= [];
         var connectionsQuery = db.Assignments
             .AsNoTracking()
-            .Where(a => a.ToId == partyUuid && a.RoleId == RoleConstants.Agent)
+            .Where(a => a.ToId == agentUuid && a.RoleId == RoleConstants.Agent)
             .WhereIf(providerUuids.Count > 0, a => providerUuids.Contains(a.FromId))
             .Join(
                 db.Entities,
@@ -296,19 +296,19 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
-    public async Task<Result<List<ContractsV2.AgentDto>>> GetMyProvidersV2(Guid partyUuid, CancellationToken cancellationToken = default)
+    public async Task<Result<List<ContractsV2.MyClientProviderDto>>> GetMyProvidersV2(Guid agentUuid, CancellationToken cancellationToken = default)
     {
         var query = await db.Assignments
             .AsNoTracking()
             .Include(a => a.From)
-            .Where(a => a.ToId == partyUuid && a.RoleId == RoleConstants.Agent)
+            .Where(a => a.ToId == agentUuid && a.RoleId == RoleConstants.Agent)
             .ToListAsync(cancellationToken);
 
         return query
-            .Select(a => new ContractsV2.AgentDto
+            .Select(a => new ContractsV2.MyClientProviderDto
             {
-                Agent = DtoMapper.Convert(a.From),
-                AgentAddedAt = a.Audit_ValidFrom,
+                Provider = DtoMapper.Convert(a.From),
+                ProviderAddedAt = a.Audit_ValidFrom,
                 Access = [
                     new()
                     {
@@ -498,12 +498,9 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             .ToListAsync(cancellationToken);
 
         // Resources are fetched as their own row set to avoid a packages x resources product per
-        // assignment. Under a package filter an assignment's resources are only included when the
-        // assignment also has a matching package, which mirrors the row survival in the package set.
+        // assignment. The packages filter does not apply to resources: delegated single resources
+        // are tied to rightholder assignments and follow the role filter.
         var resourceRows = await clientAssignments
-            .WhereIf(packageFilter.Count > 0, a =>
-                db.AssignmentPackages.Any(ap => ap.AssignmentId == a.Id && packageFilter.Contains(ap.PackageId)) ||
-                db.RolePackages.Any(rp => rp.RoleId == a.RoleId && packageFilter.Contains(rp.PackageId)))
             .Join(
                 db.AssignmentResources,
                 a => a.Id,
@@ -1459,11 +1456,11 @@ public interface IClientDelegationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets clients available to the party, grouped by provider,
+    /// Gets clients available to the authenticated agent, grouped by provider,
     /// including delegated roles, packages and resources.
     /// </summary>
     Task<Result<List<ContractsV2.MyClientDto>>> GetMyClientsV2(
-        Guid partyUuid,
+        Guid agentUuid,
         List<Guid> providerUuids,
         CancellationToken cancellationToken = default);
 
@@ -1475,10 +1472,11 @@ public interface IClientDelegationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets providers that have assigned the Agent role to the given user/party.
+    /// Gets providers that have assigned the Agent role to the authenticated agent,
+    /// seen from the agent's perspective.
     /// </summary>
-    Task<Result<List<ContractsV2.AgentDto>>> GetMyProvidersV2(
-        Guid partyUuid,
+    Task<Result<List<ContractsV2.MyClientProviderDto>>> GetMyProvidersV2(
+        Guid agentUuid,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -525,7 +525,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                             .DistinctBy(p => p.Id),
                     ],
                     Resources = [
-                        .. r.Where(p => p.AssignmentResource is { }).DistinctBy(r => r.AssignmentResource.Id).Select(p => DtoMapper.ConvertCompactResource(p.Resource))
+                        .. r.Where(p => p.AssignmentResource is { }).Select(p => DtoMapper.ConvertCompactResource(p.Resource)).DistinctBy(x => x.Id)
                     ]
                 }).ToList(),
             }).ToList();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -12,6 +12,7 @@ using Altinn.Authorization.Api.Contracts.AccessManagement;
 using Altinn.Authorization.ProblemDetails;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using ContractsV2 = Altinn.Authorization.Api.Contracts.AccessManagement.V2;
 
 namespace Altinn.AccessMgmt.Core.Services;
 
@@ -136,6 +137,137 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             .ToList();
     }
 
+    /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.MyClientDto>>> GetMyClientsV2(Guid partyUuid, List<Guid> providerUuids, CancellationToken cancellationToken = default)
+    {
+        providerUuids ??= [];
+        var connectionsQuery = db.Assignments
+            .AsNoTracking()
+            .Where(a => a.ToId == partyUuid && a.RoleId == RoleConstants.Agent)
+            .WhereIf(providerUuids.Count > 0, a => providerUuids.Contains(a.FromId))
+            .Join(
+                db.Entities,
+                a => a.FromId,
+                e => e.Id,
+                (a, e) => new { Assignment = a, ProviderEntity = e }
+            )
+            .GroupJoin(
+                db.Delegations,
+                a => a.Assignment.Id,
+                d => d.ToId,
+                (a, d) => new { Provider = a.ProviderEntity, Delegations = d }
+            )
+            .SelectMany(d => d.Delegations.DefaultIfEmpty(), (a, d) => new { a.Provider, Delegation = d, })
+            .GroupJoin(
+                db.Assignments,
+                x => x.Delegation.FromId,
+                a => a.Id,
+                (x, a) => new { x.Provider, x.Delegation, FromAssignments = a, }
+            )
+            .SelectMany(x => x.FromAssignments.DefaultIfEmpty(), (x, a) => new { x.Provider, x.Delegation, a.Role, Client = a.From });
+
+        // Packages and resources are fetched as separate row sets to avoid a
+        // packages x resources product per delegation.
+        var packageRows = connectionsQuery
+            .GroupJoin(
+                db.DelegationPackages,
+                x => x.Delegation.Id,
+                dp => dp.DelegationId,
+                (x, dp) => new
+                {
+                    x.Provider,
+                    x.Client,
+                    x.Role,
+                    Packages = dp,
+                }
+            )
+            .SelectMany(x => x.Packages.DefaultIfEmpty(), (x, dp) => new { x.Client, x.Provider, x.Role, PackageId = dp != null ? dp.PackageId : Guid.Empty });
+
+        var resourceRows = connectionsQuery
+            .Join(
+                db.DelegationResources,
+                x => x.Delegation.Id,
+                dr => dr.DelegationId,
+                (x, dr) => new { x.Client, x.Provider, x.Role, dr.ResourceId }
+            );
+
+        // Group by provider in memory to avoid the very expensive SQL "order by" clause EF
+        // generates for grouped queries. Assume partyid is always set on provider entities.
+        var packageRowsList = await packageRows.ToListAsync(cancellationToken);
+        var resourceRowsList = await resourceRows.ToListAsync(cancellationToken);
+        var executedQuery = packageRowsList
+            .Select(x => new { x.Client, x.Provider, x.Role, x.PackageId, ResourceId = Guid.Empty })
+            .Concat(resourceRowsList.Select(x => new { x.Client, x.Provider, x.Role, PackageId = Guid.Empty, x.ResourceId }))
+            .GroupBy(x => x.Provider.PartyId ?? 0)
+            .ToList();
+
+        var packageIds = executedQuery.SelectMany(q => q).Select(q => q.PackageId).Distinct().ToList();
+        var packagesRaw = await db.Packages.AsNoTracking()
+            .Where(p => packageIds.Contains(p.Id))
+            .ToListAsync(cancellationToken);
+        SortedList<Guid, CompactPackageDto> packages = new SortedList<Guid, CompactPackageDto>(packagesRaw.Count);
+        foreach (var package in packagesRaw)
+        {
+            packages.Add(package.Id, DtoMapper.ConvertCompactPackage(package));
+        }
+
+        var resourceIds = executedQuery.SelectMany(q => q).Select(q => q.ResourceId).Distinct().ToList();
+        var resourcesRaw = await db.Resources.AsNoTracking()
+            .Where(r => resourceIds.Contains(r.Id))
+            .ToListAsync(cancellationToken);
+        SortedList<Guid, CompactResourceDto> resourcesMap = new(resourcesRaw.Count);
+        foreach (var resource in resourcesRaw)
+        {
+            resourcesMap.Add(resource.Id, DtoMapper.ConvertCompactResource(resource));
+        }
+
+        return executedQuery
+            .Select(providerGroup =>
+            {
+                var provider = providerGroup.First().Provider;
+
+                var clients = providerGroup
+                    .Where(x => x.Client is not null)
+                    .GroupBy(x => x.Client.Id)
+                    .Select(clientGroup =>
+                    {
+                        var client = clientGroup.First().Client;
+
+                        var access = clientGroup
+                            .Where(x => x.Role is not null)
+                            .GroupBy(x => x.Role.Id)
+                            .Select(roleGroup => new ContractsV2.ClientDto.RoleAccess
+                            {
+                                Role = DtoMapper.ConvertCompactRole(roleGroup.First().Role),
+                                Packages = roleGroup
+                                    .Where(p => p.PackageId != Guid.Empty)
+                                    .Select(x => packages[x.PackageId])
+                                    .DistinctBy(p => p.Id)
+                                    .ToList(),
+                                Resources = roleGroup
+                                    .Where(r => r.ResourceId != Guid.Empty)
+                                    .Select(x => resourcesMap[x.ResourceId])
+                                    .DistinctBy(r => r.Id)
+                                    .ToList(),
+                            })
+                            .ToList();
+
+                        return new ContractsV2.ClientDto
+                        {
+                            Client = DtoMapper.Convert(client),
+                            Access = access
+                        };
+                    });
+
+                return new ContractsV2.MyClientDto
+                {
+                    Provider = DtoMapper.Convert(provider),
+                    Clients = clients
+                };
+            })
+            .ToList();
+    }
+
     public async Task<Result<List<AgentDto>>> GetMyProviders(Guid partyUuid, CancellationToken cancellationToken = default)
     {
         var query = await db.Assignments
@@ -154,6 +286,31 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                     {
                         Role = DtoMapper.ConvertCompactRole(a.Role),
                         Packages = [],
+                    }
+                ]
+            }).ToList();
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.AgentDto>>> GetMyProvidersV2(Guid partyUuid, CancellationToken cancellationToken = default)
+    {
+        var query = await db.Assignments
+            .AsNoTracking()
+            .Include(a => a.From)
+            .Where(a => a.ToId == partyUuid && a.RoleId == RoleConstants.Agent)
+            .ToListAsync(cancellationToken);
+
+        return query
+            .Select(a => new ContractsV2.AgentDto
+            {
+                Agent = DtoMapper.Convert(a.From),
+                AgentAddedAt = a.Audit_ValidFrom,
+                Access = [
+                    new()
+                    {
+                        Role = DtoMapper.ConvertCompactRole(a.Role),
+                        Packages = [],
+                        Resources = [],
                     }
                 ]
             }).ToList();
@@ -266,6 +423,115 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.ClientDto>>> GetClientsV2(Guid partyUuid, List<string>? roles, List<string>? packages, CancellationToken cancellationToken = default)
+    {
+        roles ??= [];
+        packages ??= [];
+        var roleFilter = new List<Guid>();
+        var packageFilter = new List<Guid>();
+
+        foreach (var r in roles)
+        {
+            if (RoleConstants.TryGetByAll(r, out var role))
+            {
+                roleFilter.Add(role.Id);
+            }
+        }
+
+        foreach (var p in packages)
+        {
+            if (PackageConstants.TryGetByUrn(p, out var package))
+            {
+                packageFilter.Add(package.Id);
+            }
+        }
+
+        if (roleFilter.Count == 0 && roles.Count > 0)
+        {
+            return new List<ContractsV2.ClientDto>();
+        }
+
+        if (packageFilter.Count == 0 && packages.Count > 0)
+        {
+            return new List<ContractsV2.ClientDto>();
+        }
+
+        var query = await db.Assignments
+            .AsNoTracking()
+            .Where(a => a.ToId == partyUuid && !ExcludeClientRoles.Contains(a.RoleId))
+            .WhereIf(roleFilter.Count > 0, r => roleFilter.Contains(r.RoleId))
+            .Include(a => a.From)
+            .GroupJoin(
+                db.AssignmentPackages,
+                a => a.Id,
+                ap => ap.AssignmentId,
+                (a, aps) => new { Assignment = a, AssignmentPackages = aps }
+            )
+            .SelectMany(
+                x => x.AssignmentPackages.DefaultIfEmpty(),
+                (x, ap) => new { x.Assignment, AssignmentPackage = ap }
+            )
+            .GroupJoin(
+                db.AssignmentResources,
+                x => x.Assignment.Id,
+                ar => ar.AssignmentId,
+                (x, ar) => new { x.Assignment, x.AssignmentPackage, AssignmentResources = ar }
+            )
+            .SelectMany(
+                x => x.AssignmentResources.DefaultIfEmpty(),
+                (x, ar) => new { x.Assignment, x.AssignmentPackage, AssignmentResource = ar }
+            )
+            .GroupJoin(
+                db.RolePackages,
+                x => x.Assignment.RoleId,
+                rp => rp.RoleId,
+                (x, rps) => new { x.Assignment, x.AssignmentPackage, x.AssignmentResource, RolePackages = rps }
+            )
+            .SelectMany(
+                x => x.RolePackages.DefaultIfEmpty(),
+                (x, rp) => new
+                {
+                    x.Assignment.To,
+                    x.Assignment.From,
+                    x.Assignment.Role,
+                    x.AssignmentResource,
+                    x.AssignmentResource.Resource,
+                    AssignmentPackage = x.AssignmentPackage.Package,
+                    RolePackage = rp.Package,
+                    RolePackageEntityVariantId = rp.EntityVariantId
+                }
+            )
+            .Where(x => x.RolePackage != null || x.AssignmentPackage != null || x.AssignmentResource != null)
+            .WhereIf(roleFilter.Count > 0, x => roleFilter.Contains(x.Role.Id))
+            .WhereIf(packageFilter.Count > 0, x => (x.RolePackage != null && packageFilter.Contains(x.RolePackage.Id)) || (x.AssignmentPackage != null && packageFilter.Contains(x.AssignmentPackage.Id)))
+            .GroupBy(x => x.From.Id)
+            .ToListAsync(cancellationToken);
+
+        return query
+            .Select(access =>
+            new ContractsV2.ClientDto()
+            {
+                Client = DtoMapper.Convert(access.First().From),
+                Access = access.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.ClientDto.RoleAccess
+                {
+                    Role = DtoMapper.ConvertCompactRole(r.First().Role),
+                    Packages = [
+                        .. r.Where(p => p.AssignmentPackage is { } && p.AssignmentPackage.IsDelegable)
+                            .Select(p => DtoMapper.ConvertCompactPackage(p.AssignmentPackage))
+                            .DistinctBy(p => p.Id),
+                        .. r.Where(p => p.RolePackage is { } && p.RolePackage.IsDelegable)
+                            .Where(p => p.RolePackageEntityVariantId == null || p.RolePackageEntityVariantId == p.From.VariantId)
+                            .Select(p => DtoMapper.ConvertCompactPackage(p.RolePackage))
+                            .DistinctBy(p => p.Id),
+                    ],
+                    Resources = [
+                        .. r.Where(p => p.AssignmentResource is { }).DistinctBy(r => r.AssignmentResource.Id).Select(p => DtoMapper.ConvertCompactResource(p.Resource))
+                    ]
+                }).ToList(),
+            }).ToList();
+    }
+
+    /// <inheritdoc/>
     public async Task<Result<List<AgentDto>>> GetAgents(Guid partyUuid, CancellationToken cancellationToken = default)
     {
         var query = await db.Assignments
@@ -282,6 +548,29 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 {
                     Role = DtoMapper.ConvertCompactRole(RoleConstants.Agent.Entity),
                     Packages = []
+                }
+            ]
+        }).ToList();
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.AgentDto>>> GetAgentsV2(Guid partyUuid, CancellationToken cancellationToken = default)
+    {
+        var query = await db.Assignments
+            .Where(a => a.FromId == partyUuid && a.RoleId == RoleConstants.Agent)
+            .Include(a => a.To)
+            .ToListAsync(cancellationToken);
+
+        return query.Select(a => new ContractsV2.AgentDto()
+        {
+            Agent = DtoMapper.Convert(a.To),
+            AgentAddedAt = a.Audit_ValidFrom,
+            Access = [
+                new()
+                {
+                    Role = DtoMapper.ConvertCompactRole(RoleConstants.Agent.Entity),
+                    Packages = [],
+                    Resources = [],
                 }
             ]
         }).ToList();
@@ -529,6 +818,44 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.AgentPackagesDto>>> GetDelegatedAccessPackagesFromClientsViaPartyV2(Guid partyUuid, Guid fromUuid, CancellationToken cancellationToken = default)
+    {
+        var query = await db.Delegations
+            .AsNoTracking()
+            .Include(d => d.From)
+            .Include(d => d.To).ThenInclude(a => a.To)
+            .Where(d => d.FacilitatorId == partyUuid && d.From.FromId == fromUuid)
+            .Join(
+                db.DelegationPackages,
+                d => d.Id,
+                dp => dp.DelegationId,
+                (d, dp) => new { Delegation = d, DelegationPackage = dp })
+            .Select(x => new
+            {
+                x.Delegation.To.To,
+                x.Delegation.From.Role,
+                x.DelegationPackage.Package,
+            })
+            .GroupBy(x => x.To.Id)
+            .ToListAsync(cancellationToken);
+
+        var result = query
+            .Select(e =>
+            new ContractsV2.AgentPackagesDto()
+            {
+                Agent = DtoMapper.Convert(e.First().To),
+                AgentAddedAt = e.First().To.Audit_ValidFrom,
+                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.AgentPackagesDto.RoleAccess
+                {
+                    Role = DtoMapper.ConvertCompactRole(r.First().Role),
+                    Packages = r.Select(r => DtoMapper.ConvertCompactPackage(r.Package)).DistinctBy(p => p.Id).ToList(),
+                }).ToList(),
+            }).ToList();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
     public async Task<Result<List<ClientDto>>> GetDelegatedAccessPackagesToAgentsViaPartyAsync(Guid partyUuid, Guid toUuid, CancellationToken cancellationToken = default)
     {
         var query = await db.Delegations
@@ -559,6 +886,43 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 {
                     Role = DtoMapper.ConvertCompactRole(r.First().Role),
                     Packages = r.Select(r => DtoMapper.ConvertCompactPackage(r.Package)).DistinctBy(p => p.Id).ToArray(),
+                }).ToList(),
+            }).ToList();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.ClientPackagesDto>>> GetDelegatedAccessPackagesToAgentsViaPartyV2(Guid partyUuid, Guid toUuid, CancellationToken cancellationToken = default)
+    {
+        var query = await db.Delegations
+            .AsNoTracking()
+            .Include(d => d.To)
+            .Include(d => d.From).ThenInclude(a => a.From)
+            .Where(d => d.FacilitatorId == partyUuid && d.To.ToId == toUuid)
+            .Join(
+                db.DelegationPackages,
+                d => d.Id,
+                dp => dp.DelegationId,
+                (d, dp) => new { Delegation = d, DelegationPackage = dp })
+            .Select(x => new
+            {
+                x.Delegation.From.From,
+                x.Delegation.From.Role,
+                x.DelegationPackage.Package
+            })
+            .GroupBy(x => x.From.Id)
+            .ToListAsync(cancellationToken);
+
+        var result = query
+            .Select(e =>
+            new ContractsV2.ClientPackagesDto()
+            {
+                Client = DtoMapper.Convert(e.First().From),
+                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.ClientPackagesDto.RoleAccess
+                {
+                    Role = DtoMapper.ConvertCompactRole(r.First().Role),
+                    Packages = r.Select(r => DtoMapper.ConvertCompactPackage(r.Package)).DistinctBy(p => p.Id).ToList(),
                 }).ToList(),
             }).ToList();
 
@@ -1082,9 +1446,25 @@ public interface IClientDelegationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets clients available to the party, grouped by provider,
+    /// including delegated roles, packages and resources.
+    /// </summary>
+    Task<Result<List<ContractsV2.MyClientDto>>> GetMyClientsV2(
+        Guid partyUuid,
+        List<Guid> providerUuids,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets providers that have assigned the Agent role to the given user/party.
     /// </summary>
     Task<Result<List<AgentDto>>> GetMyProviders(
+        Guid partyUuid,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets providers that have assigned the Agent role to the given user/party.
+    /// </summary>
+    Task<Result<List<ContractsV2.AgentDto>>> GetMyProvidersV2(
         Guid partyUuid,
         CancellationToken cancellationToken = default);
 
@@ -1121,9 +1501,27 @@ public interface IClientDelegationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets clients that have assigned roles to the party,
+    /// including delegable packages and delegated resources.
+    /// Optional role filter can be applied.
+    /// </summary>
+    Task<Result<List<ContractsV2.ClientDto>>> GetClientsV2(
+        Guid partyUuid,
+        List<string>? roles,
+        List<string>? packages,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets agents assigned by the party.
     /// </summary>
     Task<Result<List<AgentDto>>> GetAgents(
+        Guid partyUuid,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets agents assigned by the party.
+    /// </summary>
+    Task<Result<List<ContractsV2.AgentDto>>> GetAgentsV2(
         Guid partyUuid,
         CancellationToken cancellationToken = default);
 
@@ -1160,9 +1558,25 @@ public interface IClientDelegationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets packages delegated from a specific client via the party, grouped by agent.
+    /// </summary>
+    Task<Result<List<ContractsV2.AgentPackagesDto>>> GetDelegatedAccessPackagesFromClientsViaPartyV2(
+        Guid partyUuid,
+        Guid fromUuid,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets packages delegated to a specific agent via the party, grouped by client.
     /// </summary>
     Task<Result<List<ClientDto>>> GetDelegatedAccessPackagesToAgentsViaPartyAsync(
+        Guid partyUuid,
+        Guid toUuid,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets packages delegated to a specific agent via the party, grouped by client.
+    /// </summary>
+    Task<Result<List<ContractsV2.ClientPackagesDto>>> GetDelegatedAccessPackagesToAgentsViaPartyV2(
         Guid partyUuid,
         Guid toUuid,
         CancellationToken cancellationToken = default);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -192,13 +192,13 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             );
 
         // Group by provider in memory to avoid the very expensive SQL "order by" clause EF
-        // generates for grouped queries. Assume partyid is always set on provider entities.
+        // generates for grouped queries.
         var packageRowsList = await packageRows.ToListAsync(cancellationToken);
         var resourceRowsList = await resourceRows.ToListAsync(cancellationToken);
         var executedQuery = packageRowsList
             .Select(x => new { x.Client, x.Provider, x.Role, x.PackageId, ResourceId = Guid.Empty })
             .Concat(resourceRowsList.Select(x => new { x.Client, x.Provider, x.Role, PackageId = Guid.Empty, x.ResourceId }))
-            .GroupBy(x => x.Provider.PartyId ?? 0)
+            .GroupBy(x => x.Provider.Id)
             .ToList();
 
         var packageIds = executedQuery.SelectMany(q => q).Select(q => q.PackageId).Distinct().ToList();
@@ -308,7 +308,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 Access = [
                     new()
                     {
-                        Role = DtoMapper.ConvertCompactRole(a.Role),
+                        Role = DtoMapper.ConvertCompactRole(RoleConstants.Agent.Entity),
                         Packages = [],
                         Resources = [],
                     }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -1,0 +1,1178 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Json;
+using Altinn.AccessManagement.Api.Enduser.Controllers.V2;
+using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessManagement.Core.Errors;
+using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.TestUtils;
+using Altinn.AccessManagement.TestUtils.Data;
+using Altinn.AccessManagement.TestUtils.Fixtures;
+using Altinn.AccessMgmt.PersistenceEF.Constants;
+using Altinn.AccessMgmt.PersistenceEF.Models;
+using Altinn.Authorization.Api.Contracts.AccessManagement;
+using Altinn.Authorization.ProblemDetails;
+using Microsoft.EntityFrameworkCore;
+using ContractsV2 = Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+namespace Altinn.AccessManagement.Enduser.Api.Tests.Integration.Controllers.V2;
+
+public class ClientDelegationControllerTest
+{
+    public const string Route = "accessmanagement/api/v2/enduser/clientdelegations";
+
+    #region GET accessmanagement/api/v2/enduser/clientdelegations/my/clients
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.GetMyClients(List{Guid}?, AccessManagement.Api.Enduser.Models.PagingInput, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class GetMyClients : IClassFixture<ApiFixture>
+    {
+        public GetMyClients(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<GetMyClients>(db =>
+            {
+                var rightholderFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Rightholder,
+                };
+
+                var accountantFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+                var agentFromVerdiqToOrjan = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonOrjan,
+                    RoleId = RoleConstants.Agent,
+                };
+                var agentFromNordisToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var delegationToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var delegationToOrjan = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToOrjan.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var rppaula = db.RolePackages.FirstOrDefault(r => r.RoleId == RoleConstants.Accountant && r.PackageId == PackageConstants.AccountantWithSigningRights);
+                var rporjan = db.RolePackages.FirstOrDefault(r => r.RoleId == RoleConstants.Accountant && r.PackageId == PackageConstants.AccountantWithoutSigningRights);
+                var delegationPackageAccountantWithSigningRightsToPaula = new DelegationPackage()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    RolePackageId = rppaula.Id,
+                    PackageId = PackageConstants.AccountantWithSigningRights,
+                };
+                var delegationPackageAccountantSalaryToPaula = new DelegationPackage()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    RolePackageId = rppaula.Id,
+                    PackageId = PackageConstants.AccountantSalary,
+                };
+
+                var delegationPackageAccountantWithSigningRightsToOrjan = new DelegationPackage()
+                {
+                    DelegationId = delegationToOrjan.Id,
+                    RolePackageId = rporjan.Id,
+                    PackageId = PackageConstants.AccountantWithoutSigningRights,
+                };
+
+                var assignmentResourceAccountant = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                var delegationResourceToPaula = new DelegationResource()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceAccountant.Id,
+                };
+
+                db.Assignments.Add(rightholderFromNordisToVerdiq);
+                db.Assignments.Add(accountantFromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.Assignments.Add(agentFromVerdiqToOrjan);
+                db.Assignments.Add(agentFromNordisToPaula);
+
+                db.Delegations.Add(delegationToPaula);
+                db.Delegations.Add(delegationToOrjan);
+
+                db.DelegationPackages.Add(delegationPackageAccountantWithSigningRightsToPaula);
+                db.DelegationPackages.Add(delegationPackageAccountantWithSigningRightsToOrjan);
+                db.DelegationPackages.Add(delegationPackageAccountantSalaryToPaula);
+                db.AssignmentPackages.Add(new()
+                {
+                    AssignmentId = rightholderFromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.Customs,
+                });
+
+                db.AssignmentResources.Add(assignmentResourceAccountant);
+                db.DelegationResources.Add(delegationResourceToPaula);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", AuthzConstants.SCOPE_PORTAL_ENDUSER));
+            });
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task ListMyClients_WithFilter_Returns200WithFilteredClients()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/my/clients?provider={TestEntities.OrganizationVerdiqAS.Id}", TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.MyClientDto>>(data);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Single(result.Items);
+            Assert.NotEmpty(result.Items.FirstOrDefault().Clients);
+
+            response = await client.GetAsync($"{Route}/my/clients?provider={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
+
+            data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.MyClientDto>>(data);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Single(result.Items);
+            Assert.Empty(result.Items.FirstOrDefault().Clients);
+        }
+
+        [Fact]
+        public async Task ListMyClients_WithProviderFilter_Returns200IncludingDelegationResources()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/my/clients?provider={TestEntities.OrganizationVerdiqAS.Id}", TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.MyClientDto>>(data);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Single(result.Items);
+
+            var verdiq = result.Items.FirstOrDefault(p => p?.Provider?.Id == TestEntities.OrganizationVerdiqAS);
+            Assert.NotNull(verdiq);
+
+            var verdiqClient = verdiq.Clients.FirstOrDefault();
+            Assert.NotNull(verdiqClient);
+            Assert.Equal(TestEntities.OrganizationNordisAS.Id, verdiqClient.Client.Id);
+
+            var access = verdiqClient.Access.FirstOrDefault(a => a.Role.Id == RoleConstants.Accountant);
+            Assert.NotNull(access);
+
+            Assert.Single(access.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, access.Resources.FirstOrDefault()?.Id);
+        }
+
+        [Fact]
+        public async Task ListMyClients_WithProviderFilterForProviderWithoutDelegationResources_Returns200WithEmptyResources()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/my/clients?provider={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.MyClientDto>>(data);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Single(result.Items);
+
+            var nordis = result.Items.FirstOrDefault(p => p?.Provider?.Id == TestEntities.OrganizationNordisAS);
+            Assert.NotNull(nordis);
+            Assert.Empty(nordis.Clients);
+        }
+
+        [Fact]
+        public async Task ListMyClients_WithoutFilter_Returns200WithAllProvidersAndClients()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/my/clients", TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.MyClientDto>>(data);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            Assert.Equal(2, result.Items.Count());
+            var verdiq = result.Items.FirstOrDefault(p => p?.Provider?.Id == TestEntities.OrganizationVerdiqAS);
+            var nordis = result.Items.FirstOrDefault(p => p?.Provider?.Id == TestEntities.OrganizationNordisAS);
+            Assert.Empty(nordis.Clients);
+
+            Assert.Single(verdiq.Clients);
+            var verdiqClients = verdiq.Clients.FirstOrDefault();
+
+            Assert.Single(verdiqClients.Access);
+            var verdiqAccess = verdiqClients.Access.FirstOrDefault();
+
+            Assert.Equal(2, verdiqAccess.Packages.Count);
+            var verdiqPackageAccountantWithSigningRights = verdiqAccess.Packages.FirstOrDefault(p => p.Id == PackageConstants.AccountantWithSigningRights);
+            var verdiqPackageAccountantSalary = verdiqAccess.Packages.FirstOrDefault(p => p.Id == PackageConstants.AccountantSalary);
+
+            Assert.NotNull(verdiqPackageAccountantWithSigningRights);
+            Assert.NotNull(verdiqPackageAccountantSalary);
+
+            Assert.Equal(RoleConstants.Accountant.Id, verdiqAccess.Role.Id);
+            Assert.Equal(PackageConstants.AccountantWithSigningRights, verdiqPackageAccountantWithSigningRights.Id);
+            Assert.Equal(PackageConstants.AccountantSalary, verdiqPackageAccountantSalary.Id);
+
+            Assert.Equal(TestEntities.OrganizationVerdiqAS.Id, verdiq.Provider.Id);
+            Assert.Equal(TestEntities.OrganizationNordisAS.Id, verdiqClients.Client.Id);
+
+            Assert.Single(verdiqAccess.Resources);
+            var verdiqResource = verdiqAccess.Resources.FirstOrDefault();
+            Assert.NotNull(verdiqResource);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, verdiqResource.Id);
+        }
+    }
+    #endregion
+
+    #region GET accessmanagement/api/v2/enduser/clientdelegations/my/clientproviders
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.GetMyClientProviders(CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class GetMyClientProviders : IClassFixture<ApiFixture>
+    {
+        public GetMyClientProviders(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<GetMyClientProviders>(db =>
+            {
+                db.Assignments.Add(new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                });
+
+                db.Assignments.Add(new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                });
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", AuthzConstants.SCOPE_PORTAL_ENDUSER));
+            });
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task ListMyClientProviders_ForPersonWithAgentAssignments_Returns200WithProviders()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/my/clientproviders", TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.AgentDto>>(data);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(2, result.Items.Count());
+
+            var verdiq = result.Items.FirstOrDefault(p => p.Agent.Id == TestEntities.OrganizationVerdiqAS);
+            Assert.NotNull(verdiq);
+
+            var access = Assert.Single(verdiq.Access);
+            Assert.Empty(access.Packages);
+            Assert.Empty(access.Resources);
+        }
+    }
+    #endregion
+
+    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/my/clientproviders
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DeleteMyAgentViaParty(Guid, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteMyClientProvider : IClassFixture<ApiFixture>
+    {
+        public DeleteMyClientProvider(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DeleteMyClientProvider>(db =>
+            {
+                db.Assignments.Add(new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                });
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", AuthzConstants.SCOPE_PORTAL_ENDUSER));
+            });
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DeleteMyClientProvider_ForProviderWithoutDelegations_Returns204AndRemovesAgentAssignment()
+        {
+            var client = CreateClient();
+
+            var response = await client.DeleteAsync($"{Route}/my/clientproviders?provider={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+            await Fixture.QueryDb(static async db =>
+            {
+                var assignment = await db.Assignments
+                    .Where(a => a.FromId == TestEntities.OrganizationNordisAS.Id && a.ToId == TestEntities.PersonPaula.Id && a.RoleId == RoleConstants.Agent.Id)
+                    .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+                Assert.Null(assignment);
+            });
+        }
+    }
+    #endregion
+
+    #region GET accessmanagement/api/v2/enduser/clientdelegations/clients
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.GetClients(Guid, List{string}?, List{string}?, AccessManagement.Api.Enduser.Models.PagingInput, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class GetClients : IClassFixture<ApiFixture>
+    {
+        public GetClients(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<GetClients>(db =>
+            {
+                var rightholderfromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Rightholder,
+                };
+
+                var accountantFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var agentFromPaulaToNordis = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var assignmentResourceForAccountant = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                db.Assignments.Add(rightholderfromNordisToVerdiq);
+                db.Assignments.Add(accountantFromNordisToVerdiq);
+                db.Assignments.Add(agentFromPaulaToNordis);
+
+                db.AssignmentPackages.Add(new()
+                {
+                    AssignmentId = rightholderfromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.Customs,
+                });
+
+                db.AssignmentResources.Add(assignmentResourceForAccountant);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim("scope", AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ));
+            });
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task ListClient_ForOrganizationWithRightholderAssignment_Returns200WithRightholderClientAndCustomsPackage()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(data);
+
+            var connection = result.Items.FirstOrDefault(p => p.Client.Id == TestEntities.OrganizationNordisAS.Id);
+            Assert.NotNull(connection);
+            Assert.Equal(connection.Client.Id, TestEntities.OrganizationNordisAS.Id);
+
+            var access = connection.Access.FirstOrDefault(a => a.Role.Id == RoleConstants.Rightholder);
+            Assert.NotNull(access);
+            Assert.Equal(RoleConstants.Rightholder.Id, access.Role.Id);
+
+            var customsPackage = access.Packages.FirstOrDefault(p => p.Id == PackageConstants.Customs.Id);
+            Assert.NotNull(customsPackage);
+            Assert.Equal(PackageConstants.Customs.Id, customsPackage.Id);
+            Assert.Equal(PackageConstants.Customs.Entity.Urn, customsPackage.Urn);
+            Assert.Equal(PackageConstants.Customs.Entity.AreaId, customsPackage.AreaId);
+        }
+
+        [Fact]
+        public async Task ListClient_ForOrganizationWithAccountantAssignmentResource_Returns200WithResourceInAccess()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(data);
+
+            var nordisClient = result.Items.FirstOrDefault(p => p.Client.Id == TestEntities.OrganizationNordisAS.Id);
+            Assert.NotNull(nordisClient);
+
+            var accountantAccess = nordisClient.Access.FirstOrDefault(a => a.Role.Id == RoleConstants.Accountant);
+            Assert.NotNull(accountantAccess);
+
+            Assert.Single(accountantAccess.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, accountantAccess.Resources.FirstOrDefault()?.Id);
+        }
+
+        [Fact]
+        public async Task ListClient_ForOrganizationWithRightholderAssignment_Returns200WithEmptyResourcesOnRightholder()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}&roles=rettighetshaver", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(data);
+
+            var nordisClient = result.Items.FirstOrDefault(p => p.Client.Id == TestEntities.OrganizationNordisAS.Id);
+            Assert.NotNull(nordisClient);
+
+            var rightholderAccess = nordisClient.Access.FirstOrDefault(a => a.Role.Id == RoleConstants.Rightholder);
+            Assert.NotNull(rightholderAccess);
+
+            Assert.Empty(rightholderAccess.Resources);
+        }
+
+        [Fact]
+        public async Task ListClient_ForOrganizationWithAccountantRoleFilter_Returns200WithResourceInFilteredAccess()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}&roles=regnskapsforer", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(data);
+
+            var nordisClient = result.Items.FirstOrDefault(p => p.Client.Id == TestEntities.OrganizationNordisAS.Id);
+            Assert.NotNull(nordisClient);
+
+            Assert.DoesNotContain(nordisClient.Access, a => a.Role.Id == RoleConstants.Rightholder);
+
+            var accountantAccess = nordisClient.Access.FirstOrDefault(a => a.Role.Id == RoleConstants.Accountant);
+            Assert.NotNull(accountantAccess);
+
+            Assert.Single(accountantAccess.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, accountantAccess.Resources.FirstOrDefault()?.Id);
+        }
+    }
+    #endregion
+
+    #region GET accessmanagement/api/v2/enduser/clientdelegations/agents
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.GetAgents(Guid, AccessManagement.Api.Enduser.Models.PagingInput, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class GetAgents : IClassFixture<ApiFixture>
+    {
+        public GetAgents(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<GetAgents>(db =>
+            {
+                db.Assignments.Add(new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                });
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim("scope", AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ));
+            });
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task ListAgent_ForPersonWithAgentAssignment_Returns200WithAgentConnection()
+        {
+            var client = CreateClient();
+            var response = await client.GetAsync($"{Route}/agents?party={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.AgentDto>>(data);
+
+            var connection = result.Items.FirstOrDefault(p => p.Agent.Id == TestEntities.PersonPaula);
+            Assert.NotNull(connection);
+            Assert.Equal(TestEntities.PersonPaula.Id, connection.Agent.Id);
+
+            var access = connection.Access.FirstOrDefault(r => r.Role.Id == RoleConstants.Agent);
+            Assert.NotNull(access);
+            Assert.Empty(access.Packages);
+            Assert.Empty(access.Resources);
+        }
+    }
+    #endregion
+
+    #region POST accessmanagement/api/v2/enduser/clientdelegations/agents
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.AddAgent(Guid, Guid?, AccessManagement.Api.Enduser.Models.PersonInput?, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class AddAgent : IClassFixture<ApiFixture>
+    {
+        public AddAgent(ApiFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ}"));
+            });
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task AddAgent_NotPermittedEntityType_Returns400WhenEntityTypeDisallowed()
+        {
+            // Try to add organization as agent
+            var client = CreateClient();
+            var response = await client.PostAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.OrganizationNordisAS}", null, TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data);
+
+            // Ensure proper error returned
+            Assert.Single(problem.Errors);
+            Assert.All(problem.Errors, error =>
+            {
+                Assert.Equal(ValidationErrors.DisallowedEntityType.ErrorCode, error.ErrorCode);
+            });
+        }
+
+        [Fact]
+        public async Task AddAgent_PermittedEntityTypeAgentSystemUser_Returns200AndAddsAgentSystemUser()
+        {
+            var client = CreateClient();
+            var response = await client.PostAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.SystemUserClient}", null, TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var getAgents = await client.GetAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS.Id}", TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, getAgents.StatusCode);
+            var getAgentsData = await getAgents.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.AgentDto>>(getAgentsData);
+
+            var agent = result.Items.FirstOrDefault(p => p.Agent.Id == TestEntities.SystemUserClient);
+            Assert.NotNull(agent);
+        }
+    }
+
+    #endregion
+
+    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/agents
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.RemoveAgent(Guid, Guid, bool, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteAgent : IClassFixture<ApiFixture>
+    {
+        public DeleteAgent(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DeleteAgent>(db =>
+            {
+                var rightholderfromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Rightholder,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                db.Assignments.Add(rightholderfromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+
+                db.AssignmentPackages.Add(new()
+                {
+                    AssignmentId = rightholderfromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.Customs.Id,
+                });
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task RemoveAgentWithExistingDelegations_WithCascadeFalse_Returns400WhenDelegationHasActiveConnections()
+        {
+            // Create Delegation
+            var client = CreateClient();
+            var response = await client.PostAsJsonAsync(
+                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}",
+                new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                },
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // Verify Delegation exists
+            var getDelegationsToAgent = await client.GetAsync($"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
+            var delegationsToAgentPayload = await getDelegationsToAgent.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var delegationToAgentResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientPackagesDto>>(delegationsToAgentPayload);
+
+            Assert.NotEmpty(delegationToAgentResult.Items);
+
+            // Delete Delegation without cascade
+            var deleteResponse = await client.DeleteAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}&cascade=false", TestContext.Current.CancellationToken);
+            var deleteResponsePayload = await deleteResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, deleteResponse.StatusCode);
+
+            // Ensure proper error returned
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(deleteResponsePayload);
+            Assert.Single(problem.Errors);
+            Assert.All(problem.Errors, error =>
+            {
+                Assert.Equal(ValidationErrors.DelegationHasActiveConnections.ErrorCode, error.ErrorCode);
+            });
+
+            // Delete with cascade true
+            deleteResponse = await client.DeleteAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}&cascade=true", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+            // Ensure Agent is deleted
+            var getAgents = await client.GetAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}", TestContext.Current.CancellationToken);
+            var getAgentsPayload = await getAgents.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var agentResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.AgentDto>>(getAgentsPayload);
+
+            Assert.Equal(HttpStatusCode.OK, getAgents.StatusCode);
+            Assert.Empty(agentResult.Items);
+        }
+    }
+    #endregion
+
+    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/agents/clients
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.RemoveAgentsClient(Guid, Guid, Guid, bool, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class RemoveAnAgentsClient : IClassFixture<ApiFixture>
+    {
+        public RemoveAnAgentsClient(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<RemoveAnAgentsClient>(db =>
+            {
+                var rightholderfromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Rightholder,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var agentFromVerdiqToOrjan = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonOrjan,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var assignmentPackageCustomsFromNordisToVerdiq = new AssignmentPackage()
+                {
+                    AssignmentId = rightholderfromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.Customs.Id,
+                };
+
+                var assignmentPackageExplicitServiceDelegationFromNordisToVerdiq = new AssignmentPackage()
+                {
+                    AssignmentId = rightholderfromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.ExplicitServiceDelegation.Id,
+                };
+
+                var delegationFromNordisToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = rightholderfromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var delegationFromNordisToOrjan = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = rightholderfromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToOrjan.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var delegationPackageFromNordisToPaula = new DelegationPackage()
+                {
+                    AssignmentPackageId = assignmentPackageCustomsFromNordisToVerdiq.Id,
+                    DelegationId = delegationFromNordisToPaula.Id,
+                    PackageId = PackageConstants.Customs.Id,
+                };
+
+                var delegationPackageFromNordisToOrjan = new DelegationPackage()
+                {
+                    AssignmentPackageId = assignmentPackageExplicitServiceDelegationFromNordisToVerdiq.Id,
+                    DelegationId = delegationFromNordisToOrjan.Id,
+                    PackageId = PackageConstants.ExplicitServiceDelegation.Id,
+                };
+
+                db.Assignments.Add(rightholderfromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.Assignments.Add(agentFromVerdiqToOrjan);
+
+                db.AssignmentPackages.Add(assignmentPackageCustomsFromNordisToVerdiq);
+                db.AssignmentPackages.Add(assignmentPackageExplicitServiceDelegationFromNordisToVerdiq);
+
+                db.Delegations.Add(delegationFromNordisToPaula);
+                db.Delegations.Add(delegationFromNordisToOrjan);
+
+                db.DelegationPackages.Add(delegationPackageFromNordisToPaula);
+                db.DelegationPackages.Add(delegationPackageFromNordisToOrjan);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task RemoveAgentsClientWithExistingDelegations_WithCascadeFalse_Returns400WhenDelegationHasActiveConnections()
+        {
+            var client = CreateClient();
+            var response = await client.DeleteAsync($"{Route}/agents/clients?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+            // Ensure proper error returned
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data);
+            Assert.Single(problem.Errors);
+            Assert.All(problem.Errors, error =>
+            {
+                Assert.Equal(ValidationErrors.DelegationHasActiveConnections.ErrorCode, error.ErrorCode);
+            });
+        }
+
+        [Fact]
+        public async Task RemoveAgentsClientWithExistingDelegations_WithCascadeTrue_Returns204AndRemovesDelegation()
+        {
+            var client = CreateClient();
+
+            // Ensure delegation exists
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegation = await db.Delegations
+                    .Where(a => a.To.ToId == TestEntities.PersonOrjan)
+                    .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+                Assert.NotNull(delegation);
+            });
+
+            var response = await client.DeleteAsync($"{Route}/agents/clients?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonOrjan}&cascade=true", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+            // Ensure delegation has been deleted.
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegation = await db.Delegations
+                    .Where(a => a.To.ToId == TestEntities.PersonOrjan)
+                    .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+                Assert.Null(delegation);
+            });
+        }
+    }
+    #endregion
+
+    #region POST accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DelegateAccessPackageToAgent(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DelegateAccessPackageToAgent : IClassFixture<ApiFixture>
+    {
+        public DelegateAccessPackageToAgent(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DelegateAccessPackageToAgent>(db =>
+            {
+                var rightholderfromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Rightholder,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                db.Assignments.Add(rightholderfromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+
+                db.AssignmentPackages.Add(new()
+                {
+                    AssignmentId = rightholderfromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.Customs.Id,
+                });
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DelegateAccessPackageToAgent_WithValidInput_Returns200WithDelegationResult()
+        {
+            var client = CreateClient();
+
+            var response = await client.PostAsJsonAsync(
+                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}",
+                new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                },
+                TestContext.Current.CancellationToken
+            );
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var delegationResult = JsonSerializer.Deserialize<List<DelegationDto>>(data);
+            Assert.NotEmpty(delegationResult);
+            Assert.True(delegationResult.All(d => d.Changed));
+
+            var getDelegationsToAgent = await client.GetAsync($"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
+            var delegationsToAgentPayload = await getDelegationsToAgent.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var delegationToAgentResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientPackagesDto>>(delegationsToAgentPayload);
+
+            Assert.NotEmpty(delegationToAgentResult.Items);
+
+            var agentAccess = delegationToAgentResult.Items.FirstOrDefault();
+            Assert.Equal(TestEntities.OrganizationNordisAS.Id, agentAccess.Client.Id);
+            Assert.Equal(RoleConstants.Rightholder.Entity.Code, agentAccess.Access.FirstOrDefault()?.Role?.Code);
+            Assert.Equal(PackageConstants.Customs.Entity.Urn, agentAccess.Access.FirstOrDefault()?.Packages?.FirstOrDefault().Urn);
+
+            var getDelegationFromClient = await client.GetAsync($"{Route}/clients/accesspackages?party={TestEntities.OrganizationVerdiqAS.Id}&from={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
+            var delegationsFromClientPayload = await getDelegationFromClient.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var delegationsFromClientResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.AgentPackagesDto>>(delegationsFromClientPayload);
+
+            Assert.NotEmpty(delegationsFromClientResult.Items);
+
+            var accessToClient = delegationsFromClientResult.Items.FirstOrDefault();
+            Assert.Equal(TestEntities.PersonPaula.Id, accessToClient.Agent.Id);
+            Assert.Equal(RoleConstants.Rightholder.Entity.Code, accessToClient.Access.FirstOrDefault()?.Role?.Code);
+            Assert.Equal(PackageConstants.Customs.Entity.Urn, accessToClient.Access.FirstOrDefault()?.Packages?.FirstOrDefault().Urn);
+        }
+    }
+
+    #endregion
+
+    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DeleteAgentAccessPackage(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteAgentAccessPackage : IClassFixture<ApiFixture>
+    {
+        public DeleteAgentAccessPackage(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DeleteAgentAccessPackage>(db =>
+            {
+                var rightholderfromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Rightholder,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                db.Assignments.Add(rightholderfromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+
+                db.AssignmentPackages.Add(new()
+                {
+                    AssignmentId = rightholderfromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.Customs.Id,
+                });
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DeleteAccessPackageToAgent_WithValidInput_Returns200WithDeleteResult()
+        {
+            // Create Delegation
+            var client = CreateClient();
+            var response = await client.PostAsJsonAsync(
+                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}",
+                new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                },
+                TestContext.Current.CancellationToken
+            );
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // Delete Delegation
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}")
+            {
+                Content = JsonContent.Create(new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                })
+            };
+
+            var deleteResponse = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var deleteResponsePayload = await deleteResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+            var deleteResult = JsonSerializer.Deserialize<List<DelegationDto>>(deleteResponsePayload);
+            Assert.NotEmpty(deleteResult);
+            Assert.True(deleteResult.All(d => d.Changed));
+
+            // Verify Delegation deleted
+            var getDelegationsToAgent = await client.GetAsync($"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
+            var delegationsToAgentPayload = await getDelegationsToAgent.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var delegationToAgentResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientPackagesDto>>(delegationsToAgentPayload);
+
+            Assert.Empty(delegationToAgentResult.Items);
+        }
+    }
+    #endregion
+}

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -327,13 +327,14 @@ public class ClientDelegationControllerTest
             var response = await client.GetAsync($"{Route}/my/clientproviders", TestContext.Current.CancellationToken);
 
             var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.AgentDto>>(data);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.MyClientProviderDto>>(data);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(2, result.Items.Count());
 
-            var verdiq = result.Items.FirstOrDefault(p => p.Agent.Id == TestEntities.OrganizationVerdiqAS);
+            var verdiq = result.Items.FirstOrDefault(p => p.Provider.Id == TestEntities.OrganizationVerdiqAS);
             Assert.NotNull(verdiq);
+            Assert.NotNull(verdiq.Provider);
 
             var access = Assert.Single(verdiq.Access);
             Assert.Empty(access.Packages);
@@ -655,7 +656,7 @@ public class ClientDelegationControllerTest
         {
             // Try to add organization as agent
             var client = CreateClient();
-            var response = await client.PostAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.OrganizationNordisAS}", null, TestContext.Current.CancellationToken);
+            var response = await client.PostAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&agent={TestEntities.OrganizationNordisAS}", null, TestContext.Current.CancellationToken);
 
             var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -673,7 +674,7 @@ public class ClientDelegationControllerTest
         public async Task AddAgent_PermittedEntityTypeAgentSystemUser_Returns200AndAddsAgentSystemUser()
         {
             var client = CreateClient();
-            var response = await client.PostAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.SystemUserClient}", null, TestContext.Current.CancellationToken);
+            var response = await client.PostAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&agent={TestEntities.SystemUserClient}", null, TestContext.Current.CancellationToken);
 
             var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -751,7 +752,7 @@ public class ClientDelegationControllerTest
             // Create Delegation
             var client = CreateClient();
             var response = await client.PostAsJsonAsync(
-                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}",
+                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}",
                 new DelegationBatchInputDto()
                 {
                     Values = [
@@ -768,14 +769,14 @@ public class ClientDelegationControllerTest
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Verify Delegation exists
-            var getDelegationsToAgent = await client.GetAsync($"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
+            var getDelegationsToAgent = await client.GetAsync($"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&agent={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
             var delegationsToAgentPayload = await getDelegationsToAgent.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             var delegationToAgentResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientPackagesDto>>(delegationsToAgentPayload);
 
             Assert.NotEmpty(delegationToAgentResult.Items);
 
             // Delete Delegation without cascade
-            var deleteResponse = await client.DeleteAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}&cascade=false", TestContext.Current.CancellationToken);
+            var deleteResponse = await client.DeleteAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&agent={TestEntities.PersonPaula}&cascade=false", TestContext.Current.CancellationToken);
             var deleteResponsePayload = await deleteResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.BadRequest, deleteResponse.StatusCode);
@@ -789,7 +790,7 @@ public class ClientDelegationControllerTest
             });
 
             // Delete with cascade true
-            deleteResponse = await client.DeleteAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}&cascade=true", TestContext.Current.CancellationToken);
+            deleteResponse = await client.DeleteAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&agent={TestEntities.PersonPaula}&cascade=true", TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
@@ -914,7 +915,7 @@ public class ClientDelegationControllerTest
         public async Task RemoveAgentsClientWithExistingDelegations_WithCascadeFalse_Returns400WhenDelegationHasActiveConnections()
         {
             var client = CreateClient();
-            var response = await client.DeleteAsync($"{Route}/agents/clients?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
+            var response = await client.DeleteAsync($"{Route}/agents/clients?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
 
             var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -943,7 +944,7 @@ public class ClientDelegationControllerTest
                 Assert.NotNull(delegation);
             });
 
-            var response = await client.DeleteAsync($"{Route}/agents/clients?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonOrjan}&cascade=true", TestContext.Current.CancellationToken);
+            var response = await client.DeleteAsync($"{Route}/agents/clients?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonOrjan}&cascade=true", TestContext.Current.CancellationToken);
 
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
@@ -1021,7 +1022,7 @@ public class ClientDelegationControllerTest
             var client = CreateClient();
 
             var response = await client.PostAsJsonAsync(
-                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}",
+                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}",
                 new DelegationBatchInputDto()
                 {
                     Values = [
@@ -1042,7 +1043,7 @@ public class ClientDelegationControllerTest
             Assert.NotEmpty(delegationResult);
             Assert.True(delegationResult.All(d => d.Changed));
 
-            var getDelegationsToAgent = await client.GetAsync($"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
+            var getDelegationsToAgent = await client.GetAsync($"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&agent={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
             var delegationsToAgentPayload = await getDelegationsToAgent.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             var delegationToAgentResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientPackagesDto>>(delegationsToAgentPayload);
 
@@ -1053,7 +1054,7 @@ public class ClientDelegationControllerTest
             Assert.Equal(RoleConstants.Rightholder.Entity.Code, agentAccess.Access.FirstOrDefault()?.Role?.Code);
             Assert.Equal(PackageConstants.Customs.Entity.Urn, agentAccess.Access.FirstOrDefault()?.Packages?.FirstOrDefault().Urn);
 
-            var getDelegationFromClient = await client.GetAsync($"{Route}/clients/accesspackages?party={TestEntities.OrganizationVerdiqAS.Id}&from={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
+            var getDelegationFromClient = await client.GetAsync($"{Route}/clients/accesspackages?party={TestEntities.OrganizationVerdiqAS.Id}&client={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
             var delegationsFromClientPayload = await getDelegationFromClient.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             var delegationsFromClientResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.AgentPackagesDto>>(delegationsFromClientPayload);
 
@@ -1129,7 +1130,7 @@ public class ClientDelegationControllerTest
             // Create Delegation
             var client = CreateClient();
             var response = await client.PostAsJsonAsync(
-                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}",
+                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}",
                 new DelegationBatchInputDto()
                 {
                     Values = [
@@ -1146,7 +1147,7 @@ public class ClientDelegationControllerTest
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Delete Delegation
-            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&from={TestEntities.OrganizationNordisAS}&to={TestEntities.PersonPaula}")
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}")
             {
                 Content = JsonContent.Create(new DelegationBatchInputDto()
                 {
@@ -1169,7 +1170,7 @@ public class ClientDelegationControllerTest
             Assert.True(deleteResult.All(d => d.Changed));
 
             // Verify Delegation deleted
-            var getDelegationsToAgent = await client.GetAsync($"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&to={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
+            var getDelegationsToAgent = await client.GetAsync($"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&agent={TestEntities.PersonPaula}", TestContext.Current.CancellationToken);
             var delegationsToAgentPayload = await getDelegationsToAgent.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             var delegationToAgentResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientPackagesDto>>(delegationsToAgentPayload);
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Text.Json;
@@ -21,6 +21,8 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Integration.Controllers.V2;
 public class ClientDelegationControllerTest
 {
     public const string Route = "accessmanagement/api/v2/enduser/clientdelegations";
+
+    public static readonly JsonSerializerOptions SerializerOptions = new() { PropertyNameCaseInsensitive = true };
 
     #region GET accessmanagement/api/v2/enduser/clientdelegations/my/clients
 
@@ -657,7 +659,7 @@ public class ClientDelegationControllerTest
 
             var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data, SerializerOptions);
 
             // Ensure proper error returned
             Assert.Single(problem.Errors);
@@ -779,7 +781,7 @@ public class ClientDelegationControllerTest
             Assert.Equal(HttpStatusCode.BadRequest, deleteResponse.StatusCode);
 
             // Ensure proper error returned
-            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(deleteResponsePayload);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(deleteResponsePayload, SerializerOptions);
             Assert.Single(problem.Errors);
             Assert.All(problem.Errors, error =>
             {
@@ -918,7 +920,7 @@ public class ClientDelegationControllerTest
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
             // Ensure proper error returned
-            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data, SerializerOptions);
             Assert.Single(problem.Errors);
             Assert.All(problem.Errors, error =>
             {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/SwaggerDocTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/SwaggerDocTest.cs
@@ -7,9 +7,10 @@ namespace Altinn.AccessManagement.Enduser.Api.Tests.Integration;
 /// <summary>
 /// Regression tests for the generated swagger documents. The v1 document is
 /// extracted by APIM under the name "v1" at <c>/swagger/v1/swagger.json</c>,
-/// so both its URL and its content must stay stable. Swagger is only mapped
-/// in the Development environment, which is the default environment for the
-/// <see cref="ApiFixture"/> test host.
+/// so its URL, document name and path set must stay stable. Schema and
+/// operation contents are owned by the endpoints themselves and are not
+/// pinned here. Swagger is only mapped in the Development environment, which
+/// is the default environment for the <see cref="ApiFixture"/> test host.
 /// </summary>
 public class SwaggerDocTest
 {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/SwaggerDocTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/SwaggerDocTest.cs
@@ -15,6 +15,8 @@ public class SwaggerDocTest
 {
     public const string ClientDelegationV1Route = "/accessmanagement/api/v1/enduser/clientdelegations";
 
+    public const string ClientDelegationV2Route = "/accessmanagement/api/v2/enduser/clientdelegations";
+
     /// <summary>
     /// Fetches a swagger document and returns the response together with the
     /// path keys of the parsed document.
@@ -57,6 +59,31 @@ public class SwaggerDocTest
             var (_, paths) = await GetSwaggerDoc(Client, "v1");
 
             paths.Should().NotContain(p => p.Contains("/v2/", StringComparison.Ordinal));
+        }
+    }
+
+    /// <summary>
+    /// Tests for the v2 swagger document. Only the client delegation API is
+    /// versioned, so the v2 document must contain its /v2/ paths and nothing
+    /// else.
+    /// </summary>
+    [IntegrationTest]
+    public class V2Doc : IClassFixture<ApiFixture>
+    {
+        public V2Doc(ApiFixture fixture)
+        {
+            Client = fixture.BuildConfiguration();
+        }
+
+        private HttpClient Client { get; }
+
+        [Fact]
+        public async Task GetSwaggerJson_V2Doc_Returns200WithOnlyClientDelegationV2Paths()
+        {
+            var (_, paths) = await GetSwaggerDoc(Client, "v2");
+
+            paths.Should().NotBeEmpty();
+            paths.Should().OnlyContain(p => p.StartsWith($"{ClientDelegationV2Route}/", StringComparison.Ordinal));
         }
     }
 }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/SwaggerDocTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/SwaggerDocTest.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Text.Json;
+using Altinn.AccessManagement.TestUtils.Fixtures;
+
+namespace Altinn.AccessManagement.Enduser.Api.Tests.Integration;
+
+/// <summary>
+/// Regression tests for the generated swagger documents. The v1 document is
+/// extracted by APIM under the name "v1" at <c>/swagger/v1/swagger.json</c>,
+/// so both its URL and its content must stay stable. Swagger is only mapped
+/// in the Development environment, which is the default environment for the
+/// <see cref="ApiFixture"/> test host.
+/// </summary>
+public class SwaggerDocTest
+{
+    public const string ClientDelegationV1Route = "/accessmanagement/api/v1/enduser/clientdelegations";
+
+    /// <summary>
+    /// Fetches a swagger document and returns the response together with the
+    /// path keys of the parsed document.
+    /// </summary>
+    private static async Task<(HttpResponseMessage Response, List<string> Paths)> GetSwaggerDoc(HttpClient client, string docName)
+    {
+        var response = await client.GetAsync($"/swagger/{docName}/swagger.json", TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(body);
+        var paths = doc.RootElement.GetProperty("paths").EnumerateObject().Select(p => p.Name).ToList();
+        return (response, paths);
+    }
+
+    /// <summary>
+    /// Tests for the v1 swagger document.
+    /// </summary>
+    [IntegrationTest]
+    public class V1Doc : IClassFixture<ApiFixture>
+    {
+        public V1Doc(ApiFixture fixture)
+        {
+            Client = fixture.BuildConfiguration();
+        }
+
+        private HttpClient Client { get; }
+
+        [Fact]
+        public async Task GetSwaggerJson_V1Doc_Returns200WithClientDelegationV1Paths()
+        {
+            var (_, paths) = await GetSwaggerDoc(Client, "v1");
+
+            paths.Should().Contain(p => p.StartsWith($"{ClientDelegationV1Route}/", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task GetSwaggerJson_V1Doc_Returns200WithoutV2Paths()
+        {
+            var (_, paths) = await GetSwaggerDoc(Client, "v1");
+
+            paths.Should().NotContain(p => p.Contains("/v2/", StringComparison.Ordinal));
+        }
+    }
+}

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/SwaggerDocTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/SwaggerDocTest.cs
@@ -17,6 +17,8 @@ public class SwaggerDocTest
 
     public const string ClientDelegationV2Route = "/accessmanagement/api/v2/enduser/clientdelegations";
 
+    public const string AuthorizedPartiesV1Route = "/accessmanagement/api/v1/enduser/authorizedparties";
+
     /// <summary>
     /// Fetches a swagger document and returns the response together with the
     /// path keys of the parsed document.
@@ -51,6 +53,14 @@ public class SwaggerDocTest
             var (_, paths) = await GetSwaggerDoc(Client, "v1");
 
             paths.Should().Contain(p => p.StartsWith($"{ClientDelegationV1Route}/", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task GetSwaggerJson_V1Doc_Returns200WithUnversionedControllerPaths()
+        {
+            var (_, paths) = await GetSwaggerDoc(Client, "v1");
+
+            paths.Should().Contain(p => p.StartsWith(AuthorizedPartiesV1Route, StringComparison.Ordinal));
         }
 
         [Fact]

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/Compact/CompactResourceDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/Compact/CompactResourceDto.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Authorization.Api.Contracts.AccessManagement;
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement;
 
 /// <summary>
 /// Compact versjon of resource
@@ -8,10 +10,12 @@ public class CompactResourceDto
     /// <summary>
     /// Unique identifier
     /// </summary>
+    [JsonPropertyName("id")]
     public Guid Id { get; set; }
 
     /// <summary>
     /// Value
     /// </summary>
+    [JsonPropertyName("value")]
     public string Value { get; set; }
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentDto.cs
@@ -1,0 +1,52 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing a connected agent party, meaning a party which has been authorized for one or more accesses, either directly or through role(s), access packages, resources or resource instances.
+/// Model can be used both to represent a connection received from another party or a connection provided to another party.
+/// </summary>
+public class AgentDto
+{
+    /// <summary>
+    /// Gets or sets the party
+    /// </summary>
+    [JsonPropertyName("agent")]
+    public CompactEntityDto Agent { get; set; }
+
+    /// <summary>
+    /// Specifies when the <see cref="Agent"/> was added.
+    /// </summary>
+    [JsonPropertyName("agentAddedAt")]
+    public DateTimeOffset AgentAddedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets a collection of all access information for the agent
+    /// </summary>
+    [JsonPropertyName("access")]
+    public List<RoleAccess> Access { get; set; } = [];
+
+    /// <summary>
+    /// Access given through a single role
+    /// </summary>
+    public class RoleAccess
+    {
+        /// <summary>
+        /// Role
+        /// </summary>
+        [JsonPropertyName("role")]
+        public CompactRoleDto Role { get; set; }
+
+        /// <summary>
+        /// Packages
+        /// </summary>
+        [JsonPropertyName("packages")]
+        public List<CompactPackageDto> Packages { get; set; } = [];
+
+        /// <summary>
+        /// Resources
+        /// </summary>
+        [JsonPropertyName("resources")]
+        public List<CompactResourceDto> Resources { get; set; } = [];
+    }
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentPackagesDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentPackagesDto.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing a connected agent party with the access packages delegated per role.
+/// </summary>
+public class AgentPackagesDto
+{
+    /// <summary>
+    /// Gets or sets the party
+    /// </summary>
+    [JsonPropertyName("agent")]
+    public CompactEntityDto Agent { get; set; }
+
+    /// <summary>
+    /// Specifies when the <see cref="Agent"/> was added.
+    /// </summary>
+    [JsonPropertyName("agentAddedAt")]
+    public DateTimeOffset AgentAddedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets a collection of all access information for the agent
+    /// </summary>
+    [JsonPropertyName("access")]
+    public List<RoleAccess> Access { get; set; } = [];
+
+    /// <summary>
+    /// Access given through a single role
+    /// </summary>
+    public class RoleAccess
+    {
+        /// <summary>
+        /// Role
+        /// </summary>
+        [JsonPropertyName("role")]
+        public CompactRoleDto Role { get; set; }
+
+        /// <summary>
+        /// Packages
+        /// </summary>
+        [JsonPropertyName("packages")]
+        public List<CompactPackageDto> Packages { get; set; } = [];
+    }
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientDto.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing a connected client party, meaning a party which has been authorized for one or more accesses, either directly or through role(s), access packages, resources or resource instances.
+/// Model can be used both to represent a connection received from another party or a connection provided to another party.
+/// </summary>
+public class ClientDto
+{
+    /// <summary>
+    /// Gets or sets the party
+    /// </summary>
+    [JsonPropertyName("client")]
+    public CompactEntityDto Client { get; set; }
+
+    /// <summary>
+    /// Gets or sets a collection of all access information for the client
+    /// </summary>
+    [JsonPropertyName("access")]
+    public List<RoleAccess> Access { get; set; } = [];
+
+    /// <summary>
+    /// Access given through a single role
+    /// </summary>
+    public class RoleAccess
+    {
+        /// <summary>
+        /// Role
+        /// </summary>
+        [JsonPropertyName("role")]
+        public CompactRoleDto Role { get; set; }
+
+        /// <summary>
+        /// Packages
+        /// </summary>
+        [JsonPropertyName("packages")]
+        public List<CompactPackageDto> Packages { get; set; } = [];
+
+        /// <summary>
+        /// Resources
+        /// </summary>
+        [JsonPropertyName("resources")]
+        public List<CompactResourceDto> Resources { get; set; } = [];
+    }
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientPackagesDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientPackagesDto.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing a connected client party with the access packages delegated per role.
+/// </summary>
+public class ClientPackagesDto
+{
+    /// <summary>
+    /// Gets or sets the party
+    /// </summary>
+    [JsonPropertyName("client")]
+    public CompactEntityDto Client { get; set; }
+
+    /// <summary>
+    /// Gets or sets a collection of all access information for the client
+    /// </summary>
+    [JsonPropertyName("access")]
+    public List<RoleAccess> Access { get; set; } = [];
+
+    /// <summary>
+    /// Access given through a single role
+    /// </summary>
+    public class RoleAccess
+    {
+        /// <summary>
+        /// Role
+        /// </summary>
+        [JsonPropertyName("role")]
+        public CompactRoleDto Role { get; set; }
+
+        /// <summary>
+        /// Packages
+        /// </summary>
+        [JsonPropertyName("packages")]
+        public List<CompactPackageDto> Packages { get; set; } = [];
+    }
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/MyClientDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/MyClientDto.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing the clients available to a party through a provider,
+/// including the accesses delegated for each client.
+/// </summary>
+public class MyClientDto
+{
+    /// <summary>
+    /// Gets or sets the party
+    /// </summary>
+    [JsonPropertyName("provider")]
+    public CompactEntityDto Provider { get; set; }
+
+    /// <summary>
+    /// All clients for given <see cref="Provider"/>.
+    /// </summary>
+    [JsonPropertyName("clients")]
+    public IEnumerable<ClientDto> Clients { get; set; } = [];
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/MyClientProviderDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/MyClientProviderDto.cs
@@ -1,0 +1,52 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing a provider seen from the agent's perspective, meaning a party which has assigned the Agent role to the authenticated user,
+/// making the provider's clients available for delegation to the agent.
+/// </summary>
+public class MyClientProviderDto
+{
+    /// <summary>
+    /// Gets or sets the provider party which has added the authenticated user as an agent
+    /// </summary>
+    [JsonPropertyName("provider")]
+    public CompactEntityDto Provider { get; set; }
+
+    /// <summary>
+    /// Specifies when the <see cref="Provider"/> added the authenticated user as an agent.
+    /// </summary>
+    [JsonPropertyName("providerAddedAt")]
+    public DateTimeOffset ProviderAddedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets a collection of all access information the agent has through the provider
+    /// </summary>
+    [JsonPropertyName("access")]
+    public List<RoleAccess> Access { get; set; } = [];
+
+    /// <summary>
+    /// Access given through a single role
+    /// </summary>
+    public class RoleAccess
+    {
+        /// <summary>
+        /// Role
+        /// </summary>
+        [JsonPropertyName("role")]
+        public CompactRoleDto Role { get; set; }
+
+        /// <summary>
+        /// Packages
+        /// </summary>
+        [JsonPropertyName("packages")]
+        public List<CompactPackageDto> Packages { get; set; } = [];
+
+        /// <summary>
+        /// Resources
+        /// </summary>
+        [JsonPropertyName("resources")]
+        public List<CompactResourceDto> Resources { get; set; } = [];
+    }
+}


### PR DESCRIPTION
Closes #3770

Adds /v2/ endpoints for client delegation that return delegated single resources beside access packages, without touching /v1/.

### API versioning

- `Asp.Versioning.Mvc.ApiExplorer` with URL segment versioning only. v1 is the assumed default, so controllers without version attributes are unchanged, query string versions are ignored and no version headers are added
- One swagger document per discovered version with a version selector in Swagger UI. The v1 document keeps its name and URL for the APIM extraction, and regression tests pin its content: clientdelegation and unversioned controller paths present, no /v2/ paths. The generated v1 document is byte identical to before the change

### V2 endpoints

- `Controllers/V2/ClientDelegationController` mirrors every v1 endpoint under `accessmanagement/api/v2/enduser/clientdelegations` with the same authorization policies, audit attributes and validation. v2 renames the `from` and `to` query parameters to `client` and `agent`, returns a dedicated `MyClientProviderDto` from `my/clientproviders`, and narrows `DELETE my/clients` to one function: removing the whole client relationship (package removal lives on `my/clients/accesspackages`)
- New contract models in an `AccessManagement.V2` namespace: `ClientDto`, `AgentDto` and `MyClientDto` carry `resources` beside `packages` per role and are used by the listing endpoints only, while `clients/accesspackages` and `agents/accesspackages` get package only models (`AgentPackagesDto`, `ClientPackagesDto`) with the same JSON shape as today
- `GetMyClientsV2` and `GetClientsV2` fetch packages and resources as separate row sets and include clients that only have delegated resources; the remaining v2 reads mirror v1 with empty `resources` until the write side (#3771) populates them
- `CompactResourceDto` gained `[JsonPropertyName]` attributes; wire neutral since the type appears in no v1 response

### Endpoint structure

All endpoints live under `accessmanagement/api/v{version}/enduser/clientdelegations`. The first segment declares the perspective: `my/...` is self service where the authenticated party is the subject (`my/clients`, `my/clientproviders`), while the unprefixed endpoints administer a facilitator identified by the `party` query parameter (`clients`, `agents`). The next segment is the relationship sub resource: `accesspackages` carries the package level grants, and #3771 adds `resources` as a sibling. Note that `agents/accesspackages` groups its response by client and `clients/accesspackages` by agent: the path names the direction you ask about, the response pivots on the other end of the relationship. Parties are always query parameters, never path segments, which keeps the paths static for the APIM wildcard rules.

18 new v2 integration tests plus the swagger document tests; the v1 test suites are untouched and green.

### Scope and follow up

The write side (delegating single resources to agents) is deliberately kept out and follows in #3771. This PR's review contract is that /v1/ stays byte identical and everything new is additive: resources cannot appear in live responses yet since nothing creates delegation resources before #3771, and /v2/ stays externally unreachable until the APIM rules are set up. Splitting the two keeps the no behaviour change review separate from the new write behaviour, and lets the finished read surface merge instead of waiting for the write side to be rebuilt against the v2 contracts it introduces.
