### PR TITLE
fix: grant actions:read to the nightly sonar workflow

### DIFF
--- a/.github/workflows/sonar-nightly.yml
+++ b/.github/workflows/sonar-nightly.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: read
+  actions: read # tpl-vertical-ci.yml reads the jobs API to deep-link the failed-test summary
 
 # Never let two nightly scans overlap (a slow run must not stack on the next
 # day's), but don't cancel an in-progress scan — let it finish.


### PR DESCRIPTION
The nightly SonarCloud scan (`sonar-nightly.yml`) has ended in `startup_failure` with zero jobs every night since 2026-07-01, leaving main without a Sonar analysis for three weeks.

The workflow's `permissions:` block listed only `contents: read`, which sets every other scope to `none`. Its `analyze` job calls the reusable `tpl-vertical-ci.yml`, which requests `actions: read` (report-failed-tests.ps1 reads the jobs API). A caller cannot grant a reusable workflow more than it holds itself, so the graph failed to compile before any job ran. The run page reports it plainly: "The workflow is requesting 'actions: read', but is only allowed 'actions: none'."

That `actions: read` request was added to the template in #3591 (2026-06-30), so the next nightly run was the first to fail. The template's other caller, `ci.yml`, already grants `actions: read`, which is why PR and push CI kept working.

This adds `actions: read` to `sonar-nightly.yml`, matching `ci.yml`. The scope is read-only and matches exactly what the template needs. A workflow-graph change has no local build, so the green signal is the next scheduled run (or a manual `workflow_dispatch` on main) after merge.

Closes #3803
