### PR TITLE
chore(#2806): add feature flags for the Access Management frontend

### DIFF
--- a/src/apps/Altinn.AccessManagement/infra/frontend.tf
+++ b/src/apps/Altinn.AccessManagement/infra/frontend.tf
@@ -1,0 +1,28 @@
+# Feature flags for the Access Management frontend BFF
+# (https://github.com/Altinn/altinn-access-management-frontend).
+# The frontend reads these from the hub App Configuration store using the
+# "<env>-access-management-ui" label, keeping them separate from the backend
+# flags in main.tf. Defined here until the frontend moves into this repo.
+module "frontend_appsettings" {
+  source     = "../../../../infra/modules/appsettings"
+  hub_suffix = local.hub_suffix
+
+  feature_flags = [
+    {
+      name        = "AccessManagementUI.DisplayPopularSingleRightsServices"
+      description = "Whether or not to only display popular SingleRights services."
+      label       = "${lower(var.environment)}-access-management-ui"
+      default     = false
+    },
+    {
+      name        = "AccessManagementUI.UseNewSingleRightsClientDelegation"
+      description = "Whether or not to use the new version of client delegation for single rights services."
+      label       = "${lower(var.environment)}-access-management-ui"
+      default     = false
+    },
+  ]
+
+  providers = {
+    azurerm.hub = azurerm.hub
+  }
+}


### PR DESCRIPTION
## What

Adds a separate `appsettings` module instance (`frontend.tf`) in the Access Management app's infra, defining the feature flags for the Access Management frontend BFF ([altinn-access-management-frontend](https://github.com/Altinn/altinn-access-management-frontend)) in the hub App Configuration store.

## Why

Part of #2806 — the frontend is adopting the same feature flag setup as the backend: flags in the shared hub store, read at runtime via the `Altinn:AppConfiguration:*` configuration keys (mirroring `Altinn.Authorization.ServiceDefaults`), toggled in the portal without redeploys.

The flags use the label `{env}-access-management-ui`, following the same `{env}-{app}` label scheme as the backend's own flags, so the two apps never read each other's keys. Flag names are prefixed `AccessManagementUI.` for visual separation in the portal.

## Notes

- Both flags are created disabled (`default = false`). The intended per-environment state is toggled manually in the portal after apply — as with the existing flags, Terraform ignores `enabled` after creation.
- Defined in a separate `frontend.tf` next to the app's infra so it rides the existing pipeline and state file. The definitions move to the frontend's own app folder when the frontend moves into this repo.
- Separately agreed: the frontend's container apps (`altinn-{env}-amui-app`) need the **App Configuration Data Reader** role on the hub store before the frontend enables the integration per environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)