### PR TITLE
chore(#3775): connection query cleanup | extract shared filter setup

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -19,6 +19,20 @@ public class ConnectionQuery(AppDbContext db)
     private const int PostgresPlanHintTakeLimit = 100_000_000;
     private List<ConnectionQueryExtendedRecord>? _rightholderAssignments = null;
 
+    /// <summary>
+    /// Shared set of role IDs for accountant/auditor roles used in innehaver connection lookups.
+    /// </summary>
+    private static readonly HashSet<Guid> ReviRegnRoleSet =
+    [
+        RoleConstants.Accountant.Id,
+        RoleConstants.Auditor.Id,
+        RoleConstants.AccountantWithoutSigningRights.Id,
+        RoleConstants.AccountantWithSigningRights.Id,
+        RoleConstants.AccountantSalary.Id,
+        RoleConstants.AssistantAuditor,
+        RoleConstants.AuditorInCharge.Id
+    ];
+
     public async Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthersAsync(ConnectionQueryFilter filter, CancellationToken ct = default)
     {
         return await GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers, ct);
@@ -206,11 +220,11 @@ public class ConnectionQuery(AppDbContext db)
         }
     }
 
-    private IQueryable<ConnectionQueryBaseRecord> BuildBaseQueryFromOthers(AppDbContext db, ConnectionQueryFilter filter, bool doChildNesting, bool applyFromFilter)
+    /// <summary>
+    /// Builds the common filter HashSets used by both query directions.
+    /// </summary>
+    private static (HashSet<Guid>? ViaSet, HashSet<Guid>? ViaRoleSet, HashSet<Guid>? RoleSet, HashSet<Guid> RoleSetExclude) BuildFilterSets(ConnectionQueryFilter filter)
     {
-        var toId = filter.ToIds.First();
-        var fromSet = filter.FromIds?.Count > 0 ? new HashSet<Guid>(filter.FromIds) : null;
-        var fromSetForDelegation = fromSet != null && filter.IncludeDelegation ? new HashSet<Guid>(fromSet) : [];
         var viaSet = filter.ViaIds?.Count > 0 ? new HashSet<Guid>(filter.ViaIds) : null;
         var viaRoleSet = filter.ViaRoleIds?.Count > 0 ? new HashSet<Guid>(filter.ViaRoleIds) : null;
         var roleSet = filter.RoleIds?.Count > 0 ? new HashSet<Guid>(filter.RoleIds) : null;
@@ -220,6 +234,16 @@ public class ConnectionQuery(AppDbContext db)
         {
             roleSetExclude.Add(RoleConstants.AppControlledRightholder.Id); // App-controlled instance access should be excluded if not explicitly requested.
         }
+
+        return (viaSet, viaRoleSet, roleSet, roleSetExclude);
+    }
+
+    private IQueryable<ConnectionQueryBaseRecord> BuildBaseQueryFromOthers(AppDbContext db, ConnectionQueryFilter filter, bool doChildNesting, bool applyFromFilter)
+    {
+        var toId = filter.ToIds.First();
+        var fromSet = filter.FromIds?.Count > 0 ? new HashSet<Guid>(filter.FromIds) : null;
+        var fromSetForDelegation = fromSet != null && filter.IncludeDelegation ? new HashSet<Guid>(fromSet) : [];
+        var (viaSet, viaRoleSet, roleSet, roleSetExclude) = BuildFilterSets(filter);
 
         if (fromSet != null && filter.IncludeDelegation)
         {
@@ -240,17 +264,6 @@ public class ConnectionQuery(AppDbContext db)
                 .ToList();
             fromSetForDelegation.UnionWith(enksOfInnh);
         }
-
-        var reviRegnRoleSet = new HashSet<Guid>
-        {
-            RoleConstants.Accountant.Id,
-            RoleConstants.Auditor.Id,
-            RoleConstants.AccountantWithoutSigningRights.Id,
-            RoleConstants.AccountantWithSigningRights.Id,
-            RoleConstants.AccountantSalary.Id,
-            RoleConstants.AssistantAuditor,
-            RoleConstants.AuditorInCharge.Id
-        };
 
         var direct =
             db.Assignments
@@ -394,7 +407,7 @@ public class ConnectionQuery(AppDbContext db)
             join innehaverConnection in db.Assignments on reviRegnConnection.FromId equals innehaverConnection.FromId
             join innehaver in db.Entities on innehaverConnection.ToId equals innehaver.Id
             join enk in db.Entities on innehaverConnection.FromId equals enk.Id
-            where reviRegnRoleSet.Contains(reviRegnConnection.RoleId)
+            where ReviRegnRoleSet.Contains(reviRegnConnection.RoleId)
                 && innehaverConnection.RoleId == RoleConstants.Innehaver.Id
                 && enk.VariantId == EntityVariantConstants.ENK.Id
                 && innehaver.DateOfDeath == null
@@ -452,15 +465,7 @@ public class ConnectionQuery(AppDbContext db)
 
         var fromId = filter.FromIds.First();
         var toSet = filter.ToIds?.Count > 0 ? new HashSet<Guid>(filter.ToIds) : null;
-        var viaSet = filter.ViaIds?.Count > 0 ? new HashSet<Guid>(filter.ViaIds) : null;
-        var viaRoleSet = filter.ViaRoleIds?.Count > 0 ? new HashSet<Guid>(filter.ViaRoleIds) : null;
-        var roleSet = filter.RoleIds?.Count > 0 ? new HashSet<Guid>(filter.RoleIds) : null;
-        var roleSetExclude = filter.ExcludeRoleIds?.Count > 0 ? new HashSet<Guid>(filter.ExcludeRoleIds) : [];
-        roleSetExclude.Add(RoleConstants.Supplier.Id); // Supplier role should never be included in results as it is only used for maskinporten schemas.
-        if (!filter.IncludeAppControlledInstances)
-        {
-            roleSetExclude.Add(RoleConstants.AppControlledRightholder.Id); // App-controlled instance access should be excluded if not explicitly requested.
-        }
+        var (viaSet, viaRoleSet, roleSet, roleSetExclude) = BuildFilterSets(filter);
 
         /*
         Direct Assignments

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -29,10 +29,10 @@ public class ConnectionQuery(AppDbContext db)
         RoleConstants.AccountantWithoutSigningRights.Id,
         RoleConstants.AccountantWithSigningRights.Id,
         RoleConstants.AccountantSalary.Id,
-        RoleConstants.AssistantAuditor,
+        RoleConstants.AssistantAuditor.Id,
         RoleConstants.AuditorInCharge.Id
     ];
-
+     
     public async Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthersAsync(ConnectionQueryFilter filter, CancellationToken ct = default)
     {
         return await GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers, ct);

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -32,7 +32,7 @@ public class ConnectionQuery(AppDbContext db)
         RoleConstants.AssistantAuditor.Id,
         RoleConstants.AuditorInCharge.Id
     ];
-     
+    
     public async Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthersAsync(ConnectionQueryFilter filter, CancellationToken ct = default)
     {
         return await GetConnectionsAsync(filter, ConnectionQueryDirection.FromOthers, ct);


### PR DESCRIPTION
## Extract shared filter setup helper (`ConnectionQuery`)

Closes #3775 — part of the [ConnectionQuery cleanup feature](#3756).

### Problem

Both `BuildBaseQueryFromOthers` and `BuildBaseQueryToOthers` independently constructed identical role-exclusion sets and converted filter collections to `HashSet<Guid>`. The `reviRegnRoleSet` was defined inline in `BuildBaseQueryFromOthers` only. This duplication was easy to get out of sync.

### Changes

- **`ReviRegnRoleSet` static field** — the accountant/auditor role set is now a single `private static readonly HashSet<Guid>` on the class.
- **`BuildFilterSets` static helper** — builds the shared `viaSet`, `viaRoleSet`, `roleSet`, and `roleSetExclude` (Supplier always excluded, AppControlledRightholder conditionally excluded).
- **`BuildBaseQueryFromOthers`** — uses `BuildFilterSets` + `ReviRegnRoleSet`.
- **`BuildBaseQueryToOthers`** — uses `BuildFilterSets`.

### Constraints

- Pure extract-method refactoring — no change in ~~generated SQL or~~ query results. (minor change in generated SQL introduced for the use of the ReviRegnRoleSet)
- All 305 `ConnectionQueryTests` integration tests pass unchanged.