### PR TITLE
feat: delegate single resources to agents in the v2 client delegation API

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
@@ -175,10 +175,11 @@ public class ClientDelegationController(
         [FromQuery(Name = "party")][Required] Guid party,
         [FromQuery(Name = "roles")] List<string>? roles,
         [FromQuery(Name = "packages")] List<string>? packages,
+        [FromQuery(Name = "resources")] List<string>? resources,
         [FromQuery, FromHeader] PagingInput paging,
         CancellationToken cancellationToken = default)
     {
-        var result = await clientDelegationService.GetClientsV2(party, roles, packages, cancellationToken);
+        var result = await clientDelegationService.GetClientsV2(party, roles, packages, resources, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
@@ -386,5 +386,97 @@ public class ClientDelegationController(
         return Ok(result.Value);
     }
 
+    [HttpGet("agents/resources")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_READ)]
+    [ProducesResponseType<PaginatedResult<ContractsV2.ClientResourcesDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetDelegatedResourcesToAgentsViaParty(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "agent")][Required] Guid agent,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await clientDelegationService.GetDelegatedResourcesToAgentsViaPartyV2(party, agent, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(PaginatedResult.Create(result.Value, null));
+    }
+
+    [HttpGet("clients/resources")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_READ)]
+    [ProducesResponseType<PaginatedResult<ContractsV2.AgentResourcesDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetDelegatedResourcesFromClientsViaParty(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "client")][Required] Guid client,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = await clientDelegationService.GetDelegatedResourcesFromClientsViaPartyV2(party, client, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(PaginatedResult.Create(result.Value, null));
+    }
+
+    [HttpPost("agents/resources")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType<List<ContractsV2.ResourceDelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DelegateResourceToAgent(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "client")][Required] Guid client,
+        [FromQuery(Name = "agent")][Required] Guid agent,
+        [FromBody][Required] ContractsV2.ResourceDelegationBatchInputDto payload,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await clientDelegationService.DelegateResourceToAgent(party, client, agent, payload, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpDelete("agents/resources")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE)]
+    [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType<List<ContractsV2.ResourceDelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DeleteAgentResource(
+        [FromQuery(Name = "party")][Required] Guid party,
+        [FromQuery(Name = "client")][Required] Guid client,
+        [FromQuery(Name = "agent")][Required] Guid agent,
+        [FromBody][Required] ContractsV2.ResourceDelegationBatchInputDto payload,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var result = await clientDelegationService.RemoveAgentResourceDelegation(party, client, agent, payload, cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
     #endregion
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -1383,7 +1383,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
                 $"$QUERY/client",
-                [new($"{fromId}", "entity do not exist.")]
+                [new($"{fromId}", "entity does not exist.")]
             );
         }
 
@@ -1392,7 +1392,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
                 $"$QUERY/agent",
-                [new($"{toId}", "entity do not exist.")]
+                [new($"{toId}", "entity does not exist.")]
             );
         }
 
@@ -1836,7 +1836,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
                 "$QUERY/party",
-                [new($"{partyUuid}", "entity do not exist.")]
+                [new($"{partyUuid}", "entity does not exist.")]
             );
         }
 
@@ -1845,7 +1845,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
                 $"$QUERY/client",
-                [new($"{fromUuid}", "entity do not exist.")]
+                [new($"{fromUuid}", "entity does not exist.")]
             );
         }
 
@@ -1854,7 +1854,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
                 $"$QUERY/agent",
-                [new($"{toUuid}", "entity do not exist.")]
+                [new($"{toUuid}", "entity does not exist.")]
             );
         }
 
@@ -1965,16 +1965,19 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                     .AsTracking()
                     .FirstOrDefaultAsync(d => d.Id == delegation.DelegationId, cancellationToken);
 
-                await ClientRemovedNotification.Upsert(
-                    db,
-                    partyUuid,
-                    fromUuid,
-                    toUuid,
-                    appsettings?.Value?.Notifications?.ClientRemovedNotifyInSeconds ?? ClientRemovedNotification.DefaultNotifyInSeconds,
-                    cancellationToken
-                );
+                if (deleteDelegation is { })
+                {
+                    await ClientRemovedNotification.Upsert(
+                        db,
+                        partyUuid,
+                        fromUuid,
+                        toUuid,
+                        appsettings?.Value?.Notifications?.ClientRemovedNotifyInSeconds ?? ClientRemovedNotification.DefaultNotifyInSeconds,
+                        cancellationToken
+                    );
 
-                db.Delegations.Remove(deleteDelegation);
+                    db.Delegations.Remove(deleteDelegation);
+                }
             }
         }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -1503,7 +1503,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             }
 
             // A delegation created in this batch has no persisted rows yet, so the lookup only runs
-            // for pre existing delegations, once per input value.
+            // for pre-existing delegations, once per input value.
             List<DelegationResource> existingDelegationResources = createdDelegations.ContainsKey(clientAssignment.Id)
                 ? []
                 : await db.DelegationResources

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -475,11 +475,13 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             return new List<ContractsV2.ClientDto>();
         }
 
+        // The roles filter is the primary filter and narrows the client assignments themselves. The
+        // packages and resources filters behave alike: each selects the clients that hold a match
+        // and trims its own access list, without affecting the other list.
         var clientAssignments = db.Assignments
             .AsNoTracking()
             .Where(a => a.ToId == partyUuid && !ExcludeClientRoles.Contains(a.RoleId))
-            .WhereIf(roleFilter.Count > 0, r => roleFilter.Contains(r.RoleId))
-            .WhereIf(resourceFilter.Count > 0, a => db.AssignmentResources.Any(ar => ar.AssignmentId == a.Id && resourceFilter.Contains(ar.ResourceId)));
+            .WhereIf(roleFilter.Count > 0, r => roleFilter.Contains(r.RoleId));
 
         var packageRows = await clientAssignments
             .GroupJoin(
@@ -514,8 +516,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             .ToListAsync(cancellationToken);
 
         // Resources are fetched as their own row set to avoid a packages x resources product per
-        // assignment. The packages filter does not apply to resources: delegated single resources
-        // are tied to rightholder assignments and follow the role filter.
+        // assignment.
         var resourceRows = await clientAssignments
             .Join(
                 db.AssignmentResources,
@@ -523,12 +524,22 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 ar => ar.AssignmentId,
                 (a, ar) => new { a.From, a.Role, ar.Resource }
             )
+            .WhereIf(resourceFilter.Count > 0, x => resourceFilter.Contains(x.Resource.Id))
             .ToListAsync(cancellationToken);
+
+        // A client is included when it matches every active filter: a matching package somewhere in
+        // its assignments when the packages filter is set, and a matching delegated resource when
+        // the resources filter is set. The row sets are already trimmed to the matches, so the
+        // client sets fall out of them directly.
+        HashSet<Guid> packageClientIds = packageFilter.Count > 0 ? packageRows.Select(x => x.From.Id).ToHashSet() : null;
+        HashSet<Guid> resourceClientIds = resourceFilter.Count > 0 ? resourceRows.Select(x => x.From.Id).ToHashSet() : null;
 
         var query = packageRows
             .Select(x => new { x.From, x.Role, x.AssignmentPackage, x.RolePackage, x.RolePackageEntityVariantId, Resource = (Resource)null })
             .Concat(resourceRows.Select(x => new { x.From, x.Role, AssignmentPackage = (Package)null, RolePackage = (Package)null, RolePackageEntityVariantId = (Guid?)null, x.Resource }))
             .GroupBy(x => x.From.Id)
+            .Where(g => packageClientIds is null || packageClientIds.Contains(g.Key))
+            .Where(g => resourceClientIds is null || resourceClientIds.Contains(g.Key))
             .ToList();
 
         return query

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -1825,7 +1825,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 errorBuilder.Add(
                     ValidationErrors.InvalidRole,
                     $"/values[{input.RoleIdx}]/role",
-                    [new($"{input.InputRole}", "role do not exist.")]
+                    [new($"{input.InputRole}", "Role does not exist.")]
                 );
             }
         }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -552,10 +552,12 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                     Role = DtoMapper.ConvertCompactRole(r.First().Role),
                     Packages = [
                         .. r.Where(p => p.AssignmentPackage is { } && p.AssignmentPackage.IsDelegable)
+                            .Where(p => packageFilter.Count == 0 || packageFilter.Contains(p.AssignmentPackage.Id))
                             .Select(p => DtoMapper.ConvertCompactPackage(p.AssignmentPackage))
                             .DistinctBy(p => p.Id),
                         .. r.Where(p => p.RolePackage is { } && p.RolePackage.IsDelegable)
                             .Where(p => p.RolePackageEntityVariantId == null || p.RolePackageEntityVariantId == p.From.VariantId)
+                            .Where(p => packageFilter.Count == 0 || packageFilter.Contains(p.RolePackage.Id))
                             .Select(p => DtoMapper.ConvertCompactPackage(p.RolePackage))
                             .DistinctBy(p => p.Id),
                     ],

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -1453,6 +1453,13 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         }
 
         var result = new List<ContractsV2.ResourceDelegationDto>();
+
+        // The batch can repeat a role across values or a resource within a value. Rows added to the
+        // change tracker are invisible to the database lookups, so created delegations and delegation
+        // resources are tracked locally to keep repeated entries idempotent instead of colliding with
+        // the unique indexes at save time.
+        var createdDelegations = new Dictionary<Guid, Delegation>();
+        var addedDelegationResources = new HashSet<(Guid DelegationId, Guid ResourceId)>();
         foreach (var input in inputs)
         {
             var resourceIds = input.Resources.Select(r => r.ResourceId).Distinct().ToList();
@@ -1471,7 +1478,9 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
 
             var assignmentResources = await db.AssignmentResources.AsNoTracking().Where(ar => ar.AssignmentId == clientAssignment.Id && resourceIds.Contains(ar.ResourceId)).ToListAsync(cancellationToken);
 
-            var delegation = await db.Delegations.AsNoTracking().FirstOrDefaultAsync(t => t.FromId == clientAssignment.Id && t.ToId == agentAssignment.Id && t.FacilitatorId == partyId, cancellationToken);
+            var delegation = createdDelegations.TryGetValue(clientAssignment.Id, out var createdDelegation)
+                ? createdDelegation
+                : await db.Delegations.AsNoTracking().FirstOrDefaultAsync(t => t.FromId == clientAssignment.Id && t.ToId == agentAssignment.Id && t.FacilitatorId == partyId, cancellationToken);
             if (delegation is null)
             {
                 delegation = new Delegation()
@@ -1482,6 +1491,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 };
 
                 db.Delegations.Add(delegation);
+                createdDelegations[clientAssignment.Id] = delegation;
                 await ClientAddedNotification.Upsert(
                     db,
                     partyId,
@@ -1510,7 +1520,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                     continue;
                 }
 
-                var delegationResourceExist = await existingDelegationResources.AnyAsync(
+                var delegationResourceExist = addedDelegationResources.Contains((delegation.Id, resource.ResourceId)) || await existingDelegationResources.AnyAsync(
                     t =>
                     t.DelegationId == delegation.Id &&
                     t.ResourceId == resource.ResourceId &&
@@ -1525,6 +1535,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                         DelegationId = delegation.Id,
                         AssignmentResourceId = assignmentResource.Id,
                     });
+                    addedDelegationResources.Add((delegation.Id, resource.ResourceId));
                 }
 
                 result.Add(new()

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -570,6 +570,17 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             .Include(a => a.To)
             .ToListAsync(cancellationToken);
 
+        // Resources delegated to each agent via the party, grouped by the role of the client assignment.
+        var resourceRows = await db.Delegations
+            .AsNoTracking()
+            .Where(d => d.FacilitatorId == partyUuid && d.To.FromId == partyUuid && d.To.RoleId == RoleConstants.Agent)
+            .Join(
+                db.DelegationResources,
+                d => d.Id,
+                dr => dr.DelegationId,
+                (d, dr) => new { AgentId = d.To.ToId, d.From.Role, dr.Resource })
+            .ToListAsync(cancellationToken);
+
         return query.Select(a => new ContractsV2.AgentDto()
         {
             Agent = DtoMapper.Convert(a.To),
@@ -580,7 +591,16 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                     Role = DtoMapper.ConvertCompactRole(RoleConstants.Agent.Entity),
                     Packages = [],
                     Resources = [],
-                }
+                },
+                .. resourceRows
+                    .Where(r => r.AgentId == a.ToId)
+                    .GroupBy(r => r.Role.Id)
+                    .Select(roleGroup => new ContractsV2.AgentDto.RoleAccess
+                    {
+                        Role = DtoMapper.ConvertCompactRole(roleGroup.First().Role),
+                        Packages = [],
+                        Resources = roleGroup.Select(x => DtoMapper.ConvertCompactResource(x.Resource)).DistinctBy(r => r.Id).ToList(),
+                    }),
             ]
         }).ToList();
     }
@@ -867,6 +887,45 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.AgentResourcesDto>>> GetDelegatedResourcesFromClientsViaPartyV2(Guid partyUuid, Guid fromUuid, CancellationToken cancellationToken = default)
+    {
+        var query = await db.Delegations
+            .AsNoTracking()
+            .Include(d => d.From)
+            .Include(d => d.To).ThenInclude(a => a.To)
+            .Where(d => d.FacilitatorId == partyUuid && d.From.FromId == fromUuid)
+            .Join(
+                db.DelegationResources,
+                d => d.Id,
+                dr => dr.DelegationId,
+                (d, dr) => new { Delegation = d, DelegationResource = dr })
+            .Select(x => new
+            {
+                x.Delegation.To.To,
+                x.Delegation.From.Role,
+                x.DelegationResource.Resource,
+                AgentAddedAt = x.Delegation.To.Audit_ValidFrom,
+            })
+            .GroupBy(x => x.To.Id)
+            .ToListAsync(cancellationToken);
+
+        var result = query
+            .Select(e =>
+            new ContractsV2.AgentResourcesDto()
+            {
+                Agent = DtoMapper.Convert(e.First().To),
+                AgentAddedAt = e.First().AgentAddedAt,
+                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.AgentResourcesDto.RoleAccess
+                {
+                    Role = DtoMapper.ConvertCompactRole(r.First().Role),
+                    Resources = r.Select(r => DtoMapper.ConvertCompactResource(r.Resource)).DistinctBy(p => p.Id).ToList(),
+                }).ToList(),
+            }).ToList();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
     public async Task<Result<List<ClientDto>>> GetDelegatedAccessPackagesToAgentsViaPartyAsync(Guid partyUuid, Guid toUuid, CancellationToken cancellationToken = default)
     {
         var query = await db.Delegations
@@ -934,6 +993,43 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 {
                     Role = DtoMapper.ConvertCompactRole(r.First().Role),
                     Packages = r.Select(r => DtoMapper.ConvertCompactPackage(r.Package)).DistinctBy(p => p.Id).ToList(),
+                }).ToList(),
+            }).ToList();
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.ClientResourcesDto>>> GetDelegatedResourcesToAgentsViaPartyV2(Guid partyUuid, Guid toUuid, CancellationToken cancellationToken = default)
+    {
+        var query = await db.Delegations
+            .AsNoTracking()
+            .Include(d => d.To)
+            .Include(d => d.From).ThenInclude(a => a.From)
+            .Where(d => d.FacilitatorId == partyUuid && d.To.ToId == toUuid)
+            .Join(
+                db.DelegationResources,
+                d => d.Id,
+                dr => dr.DelegationId,
+                (d, dr) => new { Delegation = d, DelegationResource = dr })
+            .Select(x => new
+            {
+                x.Delegation.From.From,
+                x.Delegation.From.Role,
+                x.DelegationResource.Resource
+            })
+            .GroupBy(x => x.From.Id)
+            .ToListAsync(cancellationToken);
+
+        var result = query
+            .Select(e =>
+            new ContractsV2.ClientResourcesDto()
+            {
+                Client = DtoMapper.Convert(e.First().From),
+                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.ClientResourcesDto.RoleAccess
+                {
+                    Role = DtoMapper.ConvertCompactRole(r.First().Role),
+                    Resources = r.Select(r => DtoMapper.ConvertCompactResource(r.Resource)).DistinctBy(p => p.Id).ToList(),
                 }).ToList(),
             }).ToList();
 
@@ -1217,6 +1313,243 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.ResourceDelegationDto>>> DelegateResourceToAgent(
+        Guid partyId,
+        Guid fromId,
+        Guid toId,
+        ContractsV2.ResourceDelegationBatchInputDto payload,
+        CancellationToken cancellationToken = default)
+    {
+        ValidationErrorBuilder errorBuilder = default;
+        var inputs = payload.Values
+            .Select((r, idx) =>
+            {
+                RoleConstants.TryGetByAll(r.Role, out var role);
+                var resources = r.Resources.Select((resourceId, resourceIdx) => new
+                {
+                    ResourceId = resourceId,
+                    ResourceIdx = resourceIdx,
+                });
+
+                return new
+                {
+                    RoleIdx = idx,
+                    InputRole = r.Role,
+                    Role = role,
+                    Resources = resources,
+                };
+            }).ToList();
+
+        foreach (var input in inputs)
+        {
+            if (input.Role is null)
+            {
+                errorBuilder.Add(
+                    ValidationErrors.InvalidRole,
+                    $"/values[{input.RoleIdx}]/role",
+                    [new($"{input.InputRole}", "Role does not exist.")]
+                );
+            }
+        }
+
+        var requestedResourceIds = inputs.SelectMany(i => i.Resources).Select(r => r.ResourceId).Distinct().ToList();
+        HashSet<Guid> existingResourceIds = requestedResourceIds.Count > 0
+            ? (await db.Resources.AsNoTracking().Where(r => requestedResourceIds.Contains(r.Id)).Select(r => r.Id).ToListAsync(cancellationToken)).ToHashSet()
+            : [];
+
+        foreach (var input in inputs)
+        {
+            foreach (var inputResource in input.Resources)
+            {
+                if (!existingResourceIds.Contains(inputResource.ResourceId))
+                {
+                    errorBuilder.Add(
+                        ValidationErrors.ResourceNotExists,
+                        $"/values[{input.RoleIdx}]/resources[{inputResource.ResourceIdx}]",
+                        [new($"{inputResource.ResourceId}", "Resource does not exist.")]
+                    );
+                }
+            }
+        }
+
+        var entities = await db.Entities.Where(e => e.Id == partyId || e.Id == fromId || e.Id == toId).ToDictionaryAsync(e => e.Id, cancellationToken);
+        if (!entities.ContainsKey(partyId))
+        {
+            throw new UnreachableException();
+        }
+
+        if (!entities.ContainsKey(fromId))
+        {
+            errorBuilder.Add(
+                ValidationErrors.EntityNotExists,
+                $"$QUERY/client",
+                [new($"{fromId}", "entity do not exist.")]
+            );
+        }
+
+        if (!entities.ContainsKey(toId))
+        {
+            errorBuilder.Add(
+                ValidationErrors.EntityNotExists,
+                $"$QUERY/agent",
+                [new($"{toId}", "entity do not exist.")]
+            );
+        }
+
+        if (errorBuilder.TryBuild(out var errorResult))
+        {
+            return errorResult;
+        }
+
+        var agentAssignment = await db.Assignments
+            .FirstOrDefaultAsync(a => a.FromId == partyId && a.ToId == toId && a.RoleId == RoleConstants.Agent.Id, cancellationToken: cancellationToken);
+
+        if (agentAssignment is null)
+        {
+            entities.TryGetValue(toId, out var toEntity);
+            if (toEntity.TypeId != EntityTypeConstants.SystemUser)
+            {
+                errorBuilder.Add(
+                    ValidationErrors.MissingAssignment,
+                    $"$QUERY/agent",
+                    [new(RoleConstants.Agent.Entity.Urn, $"Role is not assigned to '{toId}' from '{partyId}'.")]
+                );
+            }
+            else
+            {
+                agentAssignment = new Assignment()
+                {
+                    FromId = partyId,
+                    ToId = toId,
+                    RoleId = RoleConstants.Agent.Id,
+                };
+                await db.Assignments.AddAsync(agentAssignment, cancellationToken);
+            }
+        }
+
+        var to = entities[toId];
+        if (!SupportedToTypes.Any(e => e.Id == to.TypeId))
+        {
+            var supportedToTypeNames = string.Join(", ", SupportedToTypes.Select(t => t.Entity.Name));
+            errorBuilder.Add(
+                ValidationErrors.DisallowedEntityType,
+                "$QUERY/agent",
+                [new($"{to.TypeId}", $"entity type is not supported as agent, only <{supportedToTypeNames}>.")]
+            );
+        }
+
+        if (to.TypeId == EntityTypeConstants.SystemUser && to.VariantId != EntityVariantConstants.AgentSystem)
+        {
+            errorBuilder.Add(
+                ValidationErrors.DisallowedEntityType,
+                "$QUERY/agent",
+                [new($"{to.Id}", $"system user '{to.Id}' is not created for client delegation.")]
+            );
+        }
+
+        if (errorBuilder.TryBuild(out errorResult))
+        {
+            return errorResult;
+        }
+
+        var result = new List<ContractsV2.ResourceDelegationDto>();
+        foreach (var input in inputs)
+        {
+            var resourceIds = input.Resources.Select(r => r.ResourceId).Distinct().ToList();
+            var clientAssignment = await db.Assignments.AsNoTracking().FirstOrDefaultAsync(t => t.FromId == fromId && t.ToId == partyId && t.RoleId == input.Role.Id, cancellationToken);
+
+            if (clientAssignment is null)
+            {
+                errorBuilder.Add(
+                    ValidationErrors.MissingAssignment,
+                    $"/values[{input.RoleIdx}]/role",
+                    [new($"{input.Role.Entity.Urn}", $"Role is not assigned to '{partyId}' from '{fromId}'.")]
+                );
+
+                continue;
+            }
+
+            var assignmentResources = await db.AssignmentResources.AsNoTracking().Where(ar => ar.AssignmentId == clientAssignment.Id && resourceIds.Contains(ar.ResourceId)).ToListAsync(cancellationToken);
+
+            var delegation = await db.Delegations.AsNoTracking().FirstOrDefaultAsync(t => t.FromId == clientAssignment.Id && t.ToId == agentAssignment.Id && t.FacilitatorId == partyId, cancellationToken);
+            if (delegation is null)
+            {
+                delegation = new Delegation()
+                {
+                    FromId = clientAssignment.Id,
+                    ToId = agentAssignment.Id,
+                    FacilitatorId = partyId
+                };
+
+                db.Delegations.Add(delegation);
+                await ClientAddedNotification.Upsert(
+                    db,
+                    partyId,
+                    fromId,
+                    toId,
+                    appsettings.Value.Notifications.ClientAddedNotifyInSeconds,
+                    cancellationToken
+                );
+            }
+
+            var existingDelegationResources = db.DelegationResources.Where(t => t.DelegationId == delegation.Id);
+            foreach (var resource in input.Resources)
+            {
+                // Only resources the facilitator received as a single resource assignment from the client
+                // may be delegated onward. Resources held through an access package have no AssignmentResource
+                // and are rejected here.
+                var assignmentResource = assignmentResources.FirstOrDefault(ar => ar.ResourceId == resource.ResourceId);
+                if (assignmentResource is null)
+                {
+                    errorBuilder.Add(
+                        ValidationErrors.UserNotAuthorized,
+                        $"/values[{input.RoleIdx}]/resources[{resource.ResourceIdx}]",
+                        [new($"{resource.ResourceId}", $"Can't delegate resource from client '{fromId}' as it hasn't been delegated to '{partyId}' as a single resource through role '{input.Role.Entity.Urn}'.")]
+                    );
+
+                    continue;
+                }
+
+                var delegationResourceExist = await existingDelegationResources.AnyAsync(
+                    t =>
+                    t.DelegationId == delegation.Id &&
+                    t.ResourceId == resource.ResourceId &&
+                    t.AssignmentResourceId == assignmentResource.Id,
+                    cancellationToken);
+
+                if (!delegationResourceExist)
+                {
+                    db.DelegationResources.Add(new DelegationResource()
+                    {
+                        ResourceId = resource.ResourceId,
+                        DelegationId = delegation.Id,
+                        AssignmentResourceId = assignmentResource.Id,
+                    });
+                }
+
+                result.Add(new()
+                {
+                    FromId = fromId,
+                    ToId = toId,
+                    ViaId = partyId,
+                    RoleId = input.Role,
+                    ResourceId = resource.ResourceId,
+                    Changed = !delegationResourceExist,
+                });
+            }
+        }
+
+        if (errorBuilder.TryBuild(out errorResult))
+        {
+            return errorResult;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return result;
+    }
+
+    /// <inheritdoc/>
     public async Task<Result<List<DelegationDto>>> RemoveAgentDelegation(
         Guid partyUuid,
         Guid fromUuid,
@@ -1329,6 +1662,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         }
 
         var result = new List<DelegationDto>();
+        var scheduledDeletedPackagesByDelegation = new Dictionary<Guid, HashSet<Guid>>();
         foreach (var input in inputs)
         {
             var pkgIds = input.Packages.Select(p => p.Package).Select(p => p.Id).Distinct();
@@ -1374,6 +1708,13 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 if (toRemove is { })
                 {
                     db.DelegationPackages.Remove(toRemove);
+                    if (!scheduledDeletedPackagesByDelegation.TryGetValue(delegation.Id, out var scheduledForDelegation))
+                    {
+                        scheduledForDelegation = [];
+                        scheduledDeletedPackagesByDelegation[delegation.Id] = scheduledForDelegation;
+                    }
+
+                    scheduledForDelegation.Add(pkgId);
                 }
 
                 result.Add(new()
@@ -1409,10 +1750,12 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             .ToListAsync(cancellationToken);
 
         // Remove delegation if all delegation packages are removed from client and no delegated resources remain.
+        // Scheduled removals are compared per delegation so one role in the batch cannot affect
+        // the deletion decision for a delegation belonging to another role.
         foreach (var delegation in delegations)
         {
-            var scheduledDeletedPackages = result.Where(r => r.Changed).Select(p => p.PackageId).ToHashSet();
-            var currentPackages = delegation.Packages.Select(p => p.PackageId).ToHashSet() ?? [];
+            HashSet<Guid> scheduledDeletedPackages = scheduledDeletedPackagesByDelegation.TryGetValue(delegation.DelegationId, out var scheduled) ? scheduled : [];
+            var currentPackages = delegation.Packages.Select(p => p.PackageId).ToHashSet();
             var shouldDeleteDelegation = !delegation.HasResources && scheduledDeletedPackages.SetEquals(currentPackages);
 
             if (shouldDeleteDelegation)
@@ -1427,6 +1770,193 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                     fromUuid,
                     toUuid,
                     appsettings?.Value?.Notifications?.AgentRemovedNotifyInSeconds ?? ClientRemovedNotification.DefaultNotifyInSeconds,
+                    cancellationToken
+                );
+
+                db.Delegations.Remove(deleteDelegation);
+            }
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.ResourceDelegationDto>>> RemoveAgentResourceDelegation(
+        Guid partyUuid,
+        Guid fromUuid,
+        Guid toUuid,
+        ContractsV2.ResourceDelegationBatchInputDto payload,
+        CancellationToken cancellationToken = default)
+    {
+        ValidationErrorBuilder errorBuilder = default;
+        var inputs = payload.Values
+            .Select((r, idx) =>
+            {
+                RoleConstants.TryGetByAll(r.Role, out var role);
+                return new
+                {
+                    RoleIdx = idx,
+                    InputRole = r.Role,
+                    Role = role,
+                    Resources = r.Resources.Distinct().ToList(),
+                };
+            }).ToList();
+
+        foreach (var input in inputs)
+        {
+            if (input.Role is null)
+            {
+                errorBuilder.Add(
+                    ValidationErrors.InvalidRole,
+                    $"/values[{input.RoleIdx}]/role",
+                    [new($"{input.InputRole}", "role do not exist.")]
+                );
+            }
+        }
+
+        var entities = await db.Entities.Where(e => e.Id == partyUuid || e.Id == fromUuid || e.Id == toUuid).ToDictionaryAsync(e => e.Id, cancellationToken);
+        if (!entities.ContainsKey(partyUuid))
+        {
+            errorBuilder.Add(
+                ValidationErrors.EntityNotExists,
+                "$QUERY/party",
+                [new($"{partyUuid}", "entity do not exist.")]
+            );
+        }
+
+        if (!entities.ContainsKey(fromUuid))
+        {
+            errorBuilder.Add(
+                ValidationErrors.EntityNotExists,
+                $"$QUERY/client",
+                [new($"{fromUuid}", "entity do not exist.")]
+            );
+        }
+
+        if (!entities.ContainsKey(toUuid))
+        {
+            errorBuilder.Add(
+                ValidationErrors.EntityNotExists,
+                $"$QUERY/agent",
+                [new($"{toUuid}", "entity do not exist.")]
+            );
+        }
+
+        var agentAssignment = await db.Assignments
+            .FirstOrDefaultAsync(a => a.FromId == partyUuid && a.ToId == toUuid && a.RoleId == RoleConstants.Agent.Id, cancellationToken: cancellationToken);
+
+        if (agentAssignment is null)
+        {
+            errorBuilder.Add(
+                ValidationErrors.MissingAssignment,
+                $"$QUERY/agent",
+                [new(RoleConstants.Agent.Entity.Urn, $"Role is not assigned to '{toUuid}' from '{partyUuid}'.")]
+            );
+        }
+
+        if (errorBuilder.TryBuild(out var errorResult))
+        {
+            return errorResult;
+        }
+
+        if (agentAssignment is null)
+        {
+            return new List<ContractsV2.ResourceDelegationDto>();
+        }
+
+        var result = new List<ContractsV2.ResourceDelegationDto>();
+        var scheduledDeletedResourcesByDelegation = new Dictionary<Guid, HashSet<Guid>>();
+        foreach (var input in inputs)
+        {
+            var clientAssignment = await db.Assignments.AsNoTracking().FirstOrDefaultAsync(t => t.FromId == fromUuid && t.ToId == partyUuid && t.RoleId == input.Role.Id, cancellationToken);
+
+            if (clientAssignment is null)
+            {
+                continue;
+            }
+
+            var delegation = await db.Delegations.AsNoTracking().FirstOrDefaultAsync(t => t.FromId == clientAssignment.Id && t.ToId == agentAssignment.Id && t.FacilitatorId == partyUuid, cancellationToken);
+            if (delegation is null)
+            {
+                result.AddRange(input.Resources.Select(resourceId => new ContractsV2.ResourceDelegationDto()
+                {
+                    FromId = fromUuid,
+                    ResourceId = resourceId,
+                    RoleId = input.Role,
+                    ToId = toUuid,
+                    ViaId = partyUuid,
+                    Changed = false,
+                }));
+
+                continue;
+            }
+
+            var existingDelegationResources = await db.DelegationResources.AsTracking().Where(t => t.DelegationId == delegation.Id).ToListAsync(cancellationToken);
+            foreach (var resourceId in input.Resources)
+            {
+                var toRemove = existingDelegationResources.FirstOrDefault(t => t.ResourceId == resourceId);
+
+                if (toRemove is { })
+                {
+                    db.DelegationResources.Remove(toRemove);
+                    if (!scheduledDeletedResourcesByDelegation.TryGetValue(delegation.Id, out var scheduledForDelegation))
+                    {
+                        scheduledForDelegation = [];
+                        scheduledDeletedResourcesByDelegation[delegation.Id] = scheduledForDelegation;
+                    }
+
+                    scheduledForDelegation.Add(resourceId);
+                }
+
+                result.Add(new()
+                {
+                    FromId = fromUuid,
+                    ToId = toUuid,
+                    ViaId = partyUuid,
+                    RoleId = input.Role,
+                    ResourceId = resourceId,
+                    Changed = toRemove is { }
+                });
+            }
+        }
+
+        // Get all delegation from client to agent via party.
+        var uniqueRoleIds = inputs.Select(p => p.Role.Id).Distinct();
+        var delegations = await db.Delegations
+            .Where(d => d.FacilitatorId == partyUuid)
+            .Where(d => d.From.FromId == fromUuid && d.From.ToId == partyUuid && uniqueRoleIds.Contains(d.From.RoleId))
+            .Where(d => d.To.ToId == toUuid && d.To.FromId == partyUuid && d.To.RoleId == RoleConstants.Agent)
+            .Select(d => new
+            {
+                DelegationId = d.Id,
+                HasPackages = d.DelegationPackages.Any(),
+                ResourceIds = d.DelegationResources.Select(r => r.ResourceId).ToList(),
+            })
+            .ToListAsync(cancellationToken);
+
+        // Remove delegation if all delegated resources are removed from client and no delegated packages remain.
+        // Scheduled removals are compared per delegation so one role in the batch cannot affect
+        // the deletion decision for a delegation belonging to another role.
+        foreach (var delegation in delegations)
+        {
+            HashSet<Guid> scheduledDeletedResources = scheduledDeletedResourcesByDelegation.TryGetValue(delegation.DelegationId, out var scheduled) ? scheduled : [];
+            var currentResources = delegation.ResourceIds.ToHashSet();
+            var shouldDeleteDelegation = !delegation.HasPackages && scheduledDeletedResources.SetEquals(currentResources);
+
+            if (shouldDeleteDelegation)
+            {
+                var deleteDelegation = await db.Delegations
+                    .AsTracking()
+                    .FirstOrDefaultAsync(d => d.Id == delegation.DelegationId, cancellationToken);
+
+                await ClientRemovedNotification.Upsert(
+                    db,
+                    partyUuid,
+                    fromUuid,
+                    toUuid,
+                    appsettings?.Value?.Notifications?.ClientRemovedNotifyInSeconds ?? ClientRemovedNotification.DefaultNotifyInSeconds,
                     cancellationToken
                 );
 
@@ -1578,6 +2108,14 @@ public interface IClientDelegationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets resources delegated from a specific client via the party, grouped by agent.
+    /// </summary>
+    Task<Result<List<ContractsV2.AgentResourcesDto>>> GetDelegatedResourcesFromClientsViaPartyV2(
+        Guid partyUuid,
+        Guid fromUuid,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets packages delegated to a specific agent via the party, grouped by client.
     /// </summary>
     Task<Result<List<ClientDto>>> GetDelegatedAccessPackagesToAgentsViaPartyAsync(
@@ -1589,6 +2127,14 @@ public interface IClientDelegationService
     /// Gets packages delegated to a specific agent via the party, grouped by client.
     /// </summary>
     Task<Result<List<ContractsV2.ClientPackagesDto>>> GetDelegatedAccessPackagesToAgentsViaPartyV2(
+        Guid partyUuid,
+        Guid toUuid,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets resources delegated to a specific agent via the party, grouped by client.
+    /// </summary>
+    Task<Result<List<ContractsV2.ClientResourcesDto>>> GetDelegatedResourcesToAgentsViaPartyV2(
         Guid partyUuid,
         Guid toUuid,
         CancellationToken cancellationToken = default);
@@ -1612,6 +2158,27 @@ public interface IClientDelegationService
         Guid fromUuid,
         Guid toUuid,
         DelegationBatchInputDto payload,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delegates single resources from a client through the party to an agent.
+    /// Only resources the party received as single resource assignments from the client are delegable.
+    /// </summary>
+    Task<Result<List<ContractsV2.ResourceDelegationDto>>> DelegateResourceToAgent(
+        Guid partyUuid,
+        Guid fromUuid,
+        Guid toUuid,
+        ContractsV2.ResourceDelegationBatchInputDto payload,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes previously delegated single resources from a client to an agent.
+    /// </summary>
+    Task<Result<List<ContractsV2.ResourceDelegationDto>>> RemoveAgentResourceDelegation(
+        Guid partyUuid,
+        Guid fromUuid,
+        Guid toUuid,
+        ContractsV2.ResourceDelegationBatchInputDto payload,
         CancellationToken cancellationToken = default);
 
     #endregion

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -1383,7 +1383,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
                 $"$QUERY/client",
-                [new($"{fromId}", "entity does not exist.")]
+                [new($"{fromId}", $"'{fromId}' is not a valid existing Client for '{partyId}'.")]
             );
         }
 
@@ -1412,7 +1412,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 errorBuilder.Add(
                     ValidationErrors.MissingAssignment,
                     $"$QUERY/agent",
-                    [new(RoleConstants.Agent.Entity.Urn, $"Role is not assigned to '{toId}' from '{partyId}'.")]
+                    [new(RoleConstants.Agent.Entity.Urn, $"The user '{toId}' is not a valid registered Agent for '{partyId}'.")]
                 );
             }
             else
@@ -1443,7 +1443,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             errorBuilder.Add(
                 ValidationErrors.DisallowedEntityType,
                 "$QUERY/agent",
-                [new($"{to.Id}", $"system user '{to.Id}' is not created for client delegation.")]
+                [new($"{to.Id}", $"system user '{to.Id}' is not supported, client delegation only supports system users of the '{EntityVariantConstants.AgentSystem.Entity.Name}' variant.")]
             );
         }
 
@@ -1845,7 +1845,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
                 $"$QUERY/client",
-                [new($"{fromUuid}", "entity does not exist.")]
+                [new($"{fromUuid}", $"'{fromUuid}' is not a valid existing Client for '{partyUuid}'.")]
             );
         }
 
@@ -1866,7 +1866,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             errorBuilder.Add(
                 ValidationErrors.MissingAssignment,
                 $"$QUERY/agent",
-                [new(RoleConstants.Agent.Entity.Urn, $"Role is not assigned to '{toUuid}' from '{partyUuid}'.")]
+                [new(RoleConstants.Agent.Entity.Urn, $"The user '{toUuid}' is not a valid registered Agent for '{partyUuid}'.")]
             );
         }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -240,7 +240,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                         var access = clientGroup
                             .Where(x => x.Role is not null)
                             .GroupBy(x => x.Role.Id)
-                            .Select(roleGroup => new ContractsV2.ClientDto.RoleAccess
+                            .Select(roleGroup => new ContractsV2.RoleAccess
                             {
                                 Role = DtoMapper.ConvertCompactRole(roleGroup.First().Role),
                                 Packages = roleGroup
@@ -427,10 +427,11 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
-    public async Task<Result<List<ContractsV2.ClientDto>>> GetClientsV2(Guid partyUuid, List<string>? roles, List<string>? packages, CancellationToken cancellationToken = default)
+    public async Task<Result<List<ContractsV2.ClientDto>>> GetClientsV2(Guid partyUuid, List<string>? roles, List<string>? packages, List<string>? resources, CancellationToken cancellationToken = default)
     {
         roles ??= [];
         packages ??= [];
+        resources ??= [];
         var roleFilter = new List<Guid>();
         var packageFilter = new List<Guid>();
 
@@ -450,6 +451,15 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             }
         }
 
+        // Filter values are resource registry ids matched exactly against Resource.RefId.
+        List<Guid> resourceFilter = resources.Count > 0
+            ? await db.Resources
+                .AsNoTracking()
+                .Where(r => resources.Contains(r.RefId))
+                .Select(r => r.Id)
+                .ToListAsync(cancellationToken)
+            : [];
+
         if (roleFilter.Count == 0 && roles.Count > 0)
         {
             return new List<ContractsV2.ClientDto>();
@@ -460,10 +470,16 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             return new List<ContractsV2.ClientDto>();
         }
 
+        if (resourceFilter.Count == 0 && resources.Count > 0)
+        {
+            return new List<ContractsV2.ClientDto>();
+        }
+
         var clientAssignments = db.Assignments
             .AsNoTracking()
             .Where(a => a.ToId == partyUuid && !ExcludeClientRoles.Contains(a.RoleId))
-            .WhereIf(roleFilter.Count > 0, r => roleFilter.Contains(r.RoleId));
+            .WhereIf(roleFilter.Count > 0, r => roleFilter.Contains(r.RoleId))
+            .WhereIf(resourceFilter.Count > 0, a => db.AssignmentResources.Any(ar => ar.AssignmentId == a.Id && resourceFilter.Contains(ar.ResourceId)));
 
         var packageRows = await clientAssignments
             .GroupJoin(
@@ -520,7 +536,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             new ContractsV2.ClientDto()
             {
                 Client = DtoMapper.Convert(access.First().From),
-                Access = access.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.ClientDto.RoleAccess
+                Access = access.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.RoleAccess
                 {
                     Role = DtoMapper.ConvertCompactRole(r.First().Role),
                     Packages = [
@@ -595,7 +611,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 .. resourceRows
                     .Where(r => r.AgentId == a.ToId)
                     .GroupBy(r => r.Role.Id)
-                    .Select(roleGroup => new ContractsV2.AgentDto.RoleAccess
+                    .Select(roleGroup => new ContractsV2.RoleAccess
                     {
                         Role = DtoMapper.ConvertCompactRole(roleGroup.First().Role),
                         Packages = [],
@@ -876,7 +892,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             {
                 Agent = DtoMapper.Convert(e.First().To),
                 AgentAddedAt = e.First().AgentAddedAt,
-                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.AgentPackagesDto.RoleAccess
+                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.PackageAccess
                 {
                     Role = DtoMapper.ConvertCompactRole(r.First().Role),
                     Packages = r.Select(r => DtoMapper.ConvertCompactPackage(r.Package)).DistinctBy(p => p.Id).ToList(),
@@ -904,7 +920,6 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 x.Delegation.To.To,
                 x.Delegation.From.Role,
                 x.DelegationResource.Resource,
-                AgentAddedAt = x.Delegation.To.Audit_ValidFrom,
             })
             .GroupBy(x => x.To.Id)
             .ToListAsync(cancellationToken);
@@ -914,8 +929,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             new ContractsV2.AgentResourcesDto()
             {
                 Agent = DtoMapper.Convert(e.First().To),
-                AgentAddedAt = e.First().AgentAddedAt,
-                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.AgentResourcesDto.RoleAccess
+                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.ResourceAccess
                 {
                     Role = DtoMapper.ConvertCompactRole(r.First().Role),
                     Resources = r.Select(r => DtoMapper.ConvertCompactResource(r.Resource)).DistinctBy(p => p.Id).ToList(),
@@ -989,7 +1003,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             new ContractsV2.ClientPackagesDto()
             {
                 Client = DtoMapper.Convert(e.First().From),
-                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.ClientPackagesDto.RoleAccess
+                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.PackageAccess
                 {
                     Role = DtoMapper.ConvertCompactRole(r.First().Role),
                     Packages = r.Select(r => DtoMapper.ConvertCompactPackage(r.Package)).DistinctBy(p => p.Id).ToList(),
@@ -1026,7 +1040,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             new ContractsV2.ClientResourcesDto()
             {
                 Client = DtoMapper.Convert(e.First().From),
-                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.ClientResourcesDto.RoleAccess
+                Access = e.GroupBy(r => r.Role.Id).Select(r => new ContractsV2.ResourceAccess
                 {
                     Role = DtoMapper.ConvertCompactRole(r.First().Role),
                     Resources = r.Select(r => DtoMapper.ConvertCompactResource(r.Resource)).DistinctBy(p => p.Id).ToList(),
@@ -1321,13 +1335,26 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         CancellationToken cancellationToken = default)
     {
         ValidationErrorBuilder errorBuilder = default;
+
+        // Input resources are resource registry ids matched exactly against Resource.RefId and
+        // resolved to internal resource ids in a single lookup.
+        var requestedRefIds = payload.Values.SelectMany(v => v.Resources).Distinct().ToList();
+        Dictionary<string, Guid> resourceIdsByRefId = requestedRefIds.Count > 0
+            ? await db.Resources
+                .AsNoTracking()
+                .Where(r => requestedRefIds.Contains(r.RefId))
+                .Select(r => new { r.RefId, r.Id })
+                .ToDictionaryAsync(r => r.RefId, r => r.Id, cancellationToken)
+            : new Dictionary<string, Guid>();
+
         var inputs = payload.Values
             .Select((r, idx) =>
             {
                 RoleConstants.TryGetByAll(r.Role, out var role);
-                var resources = r.Resources.Select((resourceId, resourceIdx) => new
+                var resources = r.Resources.Select((refId, resourceIdx) => new
                 {
-                    ResourceId = resourceId,
+                    InputResource = refId,
+                    ResourceId = refId is { } && resourceIdsByRefId.TryGetValue(refId, out var resourceId) ? resourceId : Guid.Empty,
                     ResourceIdx = resourceIdx,
                 });
 
@@ -1350,23 +1377,15 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                     [new($"{input.InputRole}", "Role does not exist.")]
                 );
             }
-        }
 
-        var requestedResourceIds = inputs.SelectMany(i => i.Resources).Select(r => r.ResourceId).Distinct().ToList();
-        HashSet<Guid> existingResourceIds = requestedResourceIds.Count > 0
-            ? (await db.Resources.AsNoTracking().Where(r => requestedResourceIds.Contains(r.Id)).Select(r => r.Id).ToListAsync(cancellationToken)).ToHashSet()
-            : [];
-
-        foreach (var input in inputs)
-        {
             foreach (var inputResource in input.Resources)
             {
-                if (!existingResourceIds.Contains(inputResource.ResourceId))
+                if (inputResource.ResourceId == Guid.Empty)
                 {
                     errorBuilder.Add(
                         ValidationErrors.ResourceNotExists,
                         $"/values[{input.RoleIdx}]/resources[{inputResource.ResourceIdx}]",
-                        [new($"{inputResource.ResourceId}", "Resource does not exist.")]
+                        [new($"{inputResource.InputResource}", "Resource does not exist.")]
                     );
                 }
             }
@@ -1805,16 +1824,36 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         CancellationToken cancellationToken = default)
     {
         ValidationErrorBuilder errorBuilder = default;
+
+        // Input resources are resource registry ids matched exactly against Resource.RefId and
+        // resolved to internal resource ids in a single lookup.
+        var requestedRefIds = payload.Values.SelectMany(v => v.Resources).Distinct().ToList();
+        Dictionary<string, Guid> resourceIdsByRefId = requestedRefIds.Count > 0
+            ? await db.Resources
+                .AsNoTracking()
+                .Where(r => requestedRefIds.Contains(r.RefId))
+                .Select(r => new { r.RefId, r.Id })
+                .ToDictionaryAsync(r => r.RefId, r => r.Id, cancellationToken)
+            : new Dictionary<string, Guid>();
+
         var inputs = payload.Values
             .Select((r, idx) =>
             {
                 RoleConstants.TryGetByAll(r.Role, out var role);
+                var inputResources = r.Resources.Select((refId, resourceIdx) => new
+                {
+                    InputResource = refId,
+                    ResourceId = refId is { } && resourceIdsByRefId.TryGetValue(refId, out var resourceId) ? resourceId : Guid.Empty,
+                    ResourceIdx = resourceIdx,
+                }).ToList();
+
                 return new
                 {
                     RoleIdx = idx,
                     InputRole = r.Role,
                     Role = role,
-                    Resources = r.Resources.Distinct().ToList(),
+                    InputResources = inputResources,
+                    Resources = inputResources.Select(x => x.ResourceId).Distinct().ToList(),
                 };
             }).ToList();
 
@@ -1827,6 +1866,18 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                     $"/values[{input.RoleIdx}]/role",
                     [new($"{input.InputRole}", "role do not exist.")]
                 );
+            }
+
+            foreach (var inputResource in input.InputResources)
+            {
+                if (inputResource.ResourceId == Guid.Empty)
+                {
+                    errorBuilder.Add(
+                        ValidationErrors.ResourceNotExists,
+                        $"/values[{input.RoleIdx}]/resources[{inputResource.ResourceIdx}]",
+                        [new($"{inputResource.InputResource}", "Resource does not exist.")]
+                    );
+                }
             }
         }
 
@@ -2062,12 +2113,13 @@ public interface IClientDelegationService
     /// <summary>
     /// Gets clients that have assigned roles to the party,
     /// including delegable packages and delegated resources.
-    /// Optional role filter can be applied.
+    /// Optional role, package and resource filters can be applied.
     /// </summary>
     Task<Result<List<ContractsV2.ClientDto>>> GetClientsV2(
         Guid partyUuid,
         List<string>? roles,
         List<string>? packages,
+        List<string>? resources,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -1502,7 +1502,14 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 );
             }
 
-            var existingDelegationResources = db.DelegationResources.Where(t => t.DelegationId == delegation.Id);
+            // A delegation created in this batch has no persisted rows yet, so the lookup only runs
+            // for pre existing delegations, once per input value.
+            List<DelegationResource> existingDelegationResources = createdDelegations.ContainsKey(clientAssignment.Id)
+                ? []
+                : await db.DelegationResources
+                    .AsNoTracking()
+                    .Where(t => t.DelegationId == delegation.Id && resourceIds.Contains(t.ResourceId))
+                    .ToListAsync(cancellationToken);
             foreach (var resource in input.Resources)
             {
                 // Only resources the facilitator received as a single resource assignment from the client
@@ -1520,12 +1527,8 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                     continue;
                 }
 
-                var delegationResourceExist = addedDelegationResources.Contains((delegation.Id, resource.ResourceId)) || await existingDelegationResources.AnyAsync(
-                    t =>
-                    t.DelegationId == delegation.Id &&
-                    t.ResourceId == resource.ResourceId &&
-                    t.AssignmentResourceId == assignmentResource.Id,
-                    cancellationToken);
+                var delegationResourceExist = addedDelegationResources.Contains((delegation.Id, resource.ResourceId))
+                    || existingDelegationResources.Any(t => t.ResourceId == resource.ResourceId && t.AssignmentResourceId == assignmentResource.Id);
 
                 if (!delegationResourceExist)
                 {

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -405,7 +405,7 @@ public class ClientDelegationControllerTest
     #region GET accessmanagement/api/v2/enduser/clientdelegations/clients
 
     /// <summary>
-    /// <see cref="ClientDelegationController.GetClients(Guid, List{string}?, List{string}?, AccessManagement.Api.Enduser.Models.PagingInput, CancellationToken)"/>
+    /// <see cref="ClientDelegationController.GetClients(Guid, List{string}?, List{string}?, List{string}?, AccessManagement.Api.Enduser.Models.PagingInput, CancellationToken)"/>
     /// </summary>
     [IntegrationTest]
     public class GetClients : IClassFixture<ApiFixture>
@@ -436,6 +436,14 @@ public class ClientDelegationControllerTest
                     RoleId = RoleConstants.Agent,
                 };
 
+                // A second client without assignment resources, used to assert the resources filter.
+                var rightholderFromOkernToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationOkernBorettslag.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Rightholder,
+                };
+
                 var assignmentResourceForAccountant = new AssignmentResource()
                 {
                     AssignmentId = accountantFromNordisToVerdiq.Id,
@@ -447,10 +455,25 @@ public class ClientDelegationControllerTest
                 db.Assignments.Add(rightholderfromNordisToVerdiq);
                 db.Assignments.Add(accountantFromNordisToVerdiq);
                 db.Assignments.Add(agentFromPaulaToNordis);
+                db.Assignments.Add(rightholderFromOkernToVerdiq);
 
                 db.AssignmentPackages.Add(new()
                 {
                     AssignmentId = rightholderfromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.Customs,
+                });
+
+                // The accountant assignment holds both a package and a resource, so a filtered
+                // client lists full access for the matching assignment.
+                db.AssignmentPackages.Add(new()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.Customs,
+                });
+
+                db.AssignmentPackages.Add(new()
+                {
+                    AssignmentId = rightholderFromOkernToVerdiq.Id,
                     PackageId = PackageConstants.Customs,
                 });
 
@@ -561,6 +584,85 @@ public class ClientDelegationControllerTest
 
             Assert.Single(accountantAccess.Resources);
             Assert.Equal(TestData.MattilsynetBakeryService.Id, accountantAccess.Resources.FirstOrDefault()?.Id);
+        }
+
+        [Fact]
+        public async Task ListClient_WithResourcesFilter_Returns200WithOnlyClientHoldingAssignmentResource()
+        {
+            var client = CreateClient();
+
+            // Both clients are listed without the filter.
+            var unfilteredResponse = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, unfilteredResponse.StatusCode);
+            var unfilteredData = await unfilteredResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var unfilteredResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(unfilteredData);
+
+            Assert.Contains(unfilteredResult.Items, p => p.Client.Id == TestEntities.OrganizationNordisAS.Id);
+            Assert.Contains(unfilteredResult.Items, p => p.Client.Id == TestEntities.OrganizationOkernBorettslag.Id);
+
+            var response = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}&resources={TestData.MattilsynetBakeryService.RefId}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(data);
+
+            var nordisClient = Assert.Single(result.Items);
+            Assert.Equal(TestEntities.OrganizationNordisAS.Id, nordisClient.Client.Id);
+
+            // The matching accountant assignment lists its full access, packages included.
+            var accountantAccess = Assert.Single(nordisClient.Access);
+            Assert.Equal(RoleConstants.Accountant.Id, accountantAccess.Role.Id);
+
+            var resource = Assert.Single(accountantAccess.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
+
+            Assert.Contains(accountantAccess.Packages, p => p.Id == PackageConstants.Customs.Id);
+        }
+
+        [Fact]
+        public async Task ListClient_WithUnknownResourcesFilter_Returns200WithEmptyResult()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}&resources=unknown-resource-ref", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(data);
+
+            Assert.Empty(result.Items);
+        }
+
+        [Fact]
+        public async Task ListClient_WithResourcesAndRolesFilter_Returns200WithClientsMatchingBothFilters()
+        {
+            var client = CreateClient();
+
+            // The accountant assignment holds the resource, so the combined filter matches.
+            var response = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}&roles=regnskapsforer&resources={TestData.MattilsynetBakeryService.RefId}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(data);
+
+            var nordisClient = Assert.Single(result.Items);
+            Assert.Equal(TestEntities.OrganizationNordisAS.Id, nordisClient.Client.Id);
+
+            var accountantAccess = Assert.Single(nordisClient.Access);
+            Assert.Equal(RoleConstants.Accountant.Id, accountantAccess.Role.Id);
+
+            var resource = Assert.Single(accountantAccess.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
+
+            // No rightholder assignment holds the resource, so the combined filter matches nothing.
+            response = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}&roles=rettighetshaver&resources={TestData.MattilsynetBakeryService.RefId}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(data);
+
+            Assert.Empty(result.Items);
         }
     }
     #endregion
@@ -1572,7 +1674,6 @@ public class ClientDelegationControllerTest
 
             var paulaAgent = Assert.Single(result.Items);
             Assert.Equal(TestEntities.PersonPaula.Id, paulaAgent.Agent.Id);
-            Assert.NotEqual(default, paulaAgent.AgentAddedAt);
 
             var access = Assert.Single(paulaAgent.Access);
             Assert.Equal(RoleConstants.Accountant.Id, access.Role.Id);
@@ -1727,7 +1828,7 @@ public class ClientDelegationControllerTest
                             new()
                             {
                                 Role = RoleConstants.Accountant.Entity.Code,
-                                Resources = [TestData.MattilsynetBakeryService.Id]
+                                Resources = [TestData.MattilsynetBakeryService.RefId]
                             }
                         ]
                     },
@@ -1756,7 +1857,7 @@ public class ClientDelegationControllerTest
                         new()
                         {
                             Role = RoleConstants.Accountant.Entity.Code,
-                            Resources = [TestData.SiriusSkattemelding.Id]
+                            Resources = [TestData.SiriusSkattemelding.RefId]
                         }
                     ]
                 },
@@ -1797,12 +1898,12 @@ public class ClientDelegationControllerTest
                         new()
                         {
                             Role = RoleConstants.Accountant.Entity.Code,
-                            Resources = [TestData.MattilsynetBakeryService.Id, TestData.MattilsynetBakeryService.Id]
+                            Resources = [TestData.MattilsynetBakeryService.RefId, TestData.MattilsynetBakeryService.RefId]
                         },
                         new()
                         {
                             Role = RoleConstants.Accountant.Entity.Code,
-                            Resources = [TestData.MattilsynetBakeryService.Id]
+                            Resources = [TestData.MattilsynetBakeryService.RefId]
                         }
                     ]
                 },
@@ -1843,7 +1944,7 @@ public class ClientDelegationControllerTest
                         new()
                         {
                             Role = RoleConstants.Accountant.Entity.Code,
-                            Resources = [Guid.CreateVersion7()]
+                            Resources = ["unknown-resource-ref"]
                         }
                     ]
                 },
@@ -2037,7 +2138,7 @@ public class ClientDelegationControllerTest
                         new()
                         {
                             Role = RoleConstants.Accountant.Entity.Code,
-                            Resources = [TestData.MattilsynetBakeryService.Id],
+                            Resources = [TestData.MattilsynetBakeryService.RefId],
                         }
                     ]
                 })

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -1610,6 +1610,13 @@ public class ClientDelegationControllerTest
                     RoleId = RoleConstants.Agent,
                 };
 
+                var agentFromVerdiqToOrjan = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonOrjan,
+                    RoleId = RoleConstants.Agent,
+                };
+
                 // The client Nordis delegated the bakery service to the facilitator Verdiq as a single resource.
                 var assignmentResourceAccountant = new AssignmentResource()
                 {
@@ -1621,7 +1628,16 @@ public class ClientDelegationControllerTest
 
                 db.Assignments.Add(accountantFromNordisToVerdiq);
                 db.Assignments.Add(agentFromVerdiqToPaula);
+                db.Assignments.Add(agentFromVerdiqToOrjan);
                 db.AssignmentResources.Add(assignmentResourceAccountant);
+
+                // Verdiq also holds an accountant package from Nordis. Resources available through the
+                // package have no AssignmentResource and are not delegable as single resources.
+                db.AssignmentPackages.Add(new()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.AccountantWithSigningRights,
+                });
 
                 db.SaveChanges();
             });
@@ -1726,11 +1742,12 @@ public class ClientDelegationControllerTest
         }
 
         [Fact]
-        public async Task DelegateResource_WithResourceNotReceivedAsSingleResource_Returns400WithUserNotAuthorized()
+        public async Task DelegateResource_WithResourceHeldThroughAccessPackageOnly_Returns400WithUserNotAuthorized()
         {
             var client = CreateClient();
 
-            // Sirius is not delegated to Verdiq as a single resource, so it cannot be delegated onward.
+            // Verdiq holds an accountant package from Nordis, but Sirius is not delegated to Verdiq as a
+            // single resource. Package held access does not make a resource delegable onward.
             var response = await client.PostAsJsonAsync(
                 $"{Route}/agents/resources?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}",
                 new ContractsV2.ResourceDelegationBatchInputDto()
@@ -1764,6 +1781,52 @@ public class ClientDelegationControllerTest
                     .ToListAsync(TestContext.Current.CancellationToken);
 
                 Assert.Empty(delegationResources);
+            });
+        }
+
+        [Fact]
+        public async Task DelegateResource_WithDuplicateResourceInPayload_Returns200WithSingleDelegationResource()
+        {
+            var client = CreateClient();
+
+            var response = await client.PostAsJsonAsync(
+                $"{Route}/agents/resources?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonOrjan}",
+                new ContractsV2.ResourceDelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Accountant.Entity.Code,
+                            Resources = [TestData.MattilsynetBakeryService.Id, TestData.MattilsynetBakeryService.Id]
+                        },
+                        new()
+                        {
+                            Role = RoleConstants.Accountant.Entity.Code,
+                            Resources = [TestData.MattilsynetBakeryService.Id]
+                        }
+                    ]
+                },
+                TestContext.Current.CancellationToken
+            );
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var result = JsonSerializer.Deserialize<List<ContractsV2.ResourceDelegationDto>>(data);
+            Assert.Equal(3, result.Count);
+            Assert.Single(result, r => r.Changed);
+
+            // One delegation and one delegation resource row despite the repeated entries.
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegations = await db.Delegations
+                    .Include(d => d.DelegationResources)
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id && d.To.ToId == TestEntities.PersonOrjan.Id)
+                    .ToListAsync(TestContext.Current.CancellationToken);
+
+                var delegation = Assert.Single(delegations);
+                var delegationResource = Assert.Single(delegation.DelegationResources);
+                Assert.Equal(TestData.MattilsynetBakeryService.Id, delegationResource.ResourceId);
             });
         }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -610,14 +610,19 @@ public class ClientDelegationControllerTest
             var nordisClient = Assert.Single(result.Items);
             Assert.Equal(TestEntities.OrganizationNordisAS.Id, nordisClient.Client.Id);
 
-            // The matching accountant assignment lists its full access, packages included.
-            var accountantAccess = Assert.Single(nordisClient.Access);
-            Assert.Equal(RoleConstants.Accountant.Id, accountantAccess.Role.Id);
+            // The whole client relationship is listed: the filter selects the client and trims the
+            // resource lists, while packages and the other role entries stay intact.
+            var accountantAccess = nordisClient.Access.FirstOrDefault(a => a.Role.Id == RoleConstants.Accountant);
+            Assert.NotNull(accountantAccess);
 
             var resource = Assert.Single(accountantAccess.Resources);
             Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
 
             Assert.Contains(accountantAccess.Packages, p => p.Id == PackageConstants.Customs.Id);
+
+            var rightholderAccess = nordisClient.Access.FirstOrDefault(a => a.Role.Id == RoleConstants.Rightholder);
+            Assert.NotNull(rightholderAccess);
+            Assert.Empty(rightholderAccess.Resources);
         }
 
         [Fact]
@@ -663,6 +668,32 @@ public class ClientDelegationControllerTest
             result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(data);
 
             Assert.Empty(result.Items);
+        }
+
+        [Fact]
+        public async Task ListClient_WithPackagesFilter_Returns200WithOnlyClientHoldingPackage()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}&packages={PackageConstants.AccountantSalary.Entity.Urn}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientDto>>(data);
+
+            // Only the client holding the package through its accountant role is selected. The
+            // package list is trimmed to the match while the resource list stays intact.
+            var nordisClient = Assert.Single(result.Items);
+            Assert.Equal(TestEntities.OrganizationNordisAS.Id, nordisClient.Client.Id);
+
+            var accountantAccess = Assert.Single(nordisClient.Access);
+            Assert.Equal(RoleConstants.Accountant.Id, accountantAccess.Role.Id);
+
+            var package = Assert.Single(accountantAccess.Packages);
+            Assert.Equal(PackageConstants.AccountantSalary.Id, package.Id);
+
+            var resource = Assert.Single(accountantAccess.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
         }
     }
     #endregion

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -578,12 +578,47 @@ public class ClientDelegationControllerTest
             Fixture = fixture;
             Fixture.EnsureSeedOnce<GetAgents>(db =>
             {
-                db.Assignments.Add(new Assignment()
+                var agentFromNordisToPaula = new Assignment()
                 {
                     FromId = TestEntities.OrganizationNordisAS.Id,
                     ToId = TestEntities.PersonPaula,
                     RoleId = RoleConstants.Agent,
-                });
+                };
+
+                var accountantFromVerdiqToNordis = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.OrganizationNordisAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var assignmentResourceAccountant = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromVerdiqToNordis.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                var delegationToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromVerdiqToNordis.Id,
+                    ToId = agentFromNordisToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationNordisAS.Id,
+                };
+
+                var delegationResourceToPaula = new DelegationResource()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceAccountant.Id,
+                };
+
+                db.Assignments.Add(agentFromNordisToPaula);
+                db.Assignments.Add(accountantFromVerdiqToNordis);
+                db.AssignmentResources.Add(assignmentResourceAccountant);
+                db.Delegations.Add(delegationToPaula);
+                db.DelegationResources.Add(delegationResourceToPaula);
 
                 db.SaveChanges();
             });
@@ -620,6 +655,27 @@ public class ClientDelegationControllerTest
             Assert.NotNull(access);
             Assert.Empty(access.Packages);
             Assert.Empty(access.Resources);
+        }
+
+        [Fact]
+        public async Task ListAgent_ForAgentWithDelegatedResource_Returns200WithResourcesPerRole()
+        {
+            var client = CreateClient();
+            var response = await client.GetAsync($"{Route}/agents?party={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.AgentDto>>(data);
+
+            var connection = result.Items.FirstOrDefault(p => p.Agent.Id == TestEntities.PersonPaula);
+            Assert.NotNull(connection);
+
+            var accountantAccess = connection.Access.FirstOrDefault(r => r.Role.Id == RoleConstants.Accountant);
+            Assert.NotNull(accountantAccess);
+            Assert.Empty(accountantAccess.Packages);
+
+            var resource = Assert.Single(accountantAccess.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
         }
     }
     #endregion
@@ -1175,6 +1231,760 @@ public class ClientDelegationControllerTest
             var delegationToAgentResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientPackagesDto>>(delegationsToAgentPayload);
 
             Assert.Empty(delegationToAgentResult.Items);
+        }
+    }
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DeleteAgentAccessPackage(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
+    /// Batch removal spanning multiple roles, where each role empties its own delegation.
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteAgentAccessPackagesAcrossRoles : IClassFixture<ApiFixture>
+    {
+        public DeleteAgentAccessPackagesAcrossRoles(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DeleteAgentAccessPackagesAcrossRoles>(db =>
+            {
+                var rightholderFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Rightholder,
+                };
+
+                var accountantFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var assignmentPackageCustoms = new AssignmentPackage()
+                {
+                    AssignmentId = rightholderFromNordisToVerdiq.Id,
+                    PackageId = PackageConstants.Customs.Id,
+                };
+
+                // Each role has its own delegation to Paula carrying a single package.
+                var rightholderDelegationToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = rightholderFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var accountantDelegationToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var rolePackage = db.RolePackages.FirstOrDefault(r => r.RoleId == RoleConstants.Accountant && r.PackageId == PackageConstants.AccountantWithSigningRights);
+                var rightholderDelegationPackage = new DelegationPackage()
+                {
+                    DelegationId = rightholderDelegationToPaula.Id,
+                    AssignmentPackageId = assignmentPackageCustoms.Id,
+                    PackageId = PackageConstants.Customs.Id,
+                };
+
+                var accountantDelegationPackage = new DelegationPackage()
+                {
+                    DelegationId = accountantDelegationToPaula.Id,
+                    RolePackageId = rolePackage.Id,
+                    PackageId = PackageConstants.AccountantWithSigningRights.Id,
+                };
+
+                db.Assignments.Add(rightholderFromNordisToVerdiq);
+                db.Assignments.Add(accountantFromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.AssignmentPackages.Add(assignmentPackageCustoms);
+                db.Delegations.Add(rightholderDelegationToPaula);
+                db.Delegations.Add(accountantDelegationToPaula);
+                db.DelegationPackages.Add(rightholderDelegationPackage);
+                db.DelegationPackages.Add(accountantDelegationPackage);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DeleteAccessPackages_WithBatchEmptyingTwoDelegationsAcrossRoles_Returns200WithBothDelegationsRemoved()
+        {
+            var client = CreateClient();
+
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}")
+            {
+                Content = JsonContent.Create(new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn],
+                        },
+                        new()
+                        {
+                            Role = RoleConstants.Accountant.Entity.Code,
+                            Packages = [PackageConstants.AccountantWithSigningRights.Entity.Urn],
+                        }
+                    ]
+                })
+            };
+
+            var deleteResponse = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var deleteResponsePayload = await deleteResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+            var deleteResult = JsonSerializer.Deserialize<List<DelegationDto>>(deleteResponsePayload);
+            Assert.Equal(2, deleteResult.Count);
+            Assert.True(deleteResult.All(d => d.Changed));
+
+            // Both delegations were emptied by their own role in the batch, so both must be removed.
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegations = await db.Delegations
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id && d.To.ToId == TestEntities.PersonPaula.Id)
+                    .ToListAsync(TestContext.Current.CancellationToken);
+
+                Assert.Empty(delegations);
+            });
+        }
+    }
+    #endregion
+
+    #region GET accessmanagement/api/v2/enduser/clientdelegations/agents/resources
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.GetDelegatedResourcesToAgentsViaParty(Guid, Guid, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class GetDelegatedResourcesToAgents : IClassFixture<ApiFixture>
+    {
+        public GetDelegatedResourcesToAgents(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<GetDelegatedResourcesToAgents>(db =>
+            {
+                var accountantFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var assignmentResourceAccountant = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                var delegationToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var delegationResourceToPaula = new DelegationResource()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceAccountant.Id,
+                };
+
+                db.Assignments.Add(accountantFromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.AssignmentResources.Add(assignmentResourceAccountant);
+                db.Delegations.Add(delegationToPaula);
+                db.DelegationResources.Add(delegationResourceToPaula);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ));
+            });
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task ListDelegatedResourcesToAgent_ForAgentWithDelegatedResource_Returns200WithResourcesGroupedByClient()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/agents/resources?party={TestEntities.OrganizationVerdiqAS.Id}&agent={TestEntities.PersonPaula.Id}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientResourcesDto>>(data);
+
+            var nordisClient = Assert.Single(result.Items);
+            Assert.Equal(TestEntities.OrganizationNordisAS.Id, nordisClient.Client.Id);
+
+            var access = Assert.Single(nordisClient.Access);
+            Assert.Equal(RoleConstants.Accountant.Id, access.Role.Id);
+
+            var resource = Assert.Single(access.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
+        }
+
+        [Fact]
+        public async Task ListDelegatedResourcesToAgent_ForAgentWithoutDelegatedResources_Returns200WithEmptyResult()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/agents/resources?party={TestEntities.OrganizationVerdiqAS.Id}&agent={TestEntities.PersonOrjan.Id}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientResourcesDto>>(data);
+
+            Assert.Empty(result.Items);
+        }
+    }
+    #endregion
+
+    #region GET accessmanagement/api/v2/enduser/clientdelegations/clients/resources
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.GetDelegatedResourcesFromClientsViaParty(Guid, Guid, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class GetDelegatedResourcesFromClients : IClassFixture<ApiFixture>
+    {
+        public GetDelegatedResourcesFromClients(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<GetDelegatedResourcesFromClients>(db =>
+            {
+                var accountantFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var assignmentResourceAccountant = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                var delegationToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var delegationResourceToPaula = new DelegationResource()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceAccountant.Id,
+                };
+
+                db.Assignments.Add(accountantFromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.AssignmentResources.Add(assignmentResourceAccountant);
+                db.Delegations.Add(delegationToPaula);
+                db.DelegationResources.Add(delegationResourceToPaula);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ));
+            });
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task ListDelegatedResourcesFromClient_ForClientWithDelegatedResource_Returns200WithResourcesGroupedByAgent()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync($"{Route}/clients/resources?party={TestEntities.OrganizationVerdiqAS.Id}&client={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var result = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.AgentResourcesDto>>(data);
+
+            var paulaAgent = Assert.Single(result.Items);
+            Assert.Equal(TestEntities.PersonPaula.Id, paulaAgent.Agent.Id);
+            Assert.NotEqual(default, paulaAgent.AgentAddedAt);
+
+            var access = Assert.Single(paulaAgent.Access);
+            Assert.Equal(RoleConstants.Accountant.Id, access.Role.Id);
+
+            var resource = Assert.Single(access.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
+        }
+    }
+    #endregion
+
+    #region POST accessmanagement/api/v2/enduser/clientdelegations/agents/resources
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DelegateResourceToAgent(Guid, Guid, Guid, ContractsV2.ResourceDelegationBatchInputDto, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DelegateResourceToAgent : IClassFixture<ApiFixture>
+    {
+        public DelegateResourceToAgent(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DelegateResourceToAgent>(db =>
+            {
+                var accountantFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                // The client Nordis delegated the bakery service to the facilitator Verdiq as a single resource.
+                var assignmentResourceAccountant = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                db.Assignments.Add(accountantFromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.AssignmentResources.Add(assignmentResourceAccountant);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DelegateResource_WithSingleResourceAssignment_Returns200WithLinkedAssignmentResource()
+        {
+            var client = CreateClient();
+
+            var delegationResult = await Delegate(client);
+
+            var delegated = Assert.Single(delegationResult);
+            Assert.True(delegated.Changed);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, delegated.ResourceId);
+            Assert.Equal(TestEntities.OrganizationNordisAS.Id, delegated.FromId);
+            Assert.Equal(TestEntities.PersonPaula.Id, delegated.ToId);
+            Assert.Equal(TestEntities.OrganizationVerdiqAS.Id, delegated.ViaId);
+
+            // Second delegation is a no-op.
+            delegationResult = await Delegate(client);
+            delegated = Assert.Single(delegationResult);
+            Assert.False(delegated.Changed);
+
+            // The delegated resource points at the originating assignment resource.
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegation = await db.Delegations
+                    .Include(d => d.DelegationResources)
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id
+                        && d.To.ToId == TestEntities.PersonPaula.Id
+                        && d.From.FromId == TestEntities.OrganizationNordisAS.Id)
+                    .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+                Assert.NotNull(delegation);
+                var delegationResource = Assert.Single(delegation.DelegationResources);
+                Assert.Equal(TestData.MattilsynetBakeryService.Id, delegationResource.ResourceId);
+
+                var assignmentResource = await db.AssignmentResources
+                    .FirstOrDefaultAsync(ar => ar.Id == delegationResource.AssignmentResourceId, TestContext.Current.CancellationToken);
+                Assert.NotNull(assignmentResource);
+                Assert.Equal(TestData.MattilsynetBakeryService.Id, assignmentResource.ResourceId);
+            });
+
+            // Read back from the client side.
+            var getFromClient = await client.GetAsync($"{Route}/clients/resources?party={TestEntities.OrganizationVerdiqAS.Id}&client={TestEntities.OrganizationNordisAS.Id}", TestContext.Current.CancellationToken);
+            var fromClientPayload = await getFromClient.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var fromClientResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.AgentResourcesDto>>(fromClientPayload);
+
+            var paulaAccess = fromClientResult.Items.FirstOrDefault(p => p.Agent.Id == TestEntities.PersonPaula);
+            Assert.NotNull(paulaAccess);
+            var paulaResource = paulaAccess.Access.SelectMany(a => a.Resources).FirstOrDefault(r => r.Id == TestData.MattilsynetBakeryService.Id);
+            Assert.NotNull(paulaResource);
+
+            // Read back from the agent side.
+            var getToAgent = await client.GetAsync($"{Route}/agents/resources?party={TestEntities.OrganizationVerdiqAS.Id}&agent={TestEntities.PersonPaula.Id}", TestContext.Current.CancellationToken);
+            var toAgentPayload = await getToAgent.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            var toAgentResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientResourcesDto>>(toAgentPayload);
+
+            var nordisAccess = toAgentResult.Items.FirstOrDefault(p => p.Client.Id == TestEntities.OrganizationNordisAS);
+            Assert.NotNull(nordisAccess);
+            var nordisResource = nordisAccess.Access.SelectMany(a => a.Resources).FirstOrDefault(r => r.Id == TestData.MattilsynetBakeryService.Id);
+            Assert.NotNull(nordisResource);
+
+            static async Task<List<ContractsV2.ResourceDelegationDto>> Delegate(HttpClient client)
+            {
+                var response = await client.PostAsJsonAsync(
+                    $"{Route}/agents/resources?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}",
+                    new ContractsV2.ResourceDelegationBatchInputDto()
+                    {
+                        Values = [
+                            new()
+                            {
+                                Role = RoleConstants.Accountant.Entity.Code,
+                                Resources = [TestData.MattilsynetBakeryService.Id]
+                            }
+                        ]
+                    },
+                    TestContext.Current.CancellationToken
+                );
+
+                var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                return JsonSerializer.Deserialize<List<ContractsV2.ResourceDelegationDto>>(data);
+            }
+        }
+
+        [Fact]
+        public async Task DelegateResource_WithResourceNotReceivedAsSingleResource_Returns400WithUserNotAuthorized()
+        {
+            var client = CreateClient();
+
+            // Sirius is not delegated to Verdiq as a single resource, so it cannot be delegated onward.
+            var response = await client.PostAsJsonAsync(
+                $"{Route}/agents/resources?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}",
+                new ContractsV2.ResourceDelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Accountant.Entity.Code,
+                            Resources = [TestData.SiriusSkattemelding.Id]
+                        }
+                    ]
+                },
+                TestContext.Current.CancellationToken
+            );
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data, SerializerOptions);
+            Assert.Single(problem.Errors);
+            Assert.All(problem.Errors, error =>
+            {
+                Assert.Equal(ValidationErrors.UserNotAuthorized.ErrorCode, error.ErrorCode);
+            });
+
+            // Nothing was persisted.
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegationResources = await db.DelegationResources
+                    .Where(r => r.ResourceId == TestData.SiriusSkattemelding.Id)
+                    .ToListAsync(TestContext.Current.CancellationToken);
+
+                Assert.Empty(delegationResources);
+            });
+        }
+
+        [Fact]
+        public async Task DelegateResource_WithNonExistentResource_Returns400WithResourceNotExists()
+        {
+            var client = CreateClient();
+
+            var response = await client.PostAsJsonAsync(
+                $"{Route}/agents/resources?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}",
+                new ContractsV2.ResourceDelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Accountant.Entity.Code,
+                            Resources = [Guid.CreateVersion7()]
+                        }
+                    ]
+                },
+                TestContext.Current.CancellationToken
+            );
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data, SerializerOptions);
+            Assert.Single(problem.Errors);
+            Assert.All(problem.Errors, error =>
+            {
+                Assert.Equal(ValidationErrors.ResourceNotExists.ErrorCode, error.ErrorCode);
+            });
+        }
+    }
+
+    #endregion
+
+    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/agents/resources
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DeleteAgentResource(Guid, Guid, Guid, ContractsV2.ResourceDelegationBatchInputDto, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteAgentResource : IClassFixture<ApiFixture>
+    {
+        public DeleteAgentResource(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DeleteAgentResource>(db =>
+            {
+                var accountantFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var agentFromVerdiqToOrjan = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonOrjan,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var assignmentResourceAccountant = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                // Paula has only the resource delegated, so removing it must delete the delegation.
+                var delegationToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var delegationResourceToPaula = new DelegationResource()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceAccountant.Id,
+                };
+
+                // Orjan has both a package and the resource, so removing the resource keeps the delegation.
+                var rolePackage = db.RolePackages.FirstOrDefault(r => r.RoleId == RoleConstants.Accountant && r.PackageId == PackageConstants.AccountantWithSigningRights);
+                var delegationToOrjan = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToOrjan.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var delegationPackageToOrjan = new DelegationPackage()
+                {
+                    DelegationId = delegationToOrjan.Id,
+                    RolePackageId = rolePackage.Id,
+                    PackageId = PackageConstants.AccountantWithSigningRights,
+                };
+
+                var delegationResourceToOrjan = new DelegationResource()
+                {
+                    DelegationId = delegationToOrjan.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceAccountant.Id,
+                };
+
+                db.Assignments.Add(accountantFromNordisToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.Assignments.Add(agentFromVerdiqToOrjan);
+                db.AssignmentResources.Add(assignmentResourceAccountant);
+                db.Delegations.Add(delegationToPaula);
+                db.Delegations.Add(delegationToOrjan);
+                db.DelegationResources.Add(delegationResourceToPaula);
+                db.DelegationPackages.Add(delegationPackageToOrjan);
+                db.DelegationResources.Add(delegationResourceToOrjan);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DeleteResource_WhenLastAccessOnDelegation_Returns200WithRemovedDelegation()
+        {
+            var client = CreateClient();
+
+            var deleteResult = await DeleteResource(client, TestEntities.PersonPaula.Id);
+
+            var deleted = Assert.Single(deleteResult);
+            Assert.True(deleted.Changed);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, deleted.ResourceId);
+
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegation = await db.Delegations
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id && d.To.ToId == TestEntities.PersonPaula.Id)
+                    .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+                Assert.Null(delegation);
+
+                var delegationResource = await db.DelegationResources
+                    .Where(r => r.ResourceId == TestData.MattilsynetBakeryService.Id && r.Delegation.To.ToId == TestEntities.PersonPaula.Id)
+                    .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+                Assert.Null(delegationResource);
+            });
+
+            // Second removal is a no-op.
+            deleteResult = await DeleteResource(client, TestEntities.PersonPaula.Id);
+            deleted = Assert.Single(deleteResult);
+            Assert.False(deleted.Changed);
+        }
+
+        [Fact]
+        public async Task DeleteResource_WithRemainingPackage_Returns200WithKeptDelegation()
+        {
+            var client = CreateClient();
+
+            var deleteResult = await DeleteResource(client, TestEntities.PersonOrjan.Id);
+
+            var deleted = Assert.Single(deleteResult);
+            Assert.True(deleted.Changed);
+
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegation = await db.Delegations
+                    .Include(d => d.DelegationPackages)
+                    .Include(d => d.DelegationResources)
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id && d.To.ToId == TestEntities.PersonOrjan.Id)
+                    .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+                Assert.NotNull(delegation);
+                Assert.Empty(delegation.DelegationResources);
+                Assert.NotEmpty(delegation.DelegationPackages);
+            });
+        }
+
+        private static async Task<List<ContractsV2.ResourceDelegationDto>> DeleteResource(HttpClient client, Guid agent)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/resources?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={agent}")
+            {
+                Content = JsonContent.Create(new ContractsV2.ResourceDelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Accountant.Entity.Code,
+                            Resources = [TestData.MattilsynetBakeryService.Id],
+                        }
+                    ]
+                })
+            };
+
+            var deleteResponse = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var deleteResponsePayload = await deleteResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+            return JsonSerializer.Deserialize<List<ContractsV2.ResourceDelegationDto>>(deleteResponsePayload);
         }
     }
     #endregion

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentDto.cs
@@ -25,28 +25,4 @@ public class AgentDto
     /// </summary>
     [JsonPropertyName("access")]
     public List<RoleAccess> Access { get; set; } = [];
-
-    /// <summary>
-    /// Access given through a single role
-    /// </summary>
-    public class RoleAccess
-    {
-        /// <summary>
-        /// Role
-        /// </summary>
-        [JsonPropertyName("role")]
-        public CompactRoleDto Role { get; set; }
-
-        /// <summary>
-        /// Packages
-        /// </summary>
-        [JsonPropertyName("packages")]
-        public List<CompactPackageDto> Packages { get; set; } = [];
-
-        /// <summary>
-        /// Resources
-        /// </summary>
-        [JsonPropertyName("resources")]
-        public List<CompactResourceDto> Resources { get; set; } = [];
-    }
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentPackagesDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentPackagesDto.cs
@@ -23,23 +23,5 @@ public class AgentPackagesDto
     /// Gets or sets a collection of all access information for the agent
     /// </summary>
     [JsonPropertyName("access")]
-    public List<RoleAccess> Access { get; set; } = [];
-
-    /// <summary>
-    /// Access given through a single role
-    /// </summary>
-    public class RoleAccess
-    {
-        /// <summary>
-        /// Role
-        /// </summary>
-        [JsonPropertyName("role")]
-        public CompactRoleDto Role { get; set; }
-
-        /// <summary>
-        /// Packages
-        /// </summary>
-        [JsonPropertyName("packages")]
-        public List<CompactPackageDto> Packages { get; set; } = [];
-    }
+    public List<PackageAccess> Access { get; set; } = [];
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentResourcesDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentResourcesDto.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing a connected agent party with the resources delegated per role.
+/// </summary>
+public class AgentResourcesDto
+{
+    /// <summary>
+    /// Gets or sets the party
+    /// </summary>
+    [JsonPropertyName("agent")]
+    public CompactEntityDto Agent { get; set; }
+
+    /// <summary>
+    /// Specifies when the <see cref="Agent"/> was added.
+    /// </summary>
+    [JsonPropertyName("agentAddedAt")]
+    public DateTimeOffset AgentAddedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets a collection of all access information for the agent
+    /// </summary>
+    [JsonPropertyName("access")]
+    public List<RoleAccess> Access { get; set; } = [];
+
+    /// <summary>
+    /// Access given through a single role
+    /// </summary>
+    public class RoleAccess
+    {
+        /// <summary>
+        /// Role
+        /// </summary>
+        [JsonPropertyName("role")]
+        public CompactRoleDto Role { get; set; }
+
+        /// <summary>
+        /// Resources
+        /// </summary>
+        [JsonPropertyName("resources")]
+        public List<CompactResourceDto> Resources { get; set; } = [];
+    }
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentResourcesDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/AgentResourcesDto.cs
@@ -14,32 +14,8 @@ public class AgentResourcesDto
     public CompactEntityDto Agent { get; set; }
 
     /// <summary>
-    /// Specifies when the <see cref="Agent"/> was added.
-    /// </summary>
-    [JsonPropertyName("agentAddedAt")]
-    public DateTimeOffset AgentAddedAt { get; set; }
-
-    /// <summary>
     /// Gets or sets a collection of all access information for the agent
     /// </summary>
     [JsonPropertyName("access")]
-    public List<RoleAccess> Access { get; set; } = [];
-
-    /// <summary>
-    /// Access given through a single role
-    /// </summary>
-    public class RoleAccess
-    {
-        /// <summary>
-        /// Role
-        /// </summary>
-        [JsonPropertyName("role")]
-        public CompactRoleDto Role { get; set; }
-
-        /// <summary>
-        /// Resources
-        /// </summary>
-        [JsonPropertyName("resources")]
-        public List<CompactResourceDto> Resources { get; set; } = [];
-    }
+    public List<ResourceAccess> Access { get; set; } = [];
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientDto.cs
@@ -19,28 +19,4 @@ public class ClientDto
     /// </summary>
     [JsonPropertyName("access")]
     public List<RoleAccess> Access { get; set; } = [];
-
-    /// <summary>
-    /// Access given through a single role
-    /// </summary>
-    public class RoleAccess
-    {
-        /// <summary>
-        /// Role
-        /// </summary>
-        [JsonPropertyName("role")]
-        public CompactRoleDto Role { get; set; }
-
-        /// <summary>
-        /// Packages
-        /// </summary>
-        [JsonPropertyName("packages")]
-        public List<CompactPackageDto> Packages { get; set; } = [];
-
-        /// <summary>
-        /// Resources
-        /// </summary>
-        [JsonPropertyName("resources")]
-        public List<CompactResourceDto> Resources { get; set; } = [];
-    }
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientPackagesDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientPackagesDto.cs
@@ -17,23 +17,5 @@ public class ClientPackagesDto
     /// Gets or sets a collection of all access information for the client
     /// </summary>
     [JsonPropertyName("access")]
-    public List<RoleAccess> Access { get; set; } = [];
-
-    /// <summary>
-    /// Access given through a single role
-    /// </summary>
-    public class RoleAccess
-    {
-        /// <summary>
-        /// Role
-        /// </summary>
-        [JsonPropertyName("role")]
-        public CompactRoleDto Role { get; set; }
-
-        /// <summary>
-        /// Packages
-        /// </summary>
-        [JsonPropertyName("packages")]
-        public List<CompactPackageDto> Packages { get; set; } = [];
-    }
+    public List<PackageAccess> Access { get; set; } = [];
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientResourcesDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientResourcesDto.cs
@@ -17,23 +17,5 @@ public class ClientResourcesDto
     /// Gets or sets a collection of all access information for the client
     /// </summary>
     [JsonPropertyName("access")]
-    public List<RoleAccess> Access { get; set; } = [];
-
-    /// <summary>
-    /// Access given through a single role
-    /// </summary>
-    public class RoleAccess
-    {
-        /// <summary>
-        /// Role
-        /// </summary>
-        [JsonPropertyName("role")]
-        public CompactRoleDto Role { get; set; }
-
-        /// <summary>
-        /// Resources
-        /// </summary>
-        [JsonPropertyName("resources")]
-        public List<CompactResourceDto> Resources { get; set; } = [];
-    }
+    public List<ResourceAccess> Access { get; set; } = [];
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientResourcesDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ClientResourcesDto.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing a connected client party with the resources delegated per role.
+/// </summary>
+public class ClientResourcesDto
+{
+    /// <summary>
+    /// Gets or sets the party
+    /// </summary>
+    [JsonPropertyName("client")]
+    public CompactEntityDto Client { get; set; }
+
+    /// <summary>
+    /// Gets or sets a collection of all access information for the client
+    /// </summary>
+    [JsonPropertyName("access")]
+    public List<RoleAccess> Access { get; set; } = [];
+
+    /// <summary>
+    /// Access given through a single role
+    /// </summary>
+    public class RoleAccess
+    {
+        /// <summary>
+        /// Role
+        /// </summary>
+        [JsonPropertyName("role")]
+        public CompactRoleDto Role { get; set; }
+
+        /// <summary>
+        /// Resources
+        /// </summary>
+        [JsonPropertyName("resources")]
+        public List<CompactResourceDto> Resources { get; set; } = [];
+    }
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/MyClientProviderDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/MyClientProviderDto.cs
@@ -25,28 +25,4 @@ public class MyClientProviderDto
     /// </summary>
     [JsonPropertyName("access")]
     public List<RoleAccess> Access { get; set; } = [];
-
-    /// <summary>
-    /// Access given through a single role
-    /// </summary>
-    public class RoleAccess
-    {
-        /// <summary>
-        /// Role
-        /// </summary>
-        [JsonPropertyName("role")]
-        public CompactRoleDto Role { get; set; }
-
-        /// <summary>
-        /// Packages
-        /// </summary>
-        [JsonPropertyName("packages")]
-        public List<CompactPackageDto> Packages { get; set; } = [];
-
-        /// <summary>
-        /// Resources
-        /// </summary>
-        [JsonPropertyName("resources")]
-        public List<CompactResourceDto> Resources { get; set; } = [];
-    }
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/PackageAccess.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/PackageAccess.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing package access granted through a single role. The role is what grants and ties together
+/// all the package accesses listed within the same model.
+/// </summary>
+public class PackageAccess
+{
+    /// <summary>
+    /// Gets or sets the role granting the packages listed in this model.
+    /// </summary>
+    [JsonPropertyName("role")]
+    public CompactRoleDto Role { get; set; }
+
+    /// <summary>
+    /// Gets or sets the packages granted through <see cref="Role"/>.
+    /// </summary>
+    [JsonPropertyName("packages")]
+    public List<CompactPackageDto> Packages { get; set; } = [];
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ResourceAccess.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ResourceAccess.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing resource access granted through a single role. The role is what grants and ties together
+/// all the resource accesses listed within the same model.
+/// </summary>
+public class ResourceAccess
+{
+    /// <summary>
+    /// Gets or sets the role granting the resources listed in this model.
+    /// </summary>
+    [JsonPropertyName("role")]
+    public CompactRoleDto Role { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resources granted through <see cref="Role"/>.
+    /// </summary>
+    [JsonPropertyName("resources")]
+    public List<CompactResourceDto> Resources { get; set; } = [];
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ResourceDelegationBatchInputDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ResourceDelegationBatchInputDto.cs
@@ -25,9 +25,9 @@ public class ResourceDelegationBatchInputDto
         public string Role { get; set; }
 
         /// <summary>
-        /// Identifiers of the resources to delegate or remove.
+        /// Resource registry identifiers of the resources to delegate or remove.
         /// </summary>
         [JsonPropertyName("resources")]
-        public List<Guid> Resources { get; set; } = [];
+        public List<string> Resources { get; set; } = [];
     }
 }

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ResourceDelegationBatchInputDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ResourceDelegationBatchInputDto.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Batch input for delegating or removing single resources between a client and an agent.
+/// </summary>
+public class ResourceDelegationBatchInputDto
+{
+    /// <summary>
+    /// The role and resource combinations to delegate or remove.
+    /// </summary>
+    [JsonPropertyName("values")]
+    public List<Permission> Values { get; set; } = [];
+
+    /// <summary>
+    /// Resources tied to a single role the client has assigned to the facilitator.
+    /// </summary>
+    public class Permission
+    {
+        /// <summary>
+        /// Code, urn or identifier of the role the client has assigned to the facilitator.
+        /// </summary>
+        [JsonPropertyName("role")]
+        public string Role { get; set; }
+
+        /// <summary>
+        /// Identifiers of the resources to delegate or remove.
+        /// </summary>
+        [JsonPropertyName("resources")]
+        public List<Guid> Resources { get; set; } = [];
+    }
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ResourceDelegationDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/ResourceDelegationDto.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Result of a single resource delegation operation between a client and an agent.
+/// </summary>
+public class ResourceDelegationDto
+{
+    /// <summary>
+    /// Identifier of the role the resource is delegated through.
+    /// </summary>
+    [JsonPropertyName("roleId")]
+    public Guid RoleId { get; set; }
+
+    /// <summary>
+    /// Identifier of the delegated resource.
+    /// </summary>
+    [JsonPropertyName("resourceId")]
+    public Guid ResourceId { get; set; }
+
+    /// <summary>
+    /// Identifier of the facilitator party the delegation goes through.
+    /// </summary>
+    [JsonPropertyName("viaId")]
+    public Guid ViaId { get; set; }
+
+    /// <summary>
+    /// Identifier of the client party the resource is delegated from.
+    /// </summary>
+    [JsonPropertyName("fromId")]
+    public Guid FromId { get; set; }
+
+    /// <summary>
+    /// Identifier of the agent party the resource is delegated to.
+    /// </summary>
+    [JsonPropertyName("toId")]
+    public Guid ToId { get; set; }
+
+    /// <summary>
+    /// Indicates whether the request resulted in any state change.
+    /// </summary>
+    [JsonPropertyName("changed")]
+    public bool Changed { get; set; }
+}

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/RoleAccess.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/RoleAccess.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Altinn.Authorization.Api.Contracts.AccessManagement.V2;
+
+/// <summary>
+/// Model representing access granted through a single role. The role is what grants and ties together
+/// all the package and resource accesses listed within the same model.
+/// </summary>
+public class RoleAccess
+{
+    /// <summary>
+    /// Gets or sets the role granting the packages and resources listed in this model.
+    /// </summary>
+    [JsonPropertyName("role")]
+    public CompactRoleDto Role { get; set; }
+
+    /// <summary>
+    /// Gets or sets the packages granted through <see cref="Role"/>.
+    /// </summary>
+    [JsonPropertyName("packages")]
+    public List<CompactPackageDto> Packages { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the resources granted through <see cref="Role"/>.
+    /// </summary>
+    [JsonPropertyName("resources")]
+    public List<CompactResourceDto> Resources { get; set; } = [];
+}


### PR DESCRIPTION
Closes #3771
Closes #3796

Adds delegation of single resources to agents in the /v2/ client delegation API, completing the resources feature (#3638) end to end.

- New `agents/resources` and `clients/resources` endpoints, siblings to the accesspackages endpoints with the same authorization and audit setup: GET in both directions (grouped by client and by agent), POST delegates and DELETE removes, with resource specific models (`ClientResourcesDto`, `AgentResourcesDto`, `ResourceDelegationBatchInputDto`, `ResourceDelegationDto`). Delegation input carries the resource registry id, not the internal guid
- The v2 access models are shared contract types: `RoleAccess` (role, packages and resources on the combined listings), `PackageAccess` and `ResourceAccess`, where the docs state the role is what grants and ties the accesses listed in the model. The resources listing carries no `agentAddedAt`
- `GET clients` gains a `resources` filter with the same AND semantics as the `roles` and `packages` filters, matching clients on their delegated single resources
- The write path resolves the `AssignmentResource` on the client assignment per role and rejects resources without one, which is what keeps package held resources from being delegated individually. Created `DelegationResource` rows carry the required `AssignmentResourceId` FK
- Delegations are deleted only when neither packages nor resources remain, on both the package and resource removal paths
- Fixes the pre-existing batch bug in `RemoveAgentDelegation`: scheduled package removals are matched per delegation instead of across the whole batch, so a multi role batch can no longer block deletion of an emptied delegation or delete a delegation that shares a package id with another role
- Repeated roles or resources in one payload are idempotent no-ops instead of unique index collisions at save time
- `GetAgentsV2` returns delegated resources per role

New integration tests cover the delegate, list and remove flows, the package held rejection, both cascade cases, payload idempotency, the filter combinations and the multi role batch. The v1 suites are untouched and green. With this, resource access flows end to end in /v2/; external exposure still waits on the APIM rules.
