### PR TITLE
fix: point v2 client delegation validation errors at the renamed query parameters

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/ClientDelegationController.cs
@@ -154,7 +154,7 @@ public class ClientDelegationController(
             return Unauthorized();
         }
 
-        var result = await clientDelegationService.DeleteMyClient(partyUuid, provider, from, payload, cancellationToken);
+        var result = await clientDelegationService.DeleteMyClient(partyUuid, provider, from, payload, ClientDelegationParameterNames.V1, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -241,7 +241,7 @@ public class ClientDelegationController(
             return entity.Problem.ToActionResult();
         }
 
-        var result = await clientDelegationService.AddAgent(party, entity.Value.Id, cancellationToken);
+        var result = await clientDelegationService.AddAgent(party, entity.Value.Id, ClientDelegationParameterNames.V1, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -355,7 +355,7 @@ public class ClientDelegationController(
         [FromBody][Required] DelegationBatchInputDto payload,
         CancellationToken cancellationToken = default)
     {
-        var result = await clientDelegationService.DelegateAccessPackageToAgent(party, from, to, payload, cancellationToken);
+        var result = await clientDelegationService.DelegateAccessPackageToAgent(party, from, to, payload, ClientDelegationParameterNames.V1, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -380,7 +380,7 @@ public class ClientDelegationController(
         CancellationToken cancellationToken = default
     )
     {
-        var result = await clientDelegationService.RemoveAgentDelegation(party, from, to, payload, cancellationToken);
+        var result = await clientDelegationService.RemoveAgentDelegation(party, from, to, payload, ClientDelegationParameterNames.V1, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
@@ -151,7 +151,15 @@ public class ClientDelegationController(
             return Unauthorized();
         }
 
-        var result = await clientDelegationService.DeleteMyClient(authenticatedUser, provider, client, payload, cancellationToken);
+        // The agent is the authenticated user, so agent errors point at the provider
+        // parameter that names the relationship.
+        var result = await clientDelegationService.DeleteMyClient(
+            authenticatedUser,
+            provider,
+            client,
+            payload,
+            new ClientDelegationParameterNames(Party: "provider", Client: "client", Agent: "provider"),
+            cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -230,6 +238,7 @@ public class ClientDelegationController(
             {
                 options.AllowedToEntityTypes = [EntityTypeConstants.Person, EntityTypeConstants.SystemUser];
                 options.EntitiesToValidateForAnyConnections = [EntityTypeConstants.Person];
+                options.ToParameterName = "agent";
             },
             cancellationToken);
 
@@ -238,7 +247,7 @@ public class ClientDelegationController(
             return entity.Problem.ToActionResult();
         }
 
-        var result = await clientDelegationService.AddAgent(party, entity.Value.Id, cancellationToken);
+        var result = await clientDelegationService.AddAgent(party, entity.Value.Id, ClientDelegationParameterNames.V2, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -352,7 +361,7 @@ public class ClientDelegationController(
         [FromBody][Required] DelegationBatchInputDto payload,
         CancellationToken cancellationToken = default)
     {
-        var result = await clientDelegationService.DelegateAccessPackageToAgent(party, client, agent, payload, cancellationToken);
+        var result = await clientDelegationService.DelegateAccessPackageToAgent(party, client, agent, payload, ClientDelegationParameterNames.V2, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();
@@ -377,7 +386,7 @@ public class ClientDelegationController(
         CancellationToken cancellationToken = default
     )
     {
-        var result = await clientDelegationService.RemoveAgentDelegation(party, client, agent, payload, cancellationToken);
+        var result = await clientDelegationService.RemoveAgentDelegation(party, client, agent, payload, ClientDelegationParameterNames.V2, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/InputValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/InputValidation.cs
@@ -66,7 +66,7 @@ public class InputValidation(
         errorBuilder.Add(
             ValidationErrors.Required,
             [$"QUERY/{options.ToParameterName}", $"/{nameof(personInput.PersonIdentifier)}", $"/{nameof(personInput.LastName)}"],
-            [new("params", $"Invalid combination of params. Either 'QUERY/{options.ToParameterName}'  must be set or '/{nameof(personInput.PersonIdentifier)}' and '/{nameof(personInput.LastName)}'.")]
+            [new("params", $"Invalid combination of params. Either 'QUERY/{options.ToParameterName}' must be set or '/{nameof(personInput.PersonIdentifier)}' and '/{nameof(personInput.LastName)}'.")]
         );
         errorBuilder.TryBuild(out var problemInstance);
         return problemInstance;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/InputValidation.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Validation/InputValidation.cs
@@ -29,7 +29,7 @@ public class InputValidation(
             var toEntity = await entityService.GetEntity(toPartyUuid, cancellationToken);
             if (toEntity is null)
             {
-                errorBuilder.Add(ValidationErrors.EntityNotExists, "QUERY/to", [new($"to", $"Cannot find any parties with uuid '{toParty}'.")]);
+                errorBuilder.Add(ValidationErrors.EntityNotExists, $"QUERY/{options.ToParameterName}", [new(options.ToParameterName, $"Cannot find any parties with uuid '{toParty}'.")]);
             }
 
             if (toEntity is { } && options.EntitiesToValidateForAnyConnections.Contains(toEntity.TypeId))
@@ -47,7 +47,7 @@ public class InputValidation(
                     return toEntity;
                 }
 
-                errorBuilder.Add(ValidationErrors.EntityNotExists, "QUERY/to", [new($"to", $"Cannot find any parties with uuid '{toParty}'.")]);
+                errorBuilder.Add(ValidationErrors.EntityNotExists, $"QUERY/{options.ToParameterName}", [new(options.ToParameterName, $"Cannot find any parties with uuid '{toParty}'.")]);
             }
 
             if (errorBuilder.TryBuild(out var problem))
@@ -65,8 +65,8 @@ public class InputValidation(
 
         errorBuilder.Add(
             ValidationErrors.Required,
-            ["QUERY/to", $"/{nameof(personInput.PersonIdentifier)}", $"/{nameof(personInput.LastName)}"],
-            [new("params", $"Invalid combination of params. Either 'QUERY/to'  must be set or '/{nameof(personInput.PersonIdentifier)}' and '/{nameof(personInput.LastName)}'.")]
+            [$"QUERY/{options.ToParameterName}", $"/{nameof(personInput.PersonIdentifier)}", $"/{nameof(personInput.LastName)}"],
+            [new("params", $"Invalid combination of params. Either 'QUERY/{options.ToParameterName}'  must be set or '/{nameof(personInput.PersonIdentifier)}' and '/{nameof(personInput.LastName)}'.")]
         );
         errorBuilder.TryBuild(out var problemInstance);
         return problemInstance;
@@ -146,6 +146,12 @@ public class SanitizeOptions
     public IReadOnlyCollection<Guid> EntitiesToValidateForAnyConnections { get; set; } = [];
 
     public IReadOnlyCollection<Guid> AllowedToEntityTypes { get; set; } = [];
+
+    /// <summary>
+    /// Name of the query parameter holding the target entity, used in validation
+    /// error pointers so they match the parameter name the endpoint exposes.
+    /// </summary>
+    public string ToParameterName { get; set; } = "to";
 }
 
 public interface IInputValidation

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -327,9 +327,9 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
-    public async Task<Result<List<DelegationDto>>> DeleteMyClient(Guid partyUuid, Guid providerUuid, Guid fromUuid, DelegationBatchInputDto payload, CancellationToken cancellationToken = default)
+    public async Task<Result<List<DelegationDto>>> DeleteMyClient(Guid partyUuid, Guid providerUuid, Guid fromUuid, DelegationBatchInputDto payload, ClientDelegationParameterNames parameterNames, CancellationToken cancellationToken = default)
     {
-        return await RemoveAgentDelegation(providerUuid, fromUuid, partyUuid, payload, cancellationToken);
+        return await RemoveAgentDelegation(providerUuid, fromUuid, partyUuid, payload, parameterNames, cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -586,7 +586,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
-    public async Task<Result<AssignmentDto>> AddAgent(Guid partyUuid, Guid toUuid, CancellationToken cancellationToken = default)
+    public async Task<Result<AssignmentDto>> AddAgent(Guid partyUuid, Guid toUuid, ClientDelegationParameterNames parameterNames, CancellationToken cancellationToken = default)
     {
         ValidationErrorBuilder errorBuilder = default;
 
@@ -607,7 +607,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             var supportedToTypeNames = string.Join(", ", SupportedToTypes.Select(t => t.Entity.Name));
             errorBuilder.Add(
                 ValidationErrors.DisallowedEntityType,
-                "$QUERY/to",
+                $"$QUERY/{parameterNames.Agent}",
                 [new($"{entity.TypeId}", $"Entity type is not supported as an agent. Supported types: <{supportedToTypeNames}>.")]
             );
         }
@@ -616,7 +616,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.DisallowedEntityType,
-                "$QUERY/to",
+                $"$QUERY/{parameterNames.Agent}",
                 [new($"{toUuid}", $"System user with id '{toUuid}' is not created for client delegation.")]
             );
         }
@@ -946,6 +946,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         Guid fromId,
         Guid toId,
         DelegationBatchInputDto payload,
+        ClientDelegationParameterNames parameterNames,
         CancellationToken cancellationToken = default)
     {
         ValidationErrorBuilder errorBuilder = default;
@@ -1020,7 +1021,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
-                $"$QUERY/from",
+                $"$QUERY/{parameterNames.Client}",
                 [new($"{fromId}", "entity do not exist.")]
             );
         }
@@ -1029,7 +1030,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
-                $"$QUERY/to",
+                $"$QUERY/{parameterNames.Agent}",
                 [new($"{toId}", "entity do not exist.")]
             );
         }
@@ -1049,7 +1050,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             {
                 errorBuilder.Add(
                     ValidationErrors.MissingAssignment,
-                    $"$QUERY/to",
+                    $"$QUERY/{parameterNames.Agent}",
                     [new(RoleConstants.Agent.Entity.Urn, $"Role is not assigned to '{toId}' from '{partyId}'.")]
                 );
             }
@@ -1071,7 +1072,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             var supportedToTypeNames = string.Join(", ", SupportedToTypes.Select(t => t.Entity.Name));
             errorBuilder.Add(
                 ValidationErrors.DisallowedEntityType,
-                "$QUERY/to",
+                $"$QUERY/{parameterNames.Agent}",
                 [new($"{to.TypeId}", $"entity type is not supported as agent, only <{supportedToTypeNames}>.")]
             );
         }
@@ -1080,7 +1081,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.DisallowedEntityType,
-                "$QUERY/to",
+                $"$QUERY/{parameterNames.Agent}",
                 [new($"{to.Id}", $"system user '{to.Id}' is not created for client delegation.")]
             );
         }
@@ -1222,6 +1223,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         Guid fromUuid,
         Guid toUuid,
         DelegationBatchInputDto payload,
+        ClientDelegationParameterNames parameterNames,
         CancellationToken cancellationToken = default)
     {
         ValidationErrorBuilder errorBuilder = default;
@@ -1283,7 +1285,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
-                "$QUERY/party",
+                $"$QUERY/{parameterNames.Party}",
                 [new($"{partyUuid}", "entity do not exist.")]
             );
         }
@@ -1292,7 +1294,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
-                $"$QUERY/from",
+                $"$QUERY/{parameterNames.Client}",
                 [new($"{fromUuid}", "entity do not exist.")]
             );
         }
@@ -1301,7 +1303,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
-                $"$QUERY/to",
+                $"$QUERY/{parameterNames.Agent}",
                 [new($"{toUuid}", "entity do not exist.")]
             );
         }
@@ -1313,7 +1315,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.MissingAssignment,
-                $"$QUERY/to",
+                $"$QUERY/{parameterNames.Agent}",
                 [new(RoleConstants.Agent.Entity.Urn, $"Role is not assigned to '{toUuid}' from '{partyUuid}'.")]
             );
         }
@@ -1496,6 +1498,7 @@ public interface IClientDelegationService
         Guid providerUuid,
         Guid fromUuid,
         DelegationBatchInputDto payload,
+        ClientDelegationParameterNames parameterNames,
         CancellationToken cancellationToken = default);
 
     #endregion
@@ -1543,6 +1546,7 @@ public interface IClientDelegationService
     Task<Result<AssignmentDto>> AddAgent(
         Guid partyUuid,
         Guid toUuid,
+        ClientDelegationParameterNames parameterNames,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -1602,6 +1606,7 @@ public interface IClientDelegationService
         Guid fromUuid,
         Guid toUuid,
         DelegationBatchInputDto payload,
+        ClientDelegationParameterNames parameterNames,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -1612,7 +1617,29 @@ public interface IClientDelegationService
         Guid fromUuid,
         Guid toUuid,
         DelegationBatchInputDto payload,
+        ClientDelegationParameterNames parameterNames,
         CancellationToken cancellationToken = default);
 
     #endregion
+}
+
+/// <summary>
+/// Names of the query parameters a client delegation endpoint exposes for the party,
+/// client and agent entities. Validation error pointers are built from these names,
+/// so each API version points at the parameters present on its own routes.
+/// </summary>
+/// <param name="Party">Name of the query parameter holding the facilitator party.</param>
+/// <param name="Client">Name of the query parameter holding the client entity.</param>
+/// <param name="Agent">Name of the query parameter holding the agent entity.</param>
+public sealed record ClientDelegationParameterNames(string Party, string Client, string Agent)
+{
+    /// <summary>
+    /// Parameter names exposed by the v1 endpoints.
+    /// </summary>
+    public static ClientDelegationParameterNames V1 { get; } = new("party", "from", "to");
+
+    /// <summary>
+    /// Parameter names exposed by the v2 endpoints.
+    /// </summary>
+    public static ClientDelegationParameterNames V2 { get; } = new("party", "client", "agent");
 }

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ClientDelegationControllerTest.cs
@@ -779,7 +779,7 @@ public class ClientDelegationControllerTest
             Assert.All(problem.Errors, error =>
             {
                 Assert.Equal(ValidationErrors.EntityNotExists.ErrorCode, error.ErrorCode);
-                Assert.Contains("QUERY/to", error.Paths);
+                Assert.Contains("$QUERY/to", error.Paths);
             });
         }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ClientDelegationControllerTest.cs
@@ -779,7 +779,8 @@ public class ClientDelegationControllerTest
             Assert.All(problem.Errors, error =>
             {
                 Assert.Equal(ValidationErrors.EntityNotExists.ErrorCode, error.ErrorCode);
-                Assert.Contains("$QUERY/to", error.Paths);
+                Assert.Contains("QUERY/to", error.Paths);
+                Assert.DoesNotContain("QUERY/agent", error.Paths);
             });
         }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/ClientDelegationControllerTest.cs
@@ -761,6 +761,25 @@ public class ClientDelegationControllerTest
             Assert.All(problem.Errors, error =>
             {
                 Assert.Equal(ValidationErrors.DisallowedEntityType.ErrorCode, error.ErrorCode);
+                Assert.Contains("$QUERY/to", error.Paths);
+            });
+        }
+
+        [Fact]
+        public async Task AddAgent_WithUnknownTo_Returns400WithToQueryPointer()
+        {
+            var client = CreateClient();
+            var response = await client.PostAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&to={Guid.NewGuid()}", null, TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data);
+
+            Assert.Single(problem.Errors);
+            Assert.All(problem.Errors, error =>
+            {
+                Assert.Equal(ValidationErrors.EntityNotExists.ErrorCode, error.ErrorCode);
+                Assert.Contains("QUERY/to", error.Paths);
             });
         }
 
@@ -1503,6 +1522,35 @@ public class ClientDelegationControllerTest
             {
                 Assert.Equal(ValidationErrors.PackageIsNotDelegable.ErrorCode, error.ErrorCode);
             });
+        }
+
+        [Fact]
+        public async Task DelegateAccessPackageToAgent_WithUnknownFromAndTo_Returns400WithFromAndToQueryPointers()
+        {
+            var client = CreateClient();
+            var response = await client.PostAsJsonAsync(
+                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&from={Guid.NewGuid()}&to={Guid.NewGuid()}",
+                new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                },
+                TestContext.Current.CancellationToken
+            );
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data);
+
+            Assert.Equal(2, problem.Errors.Count);
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/from"));
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/to"));
         }
     }
 
@@ -2383,6 +2431,97 @@ public class ClientDelegationControllerTest
                 var deleteResult = JsonSerializer.Deserialize<List<DelegationDto>>(deleteResponsePayload);
                 return deleteResult;
             }
+        }
+
+        [Fact]
+        public async Task DeleteAccessPackageToAgent_WithUnknownPartyFromAndTo_Returns400WithV1QueryPointers()
+        {
+            var client = CreateClient();
+
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/accesspackages?party={Guid.NewGuid()}&from={Guid.NewGuid()}&to={Guid.NewGuid()}")
+            {
+                Content = JsonContent.Create(new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                })
+            };
+
+            var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data);
+
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/party"));
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/from"));
+            Assert.Contains(problem.Errors, e => e.Paths.Contains("$QUERY/to"));
+            Assert.DoesNotContain(problem.Errors, e => e.Paths.Contains("$QUERY/client") || e.Paths.Contains("$QUERY/agent"));
+        }
+    }
+    #endregion
+
+    #region DELETE accessmanagement/api/v1/enduser/clientdelegations/my/clients/accesspackages
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DeleteMyPackagesToClientViaProvider(Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteMyClientAccessPackages : IClassFixture<ApiFixture>
+    {
+        public DeleteMyClientAccessPackages(ApiFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", AuthzConstants.SCOPE_PORTAL_ENDUSER));
+            });
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DeleteMyClientAccessPackages_WithUnknownProviderAndFrom_Returns400WithV1QueryPointers()
+        {
+            var client = CreateClient();
+
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/my/clients/accesspackages?provider={Guid.NewGuid()}&from={Guid.NewGuid()}")
+            {
+                Content = JsonContent.Create(new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                })
+            };
+
+            var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data);
+
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/party"));
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/from"));
+            Assert.Contains(problem.Errors, e => e.Paths.Contains("$QUERY/to"));
+            Assert.DoesNotContain(problem.Errors, e => e.Paths.Contains("$QUERY/provider") || e.Paths.Contains("$QUERY/client"));
         }
     }
     #endregion

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -685,7 +685,7 @@ public class ClientDelegationControllerTest
             Assert.All(problem.Errors, error =>
             {
                 Assert.Equal(ValidationErrors.EntityNotExists.ErrorCode, error.ErrorCode);
-                Assert.Contains("QUERY/agent", error.Paths);
+                Assert.Contains("$QUERY/agent", error.Paths);
             });
         }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -685,7 +685,8 @@ public class ClientDelegationControllerTest
             Assert.All(problem.Errors, error =>
             {
                 Assert.Equal(ValidationErrors.EntityNotExists.ErrorCode, error.ErrorCode);
-                Assert.Contains("$QUERY/agent", error.Paths);
+                Assert.Contains("QUERY/agent", error.Paths);
+                Assert.DoesNotContain("QUERY/to", error.Paths);
             });
         }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -667,6 +667,25 @@ public class ClientDelegationControllerTest
             Assert.All(problem.Errors, error =>
             {
                 Assert.Equal(ValidationErrors.DisallowedEntityType.ErrorCode, error.ErrorCode);
+                Assert.Contains("$QUERY/agent", error.Paths);
+            });
+        }
+
+        [Fact]
+        public async Task AddAgent_WithUnknownAgent_Returns400WithAgentQueryPointer()
+        {
+            var client = CreateClient();
+            var response = await client.PostAsync($"{Route}/agents?party={TestEntities.OrganizationVerdiqAS}&agent={Guid.NewGuid()}", null, TestContext.Current.CancellationToken);
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data, SerializerOptions);
+
+            Assert.Single(problem.Errors);
+            Assert.All(problem.Errors, error =>
+            {
+                Assert.Equal(ValidationErrors.EntityNotExists.ErrorCode, error.ErrorCode);
+                Assert.Contains("QUERY/agent", error.Paths);
             });
         }
 
@@ -1065,6 +1084,68 @@ public class ClientDelegationControllerTest
             Assert.Equal(RoleConstants.Rightholder.Entity.Code, accessToClient.Access.FirstOrDefault()?.Role?.Code);
             Assert.Equal(PackageConstants.Customs.Entity.Urn, accessToClient.Access.FirstOrDefault()?.Packages?.FirstOrDefault().Urn);
         }
+
+        [Fact]
+        public async Task DelegateAccessPackageToAgent_WithUnknownClientAndAgent_Returns400WithClientAndAgentQueryPointers()
+        {
+            var client = CreateClient();
+
+            var response = await client.PostAsJsonAsync(
+                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&client={Guid.NewGuid()}&agent={Guid.NewGuid()}",
+                new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                },
+                TestContext.Current.CancellationToken
+            );
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data, SerializerOptions);
+
+            Assert.Equal(2, problem.Errors.Count);
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/client"));
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/agent"));
+            Assert.DoesNotContain(problem.Errors, e => e.Paths.Contains("$QUERY/from") || e.Paths.Contains("$QUERY/to"));
+        }
+
+        [Fact]
+        public async Task DelegateAccessPackageToAgent_WithPersonWithoutAgentAssignment_Returns400WithAgentQueryPointer()
+        {
+            var client = CreateClient();
+
+            var response = await client.PostAsJsonAsync(
+                $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonOrjan}",
+                new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                },
+                TestContext.Current.CancellationToken
+            );
+
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data, SerializerOptions);
+
+            Assert.Single(problem.Errors);
+            Assert.All(problem.Errors, error =>
+            {
+                Assert.Equal(ValidationErrors.MissingAssignment.ErrorCode, error.ErrorCode);
+                Assert.Contains("$QUERY/agent", error.Paths);
+            });
+        }
     }
 
     #endregion
@@ -1175,6 +1256,96 @@ public class ClientDelegationControllerTest
             var delegationToAgentResult = JsonSerializer.Deserialize<PaginatedResult<ContractsV2.ClientPackagesDto>>(delegationsToAgentPayload);
 
             Assert.Empty(delegationToAgentResult.Items);
+        }
+
+        [Fact]
+        public async Task DeleteAccessPackageToAgent_WithUnknownPartyClientAndAgent_Returns400WithV2QueryPointers()
+        {
+            var client = CreateClient();
+
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/accesspackages?party={Guid.NewGuid()}&client={Guid.NewGuid()}&agent={Guid.NewGuid()}")
+            {
+                Content = JsonContent.Create(new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                })
+            };
+
+            var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data, SerializerOptions);
+
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/party"));
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/client"));
+            Assert.Contains(problem.Errors, e => e.Paths.Contains("$QUERY/agent"));
+            Assert.DoesNotContain(problem.Errors, e => e.Paths.Contains("$QUERY/from") || e.Paths.Contains("$QUERY/to"));
+        }
+    }
+    #endregion
+
+    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/my/clients/accesspackages
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DeleteMyPackagesToClientViaProvider(Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteMyClientAccessPackages : IClassFixture<ApiFixture>
+    {
+        public DeleteMyClientAccessPackages(ApiFixture fixture)
+        {
+            Fixture = fixture;
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", AuthzConstants.SCOPE_PORTAL_ENDUSER));
+            });
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DeleteMyClientAccessPackages_WithUnknownProviderAndClient_Returns400WithProviderAndClientQueryPointers()
+        {
+            var client = CreateClient();
+
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/my/clients/accesspackages?provider={Guid.NewGuid()}&client={Guid.NewGuid()}")
+            {
+                Content = JsonContent.Create(new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Rightholder.Entity.Code,
+                            Packages = [PackageConstants.Customs.Entity.Urn]
+                        }
+                    ]
+                })
+            };
+
+            var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data, SerializerOptions);
+
+            Assert.Contains(problem.Errors, e => e.Paths.Contains("$QUERY/provider"));
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/client"));
+            Assert.DoesNotContain(problem.Errors, e => e.Paths.Contains("$QUERY/party") || e.Paths.Contains("$QUERY/from") || e.Paths.Contains("$QUERY/to") || e.Paths.Contains("$QUERY/agent"));
         }
     }
     #endregion


### PR DESCRIPTION
The v2 client delegation endpoints renamed the `from` and `to` query parameters to `client` and `agent`, but the service methods shared with v1 emitted fixed `$QUERY/from` and `$QUERY/to` validation error pointers. On the v2 accesspackages and agent endpoints those pointers named parameters that do not exist on the route.

The exposed parameter names now come from the caller through a `ClientDelegationParameterNames` record. v1 controllers pass the V1 set (`party`, `from`, `to`), so v1 responses are unchanged. v2 controllers pass the V2 set (`client`, `agent`), or on the `my/clients` routes the `provider` and `client` names those routes actually expose. `InputValidation` takes the target parameter name the same way for the AddAgent path.

`RemoveAgent` and `RemoveClientFromAgent` only emit a `$QUERY/cascade` pointer, which is identical on both versions, so they are left unchanged.

Integration tests assert the pointer paths on both versions: v1 keeps `party`/`from`/`to`, v2 uses `client`/`agent`/`provider`, and each version asserts the other version's names are absent.

Closes #3801
