### PR TITLE
chore(#3776,#3777): connection query cleanup | extract package and resource loaders

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionIndex.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionIndex.cs
@@ -1,0 +1,33 @@
+﻿using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
+
+namespace Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
+
+internal sealed class ConnectionIndex<T>
+{
+    private readonly Dictionary<ConnectionCompositeKey, List<T>> map = new();
+
+    public void Add(ConnectionCompositeKey key, T item)
+    {
+        if (!map.TryGetValue(key, out var list))
+        {
+            map[key] = list = new List<T>(4);
+        }
+
+        list.Add(item);
+    }
+
+    public void AddRange(ConnectionCompositeKey key, IEnumerable<T> items)
+    {
+        if (!map.TryGetValue(key, out var list))
+        {
+            map[key] = list = new List<T>();
+        }
+
+        list.AddRange(items);
+    }
+
+    public IReadOnlyList<T> Get(ConnectionCompositeKey key) =>
+        map.TryGetValue(key, out var list) ? list : Array.Empty<T>();
+
+    public IEnumerable<KeyValuePair<ConnectionCompositeKey, List<T>>> Pairs => map;
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionPackageLoader.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionPackageLoader.cs
@@ -19,7 +19,7 @@ internal class ConnectionPackageLoader(AppDbContext db)
         var packageSet = filter.PackageIds?.Count > 0 ? new HashSet<Guid>(filter.PackageIds) : null;
         var index = new ConnectionIndex<ConnectionQueryPackage>();
 
-        var assignmentPackageKeys = keys.Where(k => k.AssignmentId.HasValue && k.RoleId == RoleConstants.Rightholder).Select(k => k.AssignmentId).Distinct().ToList();
+        var assignmentPackageKeys = keys.Where(k => k.AssignmentId.HasValue && k.RoleId == RoleConstants.Rightholder).Select(k => k.AssignmentId!.Value).Distinct().ToHashSet();
 
         SortedList<Guid, List<Guid>> assignmentPackages = [];
         SortedSet<Guid> assignmentPackageIds = [];
@@ -44,7 +44,7 @@ internal class ConnectionPackageLoader(AppDbContext db)
             }
         }
 
-        var rolePackageKeys = keys.Where(k => k.AssignmentId.HasValue).Select(k => k.RoleId).Distinct().ToList();
+        var rolePackageKeys = keys.Where(k => k.AssignmentId.HasValue).Select(k => k.RoleId).Distinct().ToHashSet();
         var rolePackagesRaw = await db.RolePackages.Where(r => r.HasAccess && rolePackageKeys.Contains(r.RoleId))
             .WhereIf(packageSet is not null, p => packageSet!.Contains(p.PackageId))
             .Select(rp => new { rp.PackageId, rp.RoleId, rp.EntityVariantId })
@@ -87,7 +87,7 @@ internal class ConnectionPackageLoader(AppDbContext db)
         }
 
         SortedList<Guid, Guid> entityVariants = [];
-        var entityKeys = keys.Where(k => k.AssignmentId.HasValue && rolePackagesForEntity.ContainsKey(k.RoleId)).Select(k => k.FromId).Distinct().ToList();
+        var entityKeys = keys.Where(k => k.AssignmentId.HasValue && rolePackagesForEntity.ContainsKey(k.RoleId)).Select(k => k.FromId).Distinct().ToHashSet();
         if (entityKeys.Count > 0)
         {
             var entityVariantsRaw = await db.Entities.Where(e => entityKeys.Contains(e.Id))
@@ -99,7 +99,7 @@ internal class ConnectionPackageLoader(AppDbContext db)
             }
         }
 
-        var delegationIds = keys.Select(k => k.DelegationId).Where(id => id != null).Distinct().ToList();
+        var delegationIds = keys.Select(k => k.DelegationId).Where(id => id != null).Select(id => id!.Value).Distinct().ToHashSet();
         var delegationPackagesRaw = delegationIds.Count == 0 ? [] :
             await db.DelegationPackages.Where(d => delegationIds.Contains(d.DelegationId))
             .WhereIf(packageSet is not null, p => packageSet!.Contains(p.PackageId))

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionPackageLoader.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionPackageLoader.cs
@@ -1,0 +1,250 @@
+﻿using Altinn.AccessMgmt.PersistenceEF.Constants;
+using Altinn.AccessMgmt.PersistenceEF.Contexts;
+using Altinn.AccessMgmt.PersistenceEF.Extensions;
+using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
+
+/// <summary>
+/// Responsible for loading packages and enriching them with resources for connection query results.
+/// </summary>
+internal class ConnectionPackageLoader(AppDbContext db)
+{
+    /// <summary>
+    /// Loads packages for each connection key based on assignment packages, role packages, and delegation packages.
+    /// </summary>
+    public async Task<ConnectionIndex<ConnectionQueryPackage>> LoadPackagesByKeyAsync(IEnumerable<ConnectionQueryExtendedRecord> keys, ConnectionQueryFilter filter, CancellationToken ct)
+    {
+        var packageSet = filter.PackageIds?.Count > 0 ? new HashSet<Guid>(filter.PackageIds) : null;
+        var index = new ConnectionIndex<ConnectionQueryPackage>();
+
+        var assignmentPackageKeys = keys.Where(k => k.AssignmentId.HasValue && k.RoleId == RoleConstants.Rightholder).Select(k => k.AssignmentId).Distinct().ToList();
+
+        SortedList<Guid, List<Guid>> assignmentPackages = [];
+        SortedSet<Guid> assignmentPackageIds = [];
+        if (assignmentPackageKeys.Count > 0)
+        {
+            var assignmentPackagesRaw = await db.AssignmentPackages.Where(a => assignmentPackageKeys.Contains(a.AssignmentId))
+                .WhereIf(packageSet is not null, p => packageSet!.Contains(p.PackageId))
+                .Select(ap => new { ap.PackageId, ap.AssignmentId })
+                .ToListAsync(ct);
+
+            foreach (var assignmentPackage in assignmentPackagesRaw)
+            {
+                assignmentPackageIds.Add(assignmentPackage.PackageId);
+                if (assignmentPackages.TryGetValue(assignmentPackage.AssignmentId, out var ids))
+                {
+                    ids.Add(assignmentPackage.PackageId);
+                }
+                else
+                {
+                    assignmentPackages.Add(assignmentPackage.AssignmentId, [assignmentPackage.PackageId]);
+                }
+            }
+        }
+
+        var rolePackageKeys = keys.Where(k => k.AssignmentId.HasValue).Select(k => k.RoleId).Distinct().ToList();
+        var rolePackagesRaw = await db.RolePackages.Where(r => r.HasAccess && rolePackageKeys.Contains(r.RoleId))
+            .WhereIf(packageSet is not null, p => packageSet!.Contains(p.PackageId))
+            .Select(rp => new { rp.PackageId, rp.RoleId, rp.EntityVariantId })
+            .ToListAsync(ct);
+        SortedList<Guid, List<Guid>> rolePackagesForAll = [];
+        SortedList<Guid, Dictionary<Guid, List<Guid>>> rolePackagesForEntity = [];
+        SortedSet<Guid> rolePackageIds = [];
+        foreach (var rolePackage in rolePackagesRaw)
+        {
+            rolePackageIds.Add(rolePackage.PackageId);
+            if (rolePackage.EntityVariantId == null)
+            {
+                if (rolePackagesForAll.TryGetValue(rolePackage.RoleId, out var ids))
+                {
+                    ids.Add(rolePackage.PackageId);
+                }
+                else
+                {
+                    rolePackagesForAll.Add(rolePackage.RoleId, [rolePackage.PackageId]);
+                }
+            }
+            else
+            {
+                if (rolePackagesForEntity.TryGetValue(rolePackage.RoleId, out var variantDict))
+                {
+                    if (variantDict.TryGetValue((Guid)rolePackage.EntityVariantId, out var ids))
+                    {
+                        ids.Add(rolePackage.PackageId);
+                    }
+                    else
+                    {
+                        variantDict.Add((Guid)rolePackage.EntityVariantId, [rolePackage.PackageId]);
+                    }
+                }
+                else
+                {
+                    rolePackagesForEntity.Add(rolePackage.RoleId, new() { { (Guid)rolePackage.EntityVariantId, [rolePackage.PackageId] } });
+                }
+            }
+        }
+
+        SortedList<Guid, Guid> entityVariants = [];
+        var entityKeys = keys.Where(k => k.AssignmentId.HasValue && rolePackagesForEntity.ContainsKey(k.RoleId)).Select(k => k.FromId).Distinct().ToList();
+        if (entityKeys.Count > 0)
+        {
+            var entityVariantsRaw = await db.Entities.Where(e => entityKeys.Contains(e.Id))
+                .Select(e => new { e.Id, e.VariantId })
+                .ToListAsync(ct);
+            foreach (var entityVariant in entityVariantsRaw)
+            {
+                entityVariants[entityVariant.Id] = entityVariant.VariantId;
+            }
+        }
+
+        var delegationIds = keys.Select(k => k.DelegationId).Where(id => id != null).Distinct().ToList();
+        var delegationPackagesRaw = delegationIds.Count == 0 ? [] :
+            await db.DelegationPackages.Where(d => delegationIds.Contains(d.DelegationId))
+            .WhereIf(packageSet is not null, p => packageSet!.Contains(p.PackageId))
+            .Select(d => new { d.PackageId, d.DelegationId })
+            .ToListAsync(ct);
+        SortedList<Guid, List<Guid>> delegationPackages = [];
+        SortedSet<Guid> delegationPackageIds = [];
+        foreach (var delegationPackage in delegationPackagesRaw)
+        {
+            delegationPackageIds.Add(delegationPackage.PackageId);
+            if (delegationPackages.TryGetValue(delegationPackage.DelegationId, out var ids))
+            {
+                ids.Add(delegationPackage.PackageId);
+            }
+            else
+            {
+                delegationPackages.Add(delegationPackage.DelegationId, [delegationPackage.PackageId]);
+            }
+        }
+
+        var packageIds = assignmentPackageIds
+            .Union(rolePackageIds)
+            .Union(delegationPackageIds)
+            .Distinct()
+            .ToList();
+
+        var packagesRaw = await db.Packages.Where(p => packageIds.Contains(p.Id)).Select(p => new { p.Id, p.Name, p.AreaId, p.Urn }).ToListAsync(ct);
+        SortedList<Guid, ConnectionQueryPackage> packages = [];
+        foreach (var package in packagesRaw)
+        {
+            packages[package.Id] = new() { Id = package.Id, Name = package.Name, AreaId = package.AreaId, Urn = package.Urn };
+        }
+
+        foreach (var key in keys)
+        {
+            IEnumerable<Guid> keyPackageIds = [];
+
+            if (!key.AssignmentId.HasValue)
+            {
+                // if connection record is a client delegation, we only need to consider delegationpackages, and not from assignment or role packages.
+                var clientDelegationPackages = key.DelegationId.HasValue
+                 ? (key.DelegationId != null && delegationPackages.ContainsKey((Guid)key.DelegationId)) ? delegationPackages[(Guid)key.DelegationId] : []
+                 : [];
+
+                keyPackageIds = clientDelegationPackages.Distinct();
+            }
+            else if (key.AssignmentId.HasValue && key.RoleId == RoleConstants.Rightholder.Id)
+            {
+                // if connection is for rightholder we only need to consider assignment packages and not role packages or client delegations
+                var assPackages = key.AssignmentId.HasValue
+                     ? assignmentPackages.ContainsKey((Guid)key.AssignmentId) ? assignmentPackages[(Guid)key.AssignmentId] : []
+                     : [];
+
+                keyPackageIds = assPackages.Distinct();
+            }
+            else
+            {
+                // else we need to consider check for role packages
+                List<Guid> rolePackagesForEntityForKey = [];
+                if (rolePackagesForEntity.TryGetValue(key.RoleId, out var entityDict)
+                    && entityDict.TryGetValue(entityVariants[key.FromId], out var entityIds))
+                {
+                    rolePackagesForEntityForKey = entityIds;
+                }
+
+                keyPackageIds = (rolePackagesForAll.TryGetValue(key.RoleId, out List<Guid> packagesForAll) ? packagesForAll : [])
+                        .Union(rolePackagesForEntityForKey).Distinct();
+            }
+
+            if (!keyPackageIds.Any())
+            {
+                continue;
+            }
+
+            List<ConnectionQueryPackage> keyPackages = [];
+            foreach (var id in keyPackageIds)
+            {
+                keyPackages.Add(packages[id]);
+            }
+
+            index.AddRange(new(key.FromId, key.ToId, key.RoleId, key.AssignmentId, key.DelegationId, key.ViaId, key.ViaRoleId), keyPackages);
+        }
+
+        return index;
+    }
+
+    /// <summary>
+    /// Enriches packages in the index with their associated resources.
+    /// </summary>
+    public async Task EnrichPackageResourcesAsync(ConnectionIndex<ConnectionQueryPackage> packageIndex, ConnectionQueryFilter filter, CancellationToken ct = default)
+    {
+        var packageIds = packageIndex.Pairs
+            .SelectMany(kv => kv.Value)
+            .Select(p => p.Id)
+            .Distinct()
+            .ToList();
+
+        if (packageIds.Count == 0)
+        {
+            return;
+        }
+
+        var resourceSet = filter.ResourceIds is { Count: > 0 }
+            ? new HashSet<Guid>(filter.ResourceIds!)
+            : null;
+
+        var rows = await db.PackageResources
+            .Where(pr => packageIds.Contains(pr.PackageId))
+            .WhereIf(resourceSet is not null, pr => resourceSet!.Contains(pr.ResourceId))
+            .Join(db.Resources, pr => pr.ResourceId, r => r.Id, (pr, r) => new
+            {
+                pr.PackageId,
+                Resource = new ConnectionQueryResource { Id = r.Id, Name = r.Name }
+            })
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        var resourcesByPackage = rows
+            .GroupBy(x => x.PackageId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(z => z.Resource).DistinctBy(r => r.Id).ToList()
+            );
+
+        foreach (var kv in packageIndex.Pairs)
+        {
+            var packages = kv.Value;
+
+            foreach (var pkg in packages.ToList())
+            {
+                if (resourcesByPackage.TryGetValue(pkg.Id, out var list))
+                {
+                    pkg.Resources = list.ToList();
+                }
+                else
+                {
+                    pkg.Resources = new List<ConnectionQueryResource>(capacity: 0);
+                }
+            }
+
+            // Fjern tomme pakker hvis IncludePackages er false
+            if (!filter.IncludePackages)
+            {
+                kv.Value.RemoveAll(p => p.Resources.Count == 0);
+            }
+        }
+    }
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -17,7 +17,7 @@ public class ConnectionQuery(AppDbContext db)
     // It looks like the same join order is chosen no matter if we use a low value (1) or a very large value. A very large value is
     // chosen to ensure that the cutoff doesn't really reduce the result set.
     private const int PostgresPlanHintTakeLimit = 100_000_000;
-    private List<ConnectionQueryExtendedRecord>? _rightholderAssignments = null;
+    private readonly ConnectionResourceLoader _resourceLoader = new(db);
 
     public async Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthersAsync(ConnectionQueryFilter filter, CancellationToken ct = default)
     {
@@ -121,7 +121,6 @@ public class ConnectionQuery(AppDbContext db)
     {
         try
         {
-            _rightholderAssignments = null;
             bool delayChildNesting = true;
             bool delayFromFilter = true;
             if (direction == ConnectionQueryDirection.ToOthers || (filter.FromIds?.Count > 0 && filter.FromIds?.Count <= 20))
@@ -167,7 +166,7 @@ public class ConnectionQuery(AppDbContext db)
             {
                 if (filter.IncludeResources)
                 {
-                    result = await LoadResourcesByKeyAsync(result, filter, ct);
+                    result = await _resourceLoader.LoadResourcesByKeyAsync(result, filter, ct);
                 }
             }
             catch (Exception ex)
@@ -179,7 +178,7 @@ public class ConnectionQuery(AppDbContext db)
             {
                 if (filter.IncludeInstances)
                 {
-                    result = await LoadInstancesByKeyAsync(result, filter, ct);
+                    result = await _resourceLoader.LoadInstancesByKeyAsync(result, filter, ct);
                 }
             }
             catch (Exception ex)
@@ -953,154 +952,7 @@ public class ConnectionQuery(AppDbContext db)
         return index;
     }
 
-    private async Task<List<ConnectionQueryExtendedRecord>> LoadResourcesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, ConnectionQueryFilter filter, CancellationToken ct)
-    {
-        var resourceSet = filter.ResourceIds?.Count > 0 ? new HashSet<Guid>(filter.ResourceIds) : null;
 
-        var rightholderAssignments = GetRightholderAssignments(allKeys, filter);
-        var rightholderAssignmentIds = rightholderAssignments.Select(a => (Guid)a.AssignmentId).Distinct().ToList();
-        if (rightholderAssignmentIds.Count == 0)
-        {
-            return allKeys;
-        }
-
-        var assignmentResources = await db.AssignmentResources
-            .Where(ai => rightholderAssignmentIds.Contains(ai.AssignmentId))
-            .Select(ai => new { ai.AssignmentId, ai.Id, ai.ResourceId })
-            .WhereIf(resourceSet is not null, x => resourceSet!.Contains(x.ResourceId))
-            .Join(db.Resources, x => x.ResourceId, r => r.Id, (x, r) => new
-            {
-                x.AssignmentId,
-                r.Id,
-                r.Name,
-                r.RefId
-            })
-            .AsNoTracking()
-            .ToListAsync(ct);
-
-        SortedList<Guid, List<ConnectionQueryResource>> resourcesByAssignment = [];
-        foreach (var ai in assignmentResources)
-        {
-            if (resourcesByAssignment.TryGetValue(ai.AssignmentId, out var list))
-            {
-                list.Add(new ConnectionQueryResource()
-                {
-                    Id = ai.Id,
-                    Name = ai.Name,
-                    RefId = ai.RefId
-                });
-            }
-            else
-            {
-                resourcesByAssignment[ai.AssignmentId] =
-                [
-                    new ConnectionQueryResource()
-                    {
-                        Id = ai.Id,
-                        Name = ai.Name,
-                        RefId = ai.RefId
-                    }
-                ];
-            }
-        }
-
-        foreach (var key in allKeys)
-        {
-            if (key.AssignmentId.HasValue && resourcesByAssignment.TryGetValue((Guid)key.AssignmentId!, out var list))
-            {
-                key.Resources = list;
-            }
-        }
-
-        return allKeys;
-    }
-
-    private async Task<List<ConnectionQueryExtendedRecord>> LoadInstancesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, ConnectionQueryFilter filter, CancellationToken ct)
-    {
-        var instanceSet = filter.InstanceIds?.Count > 0 ? new HashSet<string>(filter.InstanceIds) : null;
-        var resourceSet = filter.ResourceIds?.Count > 0 ? new HashSet<Guid>(filter.ResourceIds) : null;
-
-        // Assignment → AssignmentInstance
-        var rightholderAssignments = GetRightholderAssignments(allKeys, filter);
-        var rightholderAssignmentIds = rightholderAssignments.Where(a => a.Reason != ConnectionReason.Hierarchy && !a.IsMainUnitAccess).Select(a => (Guid)a.AssignmentId).Distinct().ToList();
-        if (rightholderAssignmentIds.Count == 0)
-        {
-            return allKeys;
-        }
-
-        var assignmentInstances = await db.AssignmentInstances
-            .Where(ai => rightholderAssignmentIds.Contains(ai.AssignmentId))
-            .Select(ai => new { ai.AssignmentId, ai.Id, ai.ResourceId, ai.InstanceId })
-            .WhereIf(instanceSet is not null, x => instanceSet!.Contains(x.InstanceId))
-            .WhereIf(resourceSet is not null, x => resourceSet!.Contains(x.ResourceId))
-            .Join(db.Resources, x => x.ResourceId, r => r.Id, (x, r) => new
-            {
-                x.AssignmentId,
-                x.Id,
-                x.ResourceId,
-                x.InstanceId,
-                ResourceName = r.Name,
-                ResourceRefId = r.RefId
-            })
-            .AsNoTracking()
-            .ToListAsync(ct);
-
-        SortedList<Guid, List<ConnectionQueryInstance>> instancesByAssignment = [];
-        foreach (var ai in assignmentInstances)
-        {
-            if (instancesByAssignment.TryGetValue(ai.AssignmentId, out var list))
-            {
-                list.Add(new ConnectionQueryInstance()
-                {
-                    Id = ai.Id,
-                    ResourceId = ai.ResourceId,
-                    InstanceId = ai.InstanceId,
-                    ResourceName = ai.ResourceName,
-                    ResourceRefId = ai.ResourceRefId
-                });
-            }
-            else
-            {
-                instancesByAssignment[ai.AssignmentId] =
-                [
-                    new ConnectionQueryInstance()
-                    {
-                        Id = ai.Id,
-                        ResourceId = ai.ResourceId,
-                        InstanceId = ai.InstanceId,
-                        ResourceName = ai.ResourceName,
-                        ResourceRefId = ai.ResourceRefId
-                    }
-                ];
-            }
-        }
-
-        foreach (var key in allKeys.Where(k => k.AssignmentId.HasValue && rightholderAssignmentIds.Contains((Guid)k.AssignmentId) && k.Reason != ConnectionReason.Hierarchy && !k.IsMainUnitAccess))
-        {
-            if (key.AssignmentId.HasValue && instancesByAssignment.TryGetValue((Guid)key.AssignmentId!, out var list))
-            {
-                key.Instances = list;
-            }
-        }
-
-        return allKeys;
-    }
-
-    private List<ConnectionQueryExtendedRecord> GetRightholderAssignments(List<ConnectionQueryExtendedRecord> allKeys, ConnectionQueryFilter filter)
-    {
-        List<Guid> rightholderRoles = [RoleConstants.Rightholder.Id];
-        if (filter.IncludeAppControlledInstances)
-        {
-            rightholderRoles.Add(RoleConstants.AppControlledRightholder.Id);
-        }
-
-        if (_rightholderAssignments is null)
-        {
-            _rightholderAssignments = allKeys.Where(a => a.AssignmentId.HasValue && rightholderRoles.Contains(a.RoleId)).ToList();
-        }
-
-        return _rightholderAssignments;
-    }
 
     private async Task EnrichPackageResourcesAsync(ConnectionIndex<ConnectionQueryPackage> packageIndex, ConnectionQueryFilter filter, CancellationToken ct = default)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -171,7 +171,11 @@ public class ConnectionQuery(AppDbContext db)
                 {
                     if (filter.IncludeResources)
                     {
-                        result = await _resourceLoader.LoadResourcesByKeyAsync(result, rightholderAssignments, filter, ct);
+                        var rightholderAssignmentIds = rightholderAssignments.Select(a => (Guid)a.AssignmentId).Distinct().ToHashSet();
+                        if (rightholderAssignmentIds.Count > 0)
+                        {
+                            result = await _resourceLoader.LoadResourcesByKeyAsync(result, rightholderAssignmentIds, filter, ct);
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -183,7 +187,11 @@ public class ConnectionQuery(AppDbContext db)
                 {
                     if (filter.IncludeInstances)
                     {
-                        result = await _resourceLoader.LoadInstancesByKeyAsync(result, rightholderAssignments, filter, ct);
+                        var rightholderAssignmentIds = rightholderAssignments.Where(a => a.Reason != ConnectionReason.Hierarchy && !a.IsMainUnitAccess).Select(a => (Guid)a.AssignmentId).Distinct().ToHashSet();
+                        if (rightholderAssignmentIds.Count > 0)
+                        {
+                            result = await _resourceLoader.LoadInstancesByKeyAsync(result, rightholderAssignmentIds, filter, ct);
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -812,7 +820,6 @@ public class ConnectionQuery(AppDbContext db)
         IsRoleMap = x.IsRoleMap
     };
 }
-
 
 internal static class ConnectionQueryExtensions
 {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -163,28 +163,33 @@ public class ConnectionQuery(AppDbContext db)
                 }
             }
 
-            try
+            if (filter.IncludeResources || filter.IncludeInstances)
             {
-                if (filter.IncludeResources)
-                {
-                    result = await _resourceLoader.LoadResourcesByKeyAsync(result, filter, ct);
-                }
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException("Failed to include resources", ex);
-            }
+                var rightholderAssignments = ConnectionResourceLoader.GetRightholderAssignments(result, filter);
 
-            try
-            {
-                if (filter.IncludeInstances)
+                try
                 {
-                    result = await _resourceLoader.LoadInstancesByKeyAsync(result, filter, ct);
+                    if (filter.IncludeResources)
+                    {
+                        result = await _resourceLoader.LoadResourcesByKeyAsync(result, rightholderAssignments, filter, ct);
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException("Failed to include instances", ex);
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException("Failed to include resources", ex);
+                }
+
+                try
+                {
+                    if (filter.IncludeInstances)
+                    {
+                        result = await _resourceLoader.LoadInstancesByKeyAsync(result, rightholderAssignments, filter, ct);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException("Failed to include instances", ex);
+                }
             }
 
             if (filter.EnrichEntities)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -18,6 +18,7 @@ public class ConnectionQuery(AppDbContext db)
     // chosen to ensure that the cutoff doesn't really reduce the result set.
     private const int PostgresPlanHintTakeLimit = 100_000_000;
     private readonly ConnectionResourceLoader _resourceLoader = new(db);
+    private readonly ConnectionPackageLoader _packageLoader = new(db);
 
     public async Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthersAsync(ConnectionQueryFilter filter, CancellationToken ct = default)
     {
@@ -142,10 +143,10 @@ public class ConnectionQuery(AppDbContext db)
             {
                 try
                 {
-                    var pkgs = await LoadPackagesByKeyAsync(result, filter, ct);
+                    var pkgs = await _packageLoader.LoadPackagesByKeyAsync(result, filter, ct);
                     if (filter.EnrichPackageResources)
                     {
-                        await EnrichPackageResourcesAsync(pkgs, filter, ct);
+                        await _packageLoader.EnrichPackageResourcesAsync(pkgs, filter, ct);
                     }
 
                     result = Attach(result, pkgs, p => p.Id, (dto, list) => dto.Packages = list);
@@ -780,239 +781,6 @@ public class ConnectionQuery(AppDbContext db)
         return keysWithChildren;
     }
 
-    private async Task<ConnectionIndex<ConnectionQueryPackage>> LoadPackagesByKeyAsync(IEnumerable<ConnectionQueryExtendedRecord> keys, ConnectionQueryFilter filter, CancellationToken ct)
-    {
-        var packageSet = filter.PackageIds?.Count > 0 ? new HashSet<Guid>(filter.PackageIds) : null;
-        var index = new ConnectionIndex<ConnectionQueryPackage>();
-
-        var assignmentPackageKeys = keys.Where(k => k.AssignmentId.HasValue && k.RoleId == RoleConstants.Rightholder).Select(k => k.AssignmentId).Distinct().ToList();
-
-        SortedList<Guid, List<Guid>> assignmentPackages = [];
-        SortedSet<Guid> assignmentPackageIds = [];
-        if (assignmentPackageKeys.Count > 0)
-        {
-            var assignmentPackagesRaw = await db.AssignmentPackages.Where(a => assignmentPackageKeys.Contains(a.AssignmentId))
-                .WhereIf(packageSet is not null, p => packageSet!.Contains(p.PackageId))
-                .Select(ap => new { ap.PackageId, ap.AssignmentId })
-                .ToListAsync(ct);
-
-            foreach (var assignmentPackage in assignmentPackagesRaw)
-            {
-                assignmentPackageIds.Add(assignmentPackage.PackageId);
-                if (assignmentPackages.TryGetValue(assignmentPackage.AssignmentId, out var ids))
-                {
-                    ids.Add(assignmentPackage.PackageId);
-                }
-                else
-                {
-                    assignmentPackages.Add(assignmentPackage.AssignmentId, [assignmentPackage.PackageId]);
-                }
-            }
-        }
-
-        var rolePackageKeys = keys.Where(k => k.AssignmentId.HasValue).Select(k => k.RoleId).Distinct().ToList();
-        var rolePackagesRaw = await db.RolePackages.Where(r => r.HasAccess && rolePackageKeys.Contains(r.RoleId))
-            .WhereIf(packageSet is not null, p => packageSet!.Contains(p.PackageId))
-            .Select(rp => new { rp.PackageId, rp.RoleId, rp.EntityVariantId })
-            .ToListAsync(ct);
-        SortedList<Guid, List<Guid>> rolePackagesForAll = [];
-        SortedList<Guid, Dictionary<Guid, List<Guid>>> rolePackagesForEntity = [];
-        SortedSet<Guid> rolePackageIds = [];
-        foreach (var rolePackage in rolePackagesRaw)
-        {
-            rolePackageIds.Add(rolePackage.PackageId);
-            if (rolePackage.EntityVariantId == null)
-            {
-                if (rolePackagesForAll.TryGetValue(rolePackage.RoleId, out var ids))
-                {
-                    ids.Add(rolePackage.PackageId);
-                }
-                else
-                {
-                    rolePackagesForAll.Add(rolePackage.RoleId, [rolePackage.PackageId]);
-                }
-            }
-            else
-            {
-                if (rolePackagesForEntity.TryGetValue(rolePackage.RoleId, out var variantDict))
-                {
-                    if (variantDict.TryGetValue((Guid)rolePackage.EntityVariantId, out var ids))
-                    {
-                        ids.Add(rolePackage.PackageId);
-                    }
-                    else
-                    {
-                        variantDict.Add((Guid)rolePackage.EntityVariantId, [rolePackage.PackageId]);
-                    }
-                }
-                else
-                {
-                    rolePackagesForEntity.Add(rolePackage.RoleId, new() { { (Guid)rolePackage.EntityVariantId, [rolePackage.PackageId] } });
-                }
-            }
-        }
-
-        SortedList<Guid, Guid> entityVariants = [];
-        var entityKeys = keys.Where(k => k.AssignmentId.HasValue && rolePackagesForEntity.ContainsKey(k.RoleId)).Select(k => k.FromId).Distinct().ToList();
-        if (entityKeys.Count > 0)
-        {
-            var entityVariantsRaw = await db.Entities.Where(e => entityKeys.Contains(e.Id))
-                .Select(e => new { e.Id, e.VariantId })
-                .ToListAsync(ct);
-            foreach (var entityVariant in entityVariantsRaw)
-            {
-                entityVariants[entityVariant.Id] = entityVariant.VariantId;
-            }
-        }
-
-        var delegationIds = keys.Select(k => k.DelegationId).Where(id => id != null).Distinct().ToList();
-        var delegationPackagesRaw = delegationIds.Count == 0 ? [] :
-            await db.DelegationPackages.Where(d => delegationIds.Contains(d.DelegationId))
-            .WhereIf(packageSet is not null, p => packageSet!.Contains(p.PackageId))
-            .Select(d => new { d.PackageId, d.DelegationId })
-            .ToListAsync(ct);
-        SortedList<Guid, List<Guid>> delegationPackages = [];
-        SortedSet<Guid> delegationPackageIds = [];
-        foreach (var delegationPackage in delegationPackagesRaw)
-        {
-            delegationPackageIds.Add(delegationPackage.PackageId);
-            if (delegationPackages.TryGetValue(delegationPackage.DelegationId, out var ids))
-            {
-                ids.Add(delegationPackage.PackageId);
-            }
-            else
-            {
-                delegationPackages.Add(delegationPackage.DelegationId, [delegationPackage.PackageId]);
-            }
-        }
-
-        var packageIds = assignmentPackageIds
-            .Union(rolePackageIds)
-            .Union(delegationPackageIds)
-            .Distinct()
-            .ToList();
-
-        var packagesRaw = await db.Packages.Where(p => packageIds.Contains(p.Id)).Select(p => new { p.Id, p.Name, p.AreaId, p.Urn }).ToListAsync(ct);
-        SortedList<Guid, ConnectionQueryPackage> packages = [];
-        foreach (var package in packagesRaw)
-        {
-            packages[package.Id] = new() { Id = package.Id, Name = package.Name, AreaId = package.AreaId, Urn = package.Urn };
-        }
-
-        foreach (var key in keys)
-        {
-            IEnumerable<Guid> keyPackageIds = [];
-
-            if (!key.AssignmentId.HasValue)
-            {
-                // if connection record is a client delegation, we only need to consider delegationpackages, and not from assignment or role packages.
-                var clientDelegationPackages = key.DelegationId.HasValue
-                 ? (key.DelegationId != null && delegationPackages.ContainsKey((Guid)key.DelegationId)) ? delegationPackages[(Guid)key.DelegationId] : []
-                 : [];
-
-                keyPackageIds = clientDelegationPackages.Distinct();
-            }
-            else if (key.AssignmentId.HasValue && key.RoleId == RoleConstants.Rightholder.Id)
-            {
-                // if connection is for rightholder we only need to consider assignment packages and not role packages or client delegations
-                var assPackages = key.AssignmentId.HasValue
-                     ? assignmentPackages.ContainsKey((Guid)key.AssignmentId) ? assignmentPackages[(Guid)key.AssignmentId] : []
-                     : [];
-
-                keyPackageIds = assPackages.Distinct();
-            }
-            else
-            {
-                // else we need to consider check for role packages
-                List<Guid> rolePackagesForEntityForKey = [];
-                if (rolePackagesForEntity.TryGetValue(key.RoleId, out var entityDict)
-                    && entityDict.TryGetValue(entityVariants[key.FromId], out var entityIds))
-                {
-                    rolePackagesForEntityForKey = entityIds;
-                }
-
-                keyPackageIds = (rolePackagesForAll.TryGetValue(key.RoleId, out List<Guid> packagesForAll) ? packagesForAll : [])
-                        .Union(rolePackagesForEntityForKey).Distinct();
-            }
-
-            if (!keyPackageIds.Any())
-            {
-                continue;
-            }
-
-            List<ConnectionQueryPackage> keyPackages = [];
-            foreach (var id in keyPackageIds)
-            {
-                keyPackages.Add(packages[id]);
-            }
-
-            index.AddRange(new(key.FromId, key.ToId, key.RoleId, key.AssignmentId, key.DelegationId, key.ViaId, key.ViaRoleId), keyPackages);
-        }
-
-        return index;
-    }
-
-
-
-    private async Task EnrichPackageResourcesAsync(ConnectionIndex<ConnectionQueryPackage> packageIndex, ConnectionQueryFilter filter, CancellationToken ct = default)
-    {
-        var packageIds = packageIndex.Pairs
-            .SelectMany(kv => kv.Value)
-            .Select(p => p.Id)
-            .Distinct()
-            .ToList();
-
-        if (packageIds.Count == 0)
-        {
-            return;
-        }
-
-        var resourceSet = filter.ResourceIds is { Count: > 0 }
-            ? new HashSet<Guid>(filter.ResourceIds!)
-            : null;
-
-        var rows = await db.PackageResources
-            .Where(pr => packageIds.Contains(pr.PackageId))
-            .WhereIf(resourceSet is not null, pr => resourceSet!.Contains(pr.ResourceId))
-            .Join(db.Resources, pr => pr.ResourceId, r => r.Id, (pr, r) => new
-            {
-                pr.PackageId,
-                Resource = new ConnectionQueryResource { Id = r.Id, Name = r.Name }
-            })
-            .AsNoTracking()
-            .ToListAsync(ct);
-
-        var resourcesByPackage = rows
-            .GroupBy(x => x.PackageId)
-            .ToDictionary(
-                g => g.Key,
-                g => g.Select(z => z.Resource).DistinctBy(r => r.Id).ToList()
-            );
-
-        foreach (var kv in packageIndex.Pairs)
-        {
-            var packages = kv.Value;
-
-            foreach (var pkg in packages.ToList())
-            {
-                if (resourcesByPackage.TryGetValue(pkg.Id, out var list))
-                {
-                    pkg.Resources = list.ToList();
-                }
-                else
-                {
-                    pkg.Resources = new List<ConnectionQueryResource>(capacity: 0);
-                }
-            }
-
-            // Fjern tomme pakker hvis IncludePackages er false
-            if (!filter.IncludePackages)
-            {
-                kv.Value.RemoveAll(p => p.Resources.Count == 0);
-            }
-        }
-    }
-
     private static List<ConnectionQueryExtendedRecord> Attach<T>(IEnumerable<ConnectionQueryExtendedRecord> results, ConnectionIndex<T> index, Func<T, Guid> idSelector, Action<ConnectionQueryExtendedRecord, List<T>> assign)
     {
         foreach (var dto in results)
@@ -1040,35 +808,6 @@ public class ConnectionQuery(AppDbContext db)
     };
 }
 
-internal sealed class ConnectionIndex<T>
-{
-    private readonly Dictionary<ConnectionCompositeKey, List<T>> map = new();
-
-    public void Add(ConnectionCompositeKey key, T item)
-    {
-        if (!map.TryGetValue(key, out var list))
-        {
-            map[key] = list = new List<T>(4);
-        }
-
-        list.Add(item);
-    }
-
-    public void AddRange(ConnectionCompositeKey key, IEnumerable<T> items)
-    {
-        if (!map.TryGetValue(key, out var list))
-        {
-            map[key] = list = new List<T>();
-        }
-
-        list.AddRange(items);
-    }
-
-    public IReadOnlyList<T> Get(ConnectionCompositeKey key) =>
-        map.TryGetValue(key, out var list) ? list : Array.Empty<T>();
-
-    public IEnumerable<KeyValuePair<ConnectionCompositeKey, List<T>>> Pairs => map;
-}
 
 internal static class ConnectionQueryExtensions
 {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionResourceLoader.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionResourceLoader.cs
@@ -28,11 +28,10 @@ internal class ConnectionResourceLoader(AppDbContext db)
     /// <summary>
     /// Loads resources for each rightholder assignment key and attaches them to the corresponding records.
     /// </summary>
-    public async Task<List<ConnectionQueryExtendedRecord>> LoadResourcesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, ConnectionQueryFilter filter, CancellationToken ct)
+    public async Task<List<ConnectionQueryExtendedRecord>> LoadResourcesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, List<ConnectionQueryExtendedRecord> rightholderAssignments, ConnectionQueryFilter filter, CancellationToken ct)
     {
         var resourceSet = filter.ResourceIds?.Count > 0 ? new HashSet<Guid>(filter.ResourceIds) : null;
 
-        var rightholderAssignments = GetRightholderAssignments(allKeys, filter);
         var rightholderAssignmentIds = rightholderAssignments.Select(a => (Guid)a.AssignmentId).Distinct().ToHashSet();
         if (rightholderAssignmentIds.Count == 0)
         {
@@ -93,13 +92,12 @@ internal class ConnectionResourceLoader(AppDbContext db)
     /// <summary>
     /// Loads instances for each rightholder assignment key and attaches them to the corresponding records.
     /// </summary>
-    public async Task<List<ConnectionQueryExtendedRecord>> LoadInstancesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, ConnectionQueryFilter filter, CancellationToken ct)
+    public async Task<List<ConnectionQueryExtendedRecord>> LoadInstancesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, List<ConnectionQueryExtendedRecord> rightholderAssignments, ConnectionQueryFilter filter, CancellationToken ct)
     {
         var instanceSet = filter.InstanceIds?.Count > 0 ? new HashSet<string>(filter.InstanceIds) : null;
         var resourceSet = filter.ResourceIds?.Count > 0 ? new HashSet<Guid>(filter.ResourceIds) : null;
 
         // Assignment → AssignmentInstance
-        var rightholderAssignments = GetRightholderAssignments(allKeys, filter);
         var rightholderAssignmentIds = rightholderAssignments.Where(a => a.Reason != ConnectionReason.Hierarchy && !a.IsMainUnitAccess).Select(a => (Guid)a.AssignmentId).Distinct().ToHashSet();
         if (rightholderAssignmentIds.Count == 0)
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionResourceLoader.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionResourceLoader.cs
@@ -16,7 +16,7 @@ internal class ConnectionResourceLoader(AppDbContext db)
     /// </summary>
     public static List<ConnectionQueryExtendedRecord> GetRightholderAssignments(List<ConnectionQueryExtendedRecord> allKeys, ConnectionQueryFilter filter)
     {
-        List<Guid> rightholderRoles = [RoleConstants.Rightholder.Id];
+        HashSet<Guid> rightholderRoles = new() { RoleConstants.Rightholder.Id };
         if (filter.IncludeAppControlledInstances)
         {
             rightholderRoles.Add(RoleConstants.AppControlledRightholder.Id);
@@ -33,7 +33,7 @@ internal class ConnectionResourceLoader(AppDbContext db)
         var resourceSet = filter.ResourceIds?.Count > 0 ? new HashSet<Guid>(filter.ResourceIds) : null;
 
         var rightholderAssignments = GetRightholderAssignments(allKeys, filter);
-        var rightholderAssignmentIds = rightholderAssignments.Select(a => (Guid)a.AssignmentId).Distinct().ToList();
+        var rightholderAssignmentIds = rightholderAssignments.Select(a => (Guid)a.AssignmentId).Distinct().ToHashSet();
         if (rightholderAssignmentIds.Count == 0)
         {
             return allKeys;
@@ -100,7 +100,7 @@ internal class ConnectionResourceLoader(AppDbContext db)
 
         // Assignment → AssignmentInstance
         var rightholderAssignments = GetRightholderAssignments(allKeys, filter);
-        var rightholderAssignmentIds = rightholderAssignments.Where(a => a.Reason != ConnectionReason.Hierarchy && !a.IsMainUnitAccess).Select(a => (Guid)a.AssignmentId).Distinct().ToList();
+        var rightholderAssignmentIds = rightholderAssignments.Where(a => a.Reason != ConnectionReason.Hierarchy && !a.IsMainUnitAccess).Select(a => (Guid)a.AssignmentId).Distinct().ToHashSet();
         if (rightholderAssignmentIds.Count == 0)
         {
             return allKeys;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionResourceLoader.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionResourceLoader.cs
@@ -1,0 +1,166 @@
+﻿using Altinn.AccessMgmt.PersistenceEF.Constants;
+using Altinn.AccessMgmt.PersistenceEF.Contexts;
+using Altinn.AccessMgmt.PersistenceEF.Extensions;
+using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
+
+/// <summary>
+/// Responsible for loading resources and instances for connection query results.
+/// </summary>
+internal class ConnectionResourceLoader(AppDbContext db)
+{
+    /// <summary>
+    /// Returns the subset of keys that are rightholder assignments based on filter settings.
+    /// </summary>
+    public static List<ConnectionQueryExtendedRecord> GetRightholderAssignments(List<ConnectionQueryExtendedRecord> allKeys, ConnectionQueryFilter filter)
+    {
+        List<Guid> rightholderRoles = [RoleConstants.Rightholder.Id];
+        if (filter.IncludeAppControlledInstances)
+        {
+            rightholderRoles.Add(RoleConstants.AppControlledRightholder.Id);
+        }
+
+        return allKeys.Where(a => a.AssignmentId.HasValue && rightholderRoles.Contains(a.RoleId)).ToList();
+    }
+
+    /// <summary>
+    /// Loads resources for each rightholder assignment key and attaches them to the corresponding records.
+    /// </summary>
+    public async Task<List<ConnectionQueryExtendedRecord>> LoadResourcesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, ConnectionQueryFilter filter, CancellationToken ct)
+    {
+        var resourceSet = filter.ResourceIds?.Count > 0 ? new HashSet<Guid>(filter.ResourceIds) : null;
+
+        var rightholderAssignments = GetRightholderAssignments(allKeys, filter);
+        var rightholderAssignmentIds = rightholderAssignments.Select(a => (Guid)a.AssignmentId).Distinct().ToList();
+        if (rightholderAssignmentIds.Count == 0)
+        {
+            return allKeys;
+        }
+
+        var assignmentResources = await db.AssignmentResources
+            .Where(ai => rightholderAssignmentIds.Contains(ai.AssignmentId))
+            .Select(ai => new { ai.AssignmentId, ai.Id, ai.ResourceId })
+            .WhereIf(resourceSet is not null, x => resourceSet!.Contains(x.ResourceId))
+            .Join(db.Resources, x => x.ResourceId, r => r.Id, (x, r) => new
+            {
+                x.AssignmentId,
+                r.Id,
+                r.Name,
+                r.RefId
+            })
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        SortedList<Guid, List<ConnectionQueryResource>> resourcesByAssignment = [];
+        foreach (var ai in assignmentResources)
+        {
+            if (resourcesByAssignment.TryGetValue(ai.AssignmentId, out var list))
+            {
+                list.Add(new ConnectionQueryResource()
+                {
+                    Id = ai.Id,
+                    Name = ai.Name,
+                    RefId = ai.RefId
+                });
+            }
+            else
+            {
+                resourcesByAssignment[ai.AssignmentId] =
+                [
+                    new ConnectionQueryResource()
+                    {
+                        Id = ai.Id,
+                        Name = ai.Name,
+                        RefId = ai.RefId
+                    }
+                ];
+            }
+        }
+
+        foreach (var key in allKeys)
+        {
+            if (key.AssignmentId.HasValue && resourcesByAssignment.TryGetValue((Guid)key.AssignmentId!, out var list))
+            {
+                key.Resources = list;
+            }
+        }
+
+        return allKeys;
+    }
+
+    /// <summary>
+    /// Loads instances for each rightholder assignment key and attaches them to the corresponding records.
+    /// </summary>
+    public async Task<List<ConnectionQueryExtendedRecord>> LoadInstancesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, ConnectionQueryFilter filter, CancellationToken ct)
+    {
+        var instanceSet = filter.InstanceIds?.Count > 0 ? new HashSet<string>(filter.InstanceIds) : null;
+        var resourceSet = filter.ResourceIds?.Count > 0 ? new HashSet<Guid>(filter.ResourceIds) : null;
+
+        // Assignment → AssignmentInstance
+        var rightholderAssignments = GetRightholderAssignments(allKeys, filter);
+        var rightholderAssignmentIds = rightholderAssignments.Where(a => a.Reason != ConnectionReason.Hierarchy && !a.IsMainUnitAccess).Select(a => (Guid)a.AssignmentId).Distinct().ToList();
+        if (rightholderAssignmentIds.Count == 0)
+        {
+            return allKeys;
+        }
+
+        var assignmentInstances = await db.AssignmentInstances
+            .Where(ai => rightholderAssignmentIds.Contains(ai.AssignmentId))
+            .Select(ai => new { ai.AssignmentId, ai.Id, ai.ResourceId, ai.InstanceId })
+            .WhereIf(instanceSet is not null, x => instanceSet!.Contains(x.InstanceId))
+            .WhereIf(resourceSet is not null, x => resourceSet!.Contains(x.ResourceId))
+            .Join(db.Resources, x => x.ResourceId, r => r.Id, (x, r) => new
+            {
+                x.AssignmentId,
+                x.Id,
+                x.ResourceId,
+                x.InstanceId,
+                ResourceName = r.Name,
+                ResourceRefId = r.RefId
+            })
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        SortedList<Guid, List<ConnectionQueryInstance>> instancesByAssignment = [];
+        foreach (var ai in assignmentInstances)
+        {
+            if (instancesByAssignment.TryGetValue(ai.AssignmentId, out var list))
+            {
+                list.Add(new ConnectionQueryInstance()
+                {
+                    Id = ai.Id,
+                    ResourceId = ai.ResourceId,
+                    InstanceId = ai.InstanceId,
+                    ResourceName = ai.ResourceName,
+                    ResourceRefId = ai.ResourceRefId
+                });
+            }
+            else
+            {
+                instancesByAssignment[ai.AssignmentId] =
+                [
+                    new ConnectionQueryInstance()
+                    {
+                        Id = ai.Id,
+                        ResourceId = ai.ResourceId,
+                        InstanceId = ai.InstanceId,
+                        ResourceName = ai.ResourceName,
+                        ResourceRefId = ai.ResourceRefId
+                    }
+                ];
+            }
+        }
+
+        foreach (var key in allKeys.Where(k => k.AssignmentId.HasValue && rightholderAssignmentIds.Contains((Guid)k.AssignmentId) && k.Reason != ConnectionReason.Hierarchy && !k.IsMainUnitAccess))
+        {
+            if (key.AssignmentId.HasValue && instancesByAssignment.TryGetValue((Guid)key.AssignmentId!, out var list))
+            {
+                key.Instances = list;
+            }
+        }
+
+        return allKeys;
+    }
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionResourceLoader.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionResourceLoader.cs
@@ -28,15 +28,9 @@ internal class ConnectionResourceLoader(AppDbContext db)
     /// <summary>
     /// Loads resources for each rightholder assignment key and attaches them to the corresponding records.
     /// </summary>
-    public async Task<List<ConnectionQueryExtendedRecord>> LoadResourcesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, List<ConnectionQueryExtendedRecord> rightholderAssignments, ConnectionQueryFilter filter, CancellationToken ct)
+    public async Task<List<ConnectionQueryExtendedRecord>> LoadResourcesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, HashSet<Guid> rightholderAssignmentIds, ConnectionQueryFilter filter, CancellationToken ct)
     {
         var resourceSet = filter.ResourceIds?.Count > 0 ? new HashSet<Guid>(filter.ResourceIds) : null;
-
-        var rightholderAssignmentIds = rightholderAssignments.Select(a => (Guid)a.AssignmentId).Distinct().ToHashSet();
-        if (rightholderAssignmentIds.Count == 0)
-        {
-            return allKeys;
-        }
 
         var assignmentResources = await db.AssignmentResources
             .Where(ai => rightholderAssignmentIds.Contains(ai.AssignmentId))
@@ -92,17 +86,10 @@ internal class ConnectionResourceLoader(AppDbContext db)
     /// <summary>
     /// Loads instances for each rightholder assignment key and attaches them to the corresponding records.
     /// </summary>
-    public async Task<List<ConnectionQueryExtendedRecord>> LoadInstancesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, List<ConnectionQueryExtendedRecord> rightholderAssignments, ConnectionQueryFilter filter, CancellationToken ct)
+    public async Task<List<ConnectionQueryExtendedRecord>> LoadInstancesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, HashSet<Guid> rightholderAssignmentIds, ConnectionQueryFilter filter, CancellationToken ct)
     {
         var instanceSet = filter.InstanceIds?.Count > 0 ? new HashSet<string>(filter.InstanceIds) : null;
         var resourceSet = filter.ResourceIds?.Count > 0 ? new HashSet<Guid>(filter.ResourceIds) : null;
-
-        // Assignment → AssignmentInstance
-        var rightholderAssignmentIds = rightholderAssignments.Where(a => a.Reason != ConnectionReason.Hierarchy && !a.IsMainUnitAccess).Select(a => (Guid)a.AssignmentId).Distinct().ToHashSet();
-        if (rightholderAssignmentIds.Count == 0)
-        {
-            return allKeys;
-        }
 
         var assignmentInstances = await db.AssignmentInstances
             .Where(ai => rightholderAssignmentIds.Contains(ai.AssignmentId))


### PR DESCRIPTION
## Summary

Extracts `ConnectionResourceLoader` and `ConnectionPackageLoader` from `ConnectionQuery` as part of the cleanup initiative (#3756).

Closes #3776, closes #3777.

### Changes

- **Created `ConnectionResourceLoader.cs`** — focused class containing:
  - `LoadResourcesByKeyAsync` — loads resources per rightholder assignment
  - `LoadInstancesByKeyAsync` — loads instances per rightholder assignment
  - `GetRightholderAssignments` (static) — filters keys to rightholder assignments with no mutable state

- **Created `ConnectionPackageLoader.cs`** — focused class containing:
  - `LoadPackagesByKeyAsync` — loads assignment, role, and delegation packages
  - `EnrichPackageResourcesAsync` — attaches resources to loaded packages

- **Created `ConnectionIndex.cs`** — extracted the generic `ConnectionIndex<T>` helper into its own file

- **Simplified `ConnectionQuery.cs`**:
  - Removed mutable `_rightholderAssignments` field and its reset logic
  - Removed ~380 lines of extracted private methods
  - Delegates to `_resourceLoader` and `_packageLoader` fields
  - Public API unchanged

### Constraints met

- ✅ No change in returned resources, instances, or packages
- ✅ `ConnectionQuery` public API unchanged
- ✅ All 305 integration tests pass