### PR TITLE
chore(#3779): connection query cleanup | extract base query builder

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionBaseQueryBuilder.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionBaseQueryBuilder.cs
@@ -1,0 +1,421 @@
+﻿using Altinn.AccessMgmt.PersistenceEF.Constants;
+using Altinn.AccessMgmt.PersistenceEF.Contexts;
+using Altinn.AccessMgmt.PersistenceEF.Extensions;
+using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
+
+/// <summary>
+/// Builds the base IQueryable for connection queries in both directions.
+/// </summary>
+internal class ConnectionBaseQueryBuilder
+{
+    // This is a workaround to prevent Postgres from choosing a bad join order when there is a filter on FromId in delegations.
+    // It looks like the same join order is chosen no matter if we use a low value (1) or a very large value. A very large value is
+    // chosen to ensure that the cutoff doesn't really reduce the result set.
+    private const int PostgresPlanHintTakeLimit = 100_000_000;
+
+    /// <summary>
+    /// Shared set of role IDs for accountant/auditor roles used in innehaver connection lookups.
+    /// </summary>
+    private static readonly HashSet<Guid> ReviRegnRoleSet =
+    [
+        RoleConstants.Accountant.Id,
+        RoleConstants.Auditor.Id,
+        RoleConstants.AccountantWithoutSigningRights.Id,
+        RoleConstants.AccountantWithSigningRights.Id,
+        RoleConstants.AccountantSalary.Id,
+        RoleConstants.AssistantAuditor.Id,
+        RoleConstants.AuditorInCharge.Id
+    ];
+
+    /// <summary>
+    /// Builds the common filter HashSets used by both query directions.
+    /// </summary>
+    internal static (HashSet<Guid>? ViaSet, HashSet<Guid>? ViaRoleSet, HashSet<Guid>? RoleSet, HashSet<Guid> RoleSetExclude) BuildFilterSets(ConnectionQueryFilter filter)
+    {
+        var viaSet = filter.ViaIds?.Count > 0 ? new HashSet<Guid>(filter.ViaIds) : null;
+        var viaRoleSet = filter.ViaRoleIds?.Count > 0 ? new HashSet<Guid>(filter.ViaRoleIds) : null;
+        var roleSet = filter.RoleIds?.Count > 0 ? new HashSet<Guid>(filter.RoleIds) : null;
+        var roleSetExclude = filter.ExcludeRoleIds?.Count > 0 ? new HashSet<Guid>(filter.ExcludeRoleIds) : [];
+        roleSetExclude.Add(RoleConstants.Supplier.Id); // Supplier role should never be included in results as it is only used for maskinporten schemas.
+        if (!filter.IncludeAppControlledInstances)
+        {
+            roleSetExclude.Add(RoleConstants.AppControlledRightholder.Id); // App-controlled instance access should be excluded if not explicitly requested.
+        }
+
+        return (viaSet, viaRoleSet, roleSet, roleSetExclude);
+    }
+
+    internal IQueryable<ConnectionQueryBaseRecord> FromOthers(AppDbContext db, ConnectionQueryFilter filter, bool doChildNesting, bool applyFromFilter)
+    {
+        var toId = filter.ToIds.First();
+        var fromSet = filter.FromIds?.Count > 0 ? new HashSet<Guid>(filter.FromIds) : null;
+        var fromSetForDelegation = fromSet != null && filter.IncludeDelegation ? new HashSet<Guid>(fromSet) : [];
+        var (viaSet, viaRoleSet, roleSet, roleSetExclude) = BuildFilterSets(filter);
+
+        if (fromSet != null && filter.IncludeDelegation)
+        {
+            var parentIds = db.Entities
+                .Where(e => fromSet.Distinct().Contains(e.Id) && e.ParentId != null)
+                .AsNoTracking()
+                .Select(e => e.ParentId.Value)
+                .Distinct()
+                .ToList();
+            fromSetForDelegation.UnionWith(parentIds);
+
+            var enksOfInnh = db.Assignments
+                .AsNoTracking()
+                .Where(a => fromSet.Distinct().Contains(a.ToId))
+                .Where(a => a.RoleId == RoleConstants.Innehaver.Id)
+                .Select(a => a.FromId)
+                .Distinct()
+                .ToList();
+            fromSetForDelegation.UnionWith(enksOfInnh);
+        }
+
+        var direct =
+            db.Assignments
+                .Where(a1 => a1.ToId == toId)
+                .Select(a1 => new ConnectionQueryBaseRecord
+                {
+                    AssignmentId = a1.Id,
+                    DelegationId = null,
+                    FromId = a1.FromId,
+                    ToId = a1.ToId,
+                    RoleId = a1.RoleId,
+                    ViaId = null,
+                    ViaRoleId = null,
+                    Reason = ConnectionReason.Assignment,
+                    IsKeyRoleAccess = false,
+                    IsMainUnitAccess = false,
+                    IsRoleMap = false,
+                });
+
+        var keyrole =
+            direct
+                .Join(
+                    db.Roles,
+                    d => d.RoleId,
+                    r => r.Id,
+                    (d, r) => new { d, r }
+                )
+                .Where(x => x.r.IsKeyRole)
+                .Join(
+                    db.Assignments,
+                    x => x.d.FromId,
+                    a2 => a2.ToId,
+                    (x, a2) => new { x, a2 }
+                )
+                .Where(z => 
+                    !(z.a2.From.VariantId == EntityVariantConstants.IKS.Id && z.a2.RoleId == RoleConstants.ParticipantSharedResponsibility.Id) &&
+                    !(z.a2.To.VariantId == EntityVariantConstants.IKS.Id && z.x.d.RoleId == RoleConstants.ParticipantSharedResponsibility.Id))
+                .Select(z => new ConnectionQueryBaseRecord
+                {
+                    AssignmentId = z.a2.Id,
+                    DelegationId = null,
+                    FromId = z.a2.FromId,
+                    ToId = z.x.d.ToId,
+                    RoleId = z.a2.RoleId,
+                    ViaId = z.x.d.FromId,
+                    ViaRoleId = z.x.d.RoleId,
+                    Reason = ConnectionReason.KeyRole,
+                    IsKeyRoleAccess = true,
+                    IsMainUnitAccess = false,
+                    IsRoleMap = false,
+                });
+
+        var a1 = filter.IncludeKeyRole
+            ? direct.Concat(keyrole)
+            : direct;
+
+        var rolemap =
+            a1
+                .Join(
+                    db.RoleMaps,
+                    dkr => dkr.RoleId,
+                    rm => rm.HasRoleId,
+                    (dkr, rm) => new ConnectionQueryBaseRecord
+                    {
+                        AssignmentId = dkr.AssignmentId,
+                        DelegationId = null,
+                        FromId = dkr.FromId,
+                        ToId = dkr.ToId,
+                        RoleId = rm.GetRoleId,
+                        ViaId = dkr.ViaId,
+                        ViaRoleId = null,
+                        Reason = ConnectionReason.RoleMap,
+                        IsKeyRoleAccess = dkr.IsKeyRoleAccess,
+                        IsMainUnitAccess = false,
+                        IsRoleMap = true,
+                    });
+
+        var delegations =
+            db.Assignments
+                .WhereIf(fromSetForDelegation.Count > 0, x => fromSetForDelegation.Contains(x.FromId))
+                .Join(
+                    db.Delegations,
+                    fa => fa.Id,
+                    d => d.FromId,
+                    (fa, d) => new { fa, d }
+                )
+                //// Generate a postgres limit to force a better execution plan when there's a party filter. Ref. comment on constant PostgresPlanHintTakeLimit.
+                .TakeIf(fromSetForDelegation.Count > 0, PostgresPlanHintTakeLimit)
+                .Join(
+                    db.Assignments,
+                    x => x.d.ToId,
+                    dkr => dkr.Id,
+                    (x, dkr) => new { x, dkr }
+                )
+                .Where(t =>
+                    t.dkr.ToId == toId &&
+                    t.dkr.RoleId == RoleConstants.Agent.Id
+                )
+                .Select(t => new ConnectionQueryBaseRecord
+                {
+                    AssignmentId = null,
+                    DelegationId = t.x.d.Id,
+                    FromId = t.x.fa.FromId,
+                    ToId = t.dkr.ToId,
+                    RoleId = t.x.fa.RoleId,
+                    ViaId = t.x.fa.ToId,
+                    ViaRoleId = t.dkr.RoleId,
+                    Reason = ConnectionReason.Delegation,
+                    IsKeyRoleAccess = false,
+                    IsMainUnitAccess = false,
+                    IsRoleMap = false,
+                });
+
+        var a2 = filter.IncludeDelegation
+            ? a1.Concat(rolemap).Concat(delegations)
+            : a1.Concat(rolemap);
+
+        var fromChildren = !doChildNesting ? a2 :
+        a2
+        .Join(
+            db.Entities,
+            c => c.FromId,
+            e => e.ParentId,
+            (c, e) => new ConnectionQueryBaseRecord
+            {
+                AssignmentId = c.AssignmentId,
+                DelegationId = c.DelegationId,
+                FromId = e.Id,
+                ToId = c.ToId,
+                RoleId = c.RoleId,
+                ViaId = c.FromId,
+                ViaRoleId = c.ViaRoleId,
+                Reason = ConnectionReason.Hierarchy,
+                IsKeyRoleAccess = c.IsKeyRoleAccess,
+                IsMainUnitAccess = true,
+                IsRoleMap = c.IsRoleMap,
+            });
+
+        var innehaverConnections =
+            from reviRegnConnection in a2
+            join innehaverConnection in db.Assignments on reviRegnConnection.FromId equals innehaverConnection.FromId
+            join innehaver in db.Entities on innehaverConnection.ToId equals innehaver.Id
+            join enk in db.Entities on innehaverConnection.FromId equals enk.Id
+            where ReviRegnRoleSet.Contains(reviRegnConnection.RoleId)
+                && innehaverConnection.RoleId == RoleConstants.Innehaver.Id
+                && enk.VariantId == EntityVariantConstants.ENK.Id
+                && innehaver.DateOfDeath == null
+                && (!enk.IsDeleted || (enk.DeletedAt != null && enk.DeletedAt.Value.AddYears(2) > DateTime.UtcNow))
+            select new ConnectionQueryBaseRecord()
+            {
+                AssignmentId = reviRegnConnection.AssignmentId,
+                DelegationId = reviRegnConnection.DelegationId,
+                FromId = innehaverConnection.ToId,
+                ToId = reviRegnConnection.ToId,
+                RoleId = reviRegnConnection.RoleId,
+                ViaId = innehaverConnection.FromId,
+                ViaRoleId = innehaverConnection.RoleId,
+                IsKeyRoleAccess = reviRegnConnection.IsKeyRoleAccess,
+                IsRoleMap = reviRegnConnection.IsRoleMap,
+                IsMainUnitAccess = reviRegnConnection.IsMainUnitAccess,
+                Reason = ConnectionReason.Hierarchy,
+            };
+
+        var query = doChildNesting
+            ? filter.IncludeSubConnections ? a2.Concat(fromChildren).Concat(innehaverConnections) : a2.Concat(fromChildren)
+            : filter.IncludeSubConnections ? a2.Concat(innehaverConnections) : a2;
+
+        return
+            query
+            .FromIdContains(fromSet, applyFromFilter)
+            .ViaIdContains(viaSet)
+            .ViaRoleIdContains(viaRoleSet)
+            .RoleIdContains(roleSet)
+            .RoleIdExcludes(roleSetExclude);
+    }
+
+    internal IQueryable<ConnectionQueryBaseRecord> ToOthers(AppDbContext db, ConnectionQueryFilter filter)
+    {
+        /* Senario: Tilgangsstyrer i Bakerhansen Bergen BEDR (FromId) som er underenhet av Bakerhansen AS
+
+       Oppslag skal finne:
+           - Direkte tilganger gitt til BDO AS fra Bakerhansen Bergen BEDR
+           - Direkte tilganger gitt til BDO AS fra hovedenheten Bakerhansen AS 
+           - Andre direkte tilganger gjennom Rettighetshaver, ER-roller eller Altinn 2-roller
+
+           - Nøkkelroller tilganger: Daglig leder i BDO AS arve tilganger gitt til BDO AS
+               - Personer med nøkkelrolle skal returneres som sub-connections
+
+           - Klientdelegeringer: Agent for BDO AS som har mottatt klientdelegeringer:
+               - Direkte fra Bakerhansen Bergen BEDR til Agent
+               - Fra Hovedenhet Bakerhansen AS til Agent
+
+           Scenario: Innehaver av Enk (For 1. mars og tilgangsstyringsside for privatpersoner)
+           - Revisor/Regnskapsfører forhold via ENK skal også dukke opp med tilgang til personen som er innehaver
+               - Selve Revisor/Regnskapsfører org
+               - Nøkkelrolle personer for Revi/regn
+               - Agenter med mottatt klientdelegering for Enk
+       */
+
+        var fromId = filter.FromIds.First();
+        var toSet = filter.ToIds?.Count > 0 ? new HashSet<Guid>(filter.ToIds) : null;
+        var (viaSet, viaRoleSet, roleSet, roleSetExclude) = BuildFilterSets(filter);
+
+        /*
+        Direct Assignments
+        */
+
+        var direct =
+            from childAss in db.Assignments
+            where childAss.FromId == fromId
+            select new ConnectionQueryBaseRecord()
+            {
+                AssignmentId = childAss.Id,
+                DelegationId = null,
+                FromId = childAss.FromId,
+                ToId = childAss.ToId,
+                RoleId = childAss.RoleId,
+                ViaId = null,
+                ViaRoleId = null,
+                IsRoleMap = false,
+                IsKeyRoleAccess = false,
+                IsMainUnitAccess = false,
+                Reason = ConnectionReason.Assignment
+            };
+
+        /*
+        If FromId is a subunit, this will get mainunit assignments
+        */
+        var mainAssignments =
+            from e in db.Entities
+            where e.Id == fromId
+            join ass in db.Assignments on e.ParentId equals ass.FromId
+            select new ConnectionQueryBaseRecord()
+            {
+                AssignmentId = ass.Id,
+                DelegationId = null,
+                FromId = e.Id,      // Subunit (from-party)
+                ToId = ass.ToId,    // BDO / mottaker av tilgang fra hovedenhet
+                RoleId = ass.RoleId,// Regnskapsfører / rolle-tilgang gitt fra hovedenheten
+                ViaId = ass.FromId, // Hovedenheten til from-party
+                ViaRoleId = null,
+                IsRoleMap = false,
+                IsKeyRoleAccess = false,
+                IsMainUnitAccess = true,
+                Reason = ConnectionReason.Hierarchy
+            };
+
+        /*
+        Combine direct and mainunit assignments based on filter request
+        */
+        var allAssignments = filter.IncludeMainUnitConnections ? direct.Union(mainAssignments) : direct;
+
+        /*
+        Add RoleMap roles to allAssignments 
+        */
+        var roleMapAssignments =
+           from assignment in allAssignments
+           join rolemap in db.RoleMaps on assignment.RoleId equals rolemap.HasRoleId
+           select new ConnectionQueryBaseRecord()
+           {
+               AssignmentId = assignment.AssignmentId,
+               DelegationId = null,
+               FromId = assignment.FromId,
+               ToId = assignment.ToId,
+               RoleId = rolemap.GetRoleId,
+               ViaId = assignment.ViaId,
+               ViaRoleId = assignment.ViaRoleId,
+               IsRoleMap = true,
+               IsKeyRoleAccess = assignment.IsKeyRoleAccess,
+               IsMainUnitAccess = assignment.IsMainUnitAccess,
+               Reason = ConnectionReason.RoleMap
+           };
+
+        /*
+        Add Delegations from AllAssignments
+        */
+        var clientDelegations =
+           from delegation in db.Delegations
+           join fromAssignment in allAssignments on delegation.FromId equals fromAssignment.AssignmentId
+           join toAssignment in db.Assignments on delegation.ToId equals toAssignment.Id
+           select new ConnectionQueryBaseRecord()
+           {
+               AssignmentId = null,
+               DelegationId = delegation.Id,
+               FromId = fromAssignment.FromId,
+               ToId = toAssignment.ToId,
+               RoleId = fromAssignment.RoleId,
+               ViaId = fromAssignment.ToId,
+               ViaRoleId = toAssignment.RoleId,
+               IsRoleMap = false,
+               IsKeyRoleAccess = false,
+               IsMainUnitAccess = false,
+               Reason = ConnectionReason.Delegation
+           };
+
+        /*
+        Add KeyRoles on allAssignments
+        */
+        var keyRoleAssignments =
+            from all in allAssignments.Concat(roleMapAssignments) // Must include RoleMap assignments
+            join fromEntity in db.Entities on all.FromId equals fromEntity.Id
+            join toEntity in db.Entities on all.ToId equals toEntity.Id
+            join keyRoleAssignment in db.Assignments on all.ToId equals keyRoleAssignment.FromId            
+            join role in db.Roles on keyRoleAssignment.RoleId equals role.Id
+            where 
+                role.IsKeyRole && 
+                !(fromEntity.VariantId == EntityVariantConstants.IKS.Id && all.RoleId == RoleConstants.ParticipantSharedResponsibility.Id) &&
+                !(toEntity.VariantId == EntityVariantConstants.IKS.Id && keyRoleAssignment.RoleId == RoleConstants.ParticipantSharedResponsibility.Id)
+            select new ConnectionQueryBaseRecord()
+            {
+                AssignmentId = all.AssignmentId,
+                DelegationId = null,
+                FromId = all.FromId,
+                ToId = keyRoleAssignment.ToId,
+                RoleId = all.RoleId,
+                ViaId = keyRoleAssignment.FromId,
+                ViaRoleId = keyRoleAssignment.RoleId,
+                IsKeyRoleAccess = true,
+                IsRoleMap = all.IsRoleMap,
+                IsMainUnitAccess = all.IsMainUnitAccess,
+                Reason = ConnectionReason.KeyRole
+            };
+
+        /*
+        Combine everything
+        */
+        IQueryable<ConnectionQueryBaseRecord> allCombined = allAssignments.Union(roleMapAssignments);
+        if (filter.IncludeDelegation)
+        {
+            allCombined = allCombined.Union(clientDelegations);
+        }
+
+        if (filter.IncludeKeyRole)
+        {
+            allCombined = allCombined.Union(keyRoleAssignments);
+        }
+
+        return allCombined
+            .ToIdContains(toSet)
+            .ViaIdContains(viaSet)
+            .ViaRoleIdContains(viaRoleSet)
+            .RoleIdContains(roleSet)
+            .RoleIdExcludes(roleSetExclude);
+    }
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionBaseQueryBuilder.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionBaseQueryBuilder.cs
@@ -252,7 +252,7 @@ internal class ConnectionBaseQueryBuilder
 
     internal IQueryable<ConnectionQueryBaseRecord> ToOthers(AppDbContext db, ConnectionQueryFilter filter)
     {
-        /* Senario: Tilgangsstyrer i Bakerhansen Bergen BEDR (FromId) som er underenhet av Bakerhansen AS
+        /* Scenario: Tilgangsstyrer i Bakerhansen Bergen BEDR (FromId) som er underenhet av Bakerhansen AS
 
        Oppslag skal finne:
            - Direkte tilganger gitt til BDO AS fra Bakerhansen Bergen BEDR

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -25,7 +25,7 @@ public class ConnectionQuery(AppDbContext db)
     }
 
     /// <summary>
-    /// Checks if connection exists between to parties
+    /// Checks if connection exists between two parties
     /// Returns first result only (Assignment => Delegation => Hierarchy => KeyRole)
     ///  
     /// Note: Incomplete implementation. Missing support for combined reasons (e.g. Delegation + Hierarchy, KeyRole + Hierarchy or Innehaver of Enk through Revi/Regn).
@@ -34,23 +34,24 @@ public class ConnectionQuery(AppDbContext db)
     /// </summary>
     /// <param name="fromId">From identifier</param>
     /// <param name="toId">To identifier</param>
-    /// <returns></returns>
+    /// <returns>Tuple indicating if connection exists and the reason</returns>
     public async Task<(bool Result, ConnectionReason? Reason)> HasConnection(Guid fromId, Guid toId)
     {
         return await HasConnection(fromId, toId, [ConnectionReason.Assignment, ConnectionReason.Delegation, ConnectionReason.Hierarchy, ConnectionReason.KeyRole]);
     }
 
     /// <summary>
-    /// Checks if connection exists between to parties
+    /// Checks if connection exists between two parties
     /// Returns first result only (Assignment => Delegation => Hierarchy => KeyRole)
     /// 
     /// Note: Incomplete implementation. Missing support for combined reasons (e.g. Delegation + Hierarchy, KeyRole + Hierarchy or Innehaver of Enk through Revi/Regn).
     /// Current use-case is however limited to validating whether to allow the fromId to create an access request to the toId, where these connections might not be valid.
     /// But beware if considering use of this method for other purposes.
+    /// </summary>
     /// <param name="fromId">From identifier</param>
     /// <param name="toId">To identifier</param>
     /// <param name="reasons">Reasons to check</param>
-    /// </summary>
+    /// <returns>Tuple indicating if connection exists and the reason</returns>
     public async Task<(bool Result, ConnectionReason? Reason)> HasConnection(Guid fromId, Guid toId, ConnectionReason[] reasons)
     {
         if (reasons == null || reasons.Length == 0)
@@ -118,7 +119,7 @@ public class ConnectionQuery(AppDbContext db)
     }
 
     /// <summary>
-    /// Returns connections between to entities based on assignments and delegations
+    /// Returns connections between two entities based on assignments and delegations
     /// </summary>
     public async Task<List<ConnectionQueryExtendedRecord>> GetConnectionsAsync(ConnectionQueryFilter filter, ConnectionQueryDirection direction, CancellationToken ct = default)
     {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -1,38 +1,18 @@
 ﻿using System.Text.Json;
 using Altinn.AccessMgmt.PersistenceEF.Constants;
 using Altinn.AccessMgmt.PersistenceEF.Contexts;
-using Altinn.AccessMgmt.PersistenceEF.Extensions;
-using Altinn.AccessMgmt.PersistenceEF.Models;
 using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
 
 /// <summary>
-/// A query based on assignments and delegations
+/// The ConnectionQuery class provides methods for querying connections between entities based on assignments, delegations, and other relationships.
+/// It supports filtering, enrichment of results with related data, and checking for the existence of connections between two parties.
 /// </summary>
 public class ConnectionQuery(AppDbContext db)
 {
-    // This is a workaround to prevent Postgres from choosing a bad join order when there is a filter on FromId in delegations.
-    // It looks like the same join order is chosen no matter if we use a low value (1) or a very large value. A very large value is
-    // chosen to ensure that the cutoff doesn't really reduce the result set.
-    private const int PostgresPlanHintTakeLimit = 100_000_000;
-    private readonly ConnectionResourceLoader _resourceLoader = new(db);
-    private readonly ConnectionPackageLoader _packageLoader = new(db);
-
-    /// <summary>
-    /// Shared set of role IDs for accountant/auditor roles used in innehaver connection lookups.
-    /// </summary>
-    private static readonly HashSet<Guid> ReviRegnRoleSet =
-    [
-        RoleConstants.Accountant.Id,
-        RoleConstants.Auditor.Id,
-        RoleConstants.AccountantWithoutSigningRights.Id,
-        RoleConstants.AccountantWithSigningRights.Id,
-        RoleConstants.AccountantSalary.Id,
-        RoleConstants.AssistantAuditor.Id,
-        RoleConstants.AuditorInCharge.Id
-    ];
+    private readonly ConnectionBaseQueryBuilder _baseQueryBuilder = new();
     
     public async Task<List<ConnectionQueryExtendedRecord>> GetConnectionsFromOthersAsync(ConnectionQueryFilter filter, CancellationToken ct = default)
     {
@@ -47,6 +27,10 @@ public class ConnectionQuery(AppDbContext db)
     /// <summary>
     /// Checks if connection exists between to parties
     /// Returns first result only (Assignment => Delegation => Hierarchy => KeyRole)
+    ///  
+    /// Note: Incomplete implementation. Missing support for combined reasons (e.g. Delegation + Hierarchy, KeyRole + Hierarchy or Innehaver of Enk through Revi/Regn).
+    /// Current use-case is however limited to validating whether to allow the fromId to create an access request to the toId, where these connections might not be valid.
+    /// But beware if considering use of this method for other purposes.
     /// </summary>
     /// <param name="fromId">From identifier</param>
     /// <param name="toId">To identifier</param>
@@ -59,6 +43,10 @@ public class ConnectionQuery(AppDbContext db)
     /// <summary>
     /// Checks if connection exists between to parties
     /// Returns first result only (Assignment => Delegation => Hierarchy => KeyRole)
+    /// 
+    /// Note: Incomplete implementation. Missing support for combined reasons (e.g. Delegation + Hierarchy, KeyRole + Hierarchy or Innehaver of Enk through Revi/Regn).
+    /// Current use-case is however limited to validating whether to allow the fromId to create an access request to the toId, where these connections might not be valid.
+    /// But beware if considering use of this method for other purposes.
     /// <param name="fromId">From identifier</param>
     /// <param name="toId">To identifier</param>
     /// <param name="reasons">Reasons to check</param>
@@ -145,22 +133,23 @@ public class ConnectionQuery(AppDbContext db)
             }
 
             var baseQuery = direction == ConnectionQueryDirection.FromOthers
-                ? BuildBaseQueryFromOthers(
+                ? _baseQueryBuilder.FromOthers(
                         db,
                         filter,
                         filter.IncludeSubConnections && !delayChildNesting,
                         !filter.IncludeSubConnections || !delayFromFilter)
-                : BuildBaseQueryToOthers(db, filter);
+                : _baseQueryBuilder.ToOthers(db, filter);
 
             var result = baseQuery.Select(ToDtoEmpty).ToList();
             if (filter.IncludePackages || filter.EnrichPackageResources)
             {
                 try
                 {
-                    var pkgs = await _packageLoader.LoadPackagesByKeyAsync(result, filter, ct);
+                    var packageLoader = new ConnectionPackageLoader(db);
+                    var pkgs = await packageLoader.LoadPackagesByKeyAsync(result, filter, ct);
                     if (filter.EnrichPackageResources)
                     {
-                        await _packageLoader.EnrichPackageResourcesAsync(pkgs, filter, ct);
+                        await packageLoader.EnrichPackageResourcesAsync(pkgs, filter, ct);
                     }
 
                     result = Attach(result, pkgs, p => p.Id, (dto, list) => dto.Packages = list);
@@ -179,6 +168,7 @@ public class ConnectionQuery(AppDbContext db)
 
             if (filter.IncludeResources || filter.IncludeInstances)
             {
+                var resourceLoader = new ConnectionResourceLoader(db);
                 var rightholderAssignments = ConnectionResourceLoader.GetRightholderAssignments(result, filter);
 
                 try
@@ -188,7 +178,7 @@ public class ConnectionQuery(AppDbContext db)
                         var rightholderAssignmentIds = rightholderAssignments.Select(a => (Guid)a.AssignmentId).Distinct().ToHashSet();
                         if (rightholderAssignmentIds.Count > 0)
                         {
-                            result = await _resourceLoader.LoadResourcesByKeyAsync(result, rightholderAssignmentIds, filter, ct);
+                            result = await resourceLoader.LoadResourcesByKeyAsync(result, rightholderAssignmentIds, filter, ct);
                         }
                     }
                 }
@@ -204,7 +194,7 @@ public class ConnectionQuery(AppDbContext db)
                         var rightholderAssignmentIds = rightholderAssignments.Where(a => a.Reason != ConnectionReason.Hierarchy && !a.IsMainUnitAccess).Select(a => (Guid)a.AssignmentId).Distinct().ToHashSet();
                         if (rightholderAssignmentIds.Count > 0)
                         {
-                            result = await _resourceLoader.LoadInstancesByKeyAsync(result, rightholderAssignmentIds, filter, ct);
+                            result = await resourceLoader.LoadInstancesByKeyAsync(result, rightholderAssignmentIds, filter, ct);
                         }
                     }
                 }
@@ -233,395 +223,6 @@ public class ConnectionQuery(AppDbContext db)
         }
     }
 
-    /// <summary>
-    /// Builds the common filter HashSets used by both query directions.
-    /// </summary>
-    private static (HashSet<Guid>? ViaSet, HashSet<Guid>? ViaRoleSet, HashSet<Guid>? RoleSet, HashSet<Guid> RoleSetExclude) BuildFilterSets(ConnectionQueryFilter filter)
-    {
-        var viaSet = filter.ViaIds?.Count > 0 ? new HashSet<Guid>(filter.ViaIds) : null;
-        var viaRoleSet = filter.ViaRoleIds?.Count > 0 ? new HashSet<Guid>(filter.ViaRoleIds) : null;
-        var roleSet = filter.RoleIds?.Count > 0 ? new HashSet<Guid>(filter.RoleIds) : null;
-        var roleSetExclude = filter.ExcludeRoleIds?.Count > 0 ? new HashSet<Guid>(filter.ExcludeRoleIds) : [];
-        roleSetExclude.Add(RoleConstants.Supplier.Id); // Supplier role should never be included in results as it is only used for maskinporten schemas.
-        if (!filter.IncludeAppControlledInstances)
-        {
-            roleSetExclude.Add(RoleConstants.AppControlledRightholder.Id); // App-controlled instance access should be excluded if not explicitly requested.
-        }
-
-        return (viaSet, viaRoleSet, roleSet, roleSetExclude);
-    }
-
-    private IQueryable<ConnectionQueryBaseRecord> BuildBaseQueryFromOthers(AppDbContext db, ConnectionQueryFilter filter, bool doChildNesting, bool applyFromFilter)
-    {
-        var toId = filter.ToIds.First();
-        var fromSet = filter.FromIds?.Count > 0 ? new HashSet<Guid>(filter.FromIds) : null;
-        var fromSetForDelegation = fromSet != null && filter.IncludeDelegation ? new HashSet<Guid>(fromSet) : [];
-        var (viaSet, viaRoleSet, roleSet, roleSetExclude) = BuildFilterSets(filter);
-
-        if (fromSet != null && filter.IncludeDelegation)
-        {
-            var parentIds = db.Entities
-                .Where(e => fromSet.Distinct().Contains(e.Id) && e.ParentId != null)
-                .AsNoTracking()
-                .Select(e => e.ParentId.Value)
-                .Distinct()
-                .ToList();
-            fromSetForDelegation.UnionWith(parentIds);
-
-            var enksOfInnh = db.Assignments
-                .AsNoTracking()
-                .Where(a => fromSet.Distinct().Contains(a.ToId))
-                .Where(a => a.RoleId == RoleConstants.Innehaver.Id)
-                .Select(a => a.FromId)
-                .Distinct()
-                .ToList();
-            fromSetForDelegation.UnionWith(enksOfInnh);
-        }
-
-        var direct =
-            db.Assignments
-                .Where(a1 => a1.ToId == toId)
-                .Select(a1 => new ConnectionQueryBaseRecord
-                {
-                    AssignmentId = a1.Id,
-                    DelegationId = null,
-                    FromId = a1.FromId,
-                    ToId = a1.ToId,
-                    RoleId = a1.RoleId,
-                    ViaId = null,
-                    ViaRoleId = null,
-                    Reason = ConnectionReason.Assignment,
-                    IsKeyRoleAccess = false,
-                    IsMainUnitAccess = false,
-                    IsRoleMap = false,
-                });
-
-        var keyrole =
-            direct
-                .Join(
-                    db.Roles,
-                    d => d.RoleId,
-                    r => r.Id,
-                    (d, r) => new { d, r }
-                )
-                .Where(x => x.r.IsKeyRole)
-                .Join(
-                    db.Assignments,
-                    x => x.d.FromId,
-                    a2 => a2.ToId,
-                    (x, a2) => new { x, a2 }
-                )
-                .Where(z => 
-                    !(z.a2.From.VariantId == EntityVariantConstants.IKS.Id && z.a2.RoleId == RoleConstants.ParticipantSharedResponsibility.Id) &&
-                    !(z.a2.To.VariantId == EntityVariantConstants.IKS.Id && z.x.d.RoleId == RoleConstants.ParticipantSharedResponsibility.Id))
-                .Select(z => new ConnectionQueryBaseRecord
-                {
-                    AssignmentId = z.a2.Id,
-                    DelegationId = null,
-                    FromId = z.a2.FromId,
-                    ToId = z.x.d.ToId,
-                    RoleId = z.a2.RoleId,
-                    ViaId = z.x.d.FromId,
-                    ViaRoleId = z.x.d.RoleId,
-                    Reason = ConnectionReason.KeyRole,
-                    IsKeyRoleAccess = true,
-                    IsMainUnitAccess = false,
-                    IsRoleMap = false,
-                });
-
-        var a1 = filter.IncludeKeyRole
-            ? direct.Concat(keyrole)
-            : direct;
-
-        var rolemap =
-            a1
-                .Join(
-                    db.RoleMaps,
-                    dkr => dkr.RoleId,
-                    rm => rm.HasRoleId,
-                    (dkr, rm) => new ConnectionQueryBaseRecord
-                    {
-                        AssignmentId = dkr.AssignmentId,
-                        DelegationId = null,
-                        FromId = dkr.FromId,
-                        ToId = dkr.ToId,
-                        RoleId = rm.GetRoleId,
-                        ViaId = dkr.ViaId,
-                        ViaRoleId = null,
-                        Reason = ConnectionReason.RoleMap,
-                        IsKeyRoleAccess = dkr.IsKeyRoleAccess,
-                        IsMainUnitAccess = false,
-                        IsRoleMap = true,
-                    });
-
-        var delegations =
-            db.Assignments
-                .WhereIf(fromSetForDelegation.Count > 0, x => fromSetForDelegation.Contains(x.FromId))
-                .Join(
-                    db.Delegations,
-                    fa => fa.Id,
-                    d => d.FromId,
-                    (fa, d) => new { fa, d }
-                )
-                //// Generate a postgres limit to force a better execution plan when there's a party filter. Ref. comment on constant PostgresPlanHintTakeLimit.
-                .TakeIf(fromSetForDelegation.Count > 0, PostgresPlanHintTakeLimit)
-                .Join(
-                    db.Assignments,
-                    x => x.d.ToId,
-                    dkr => dkr.Id,
-                    (x, dkr) => new { x, dkr }
-                )
-                .Where(t =>
-                    t.dkr.ToId == toId &&
-                    t.dkr.RoleId == RoleConstants.Agent.Id
-                )
-                .Select(t => new ConnectionQueryBaseRecord
-                {
-                    AssignmentId = null,
-                    DelegationId = t.x.d.Id,
-                    FromId = t.x.fa.FromId,
-                    ToId = t.dkr.ToId,
-                    RoleId = t.x.fa.RoleId,
-                    ViaId = t.x.fa.ToId,
-                    ViaRoleId = t.dkr.RoleId,
-                    Reason = ConnectionReason.Delegation,
-                    IsKeyRoleAccess = false,
-                    IsMainUnitAccess = false,
-                    IsRoleMap = false,
-                });
-
-        var a2 = filter.IncludeDelegation
-            ? a1.Concat(rolemap).Concat(delegations)
-            : a1.Concat(rolemap);
-
-        var fromChildren = !doChildNesting ? a2 :
-        a2
-        .Join(
-            db.Entities,
-            c => c.FromId,
-            e => e.ParentId,
-            (c, e) => new ConnectionQueryBaseRecord
-            {
-                AssignmentId = c.AssignmentId,
-                DelegationId = c.DelegationId,
-                FromId = e.Id,
-                ToId = c.ToId,
-                RoleId = c.RoleId,
-                ViaId = c.FromId,
-                ViaRoleId = c.ViaRoleId,
-                Reason = ConnectionReason.Hierarchy,
-                IsKeyRoleAccess = c.IsKeyRoleAccess,
-                IsMainUnitAccess = true,
-                IsRoleMap = c.IsRoleMap,
-            });
-
-        var innehaverConnections =
-            from reviRegnConnection in a2
-            join innehaverConnection in db.Assignments on reviRegnConnection.FromId equals innehaverConnection.FromId
-            join innehaver in db.Entities on innehaverConnection.ToId equals innehaver.Id
-            join enk in db.Entities on innehaverConnection.FromId equals enk.Id
-            where ReviRegnRoleSet.Contains(reviRegnConnection.RoleId)
-                && innehaverConnection.RoleId == RoleConstants.Innehaver.Id
-                && enk.VariantId == EntityVariantConstants.ENK.Id
-                && innehaver.DateOfDeath == null
-                && (!enk.IsDeleted || (enk.DeletedAt != null && enk.DeletedAt.Value.AddYears(2) > DateTime.UtcNow))
-            select new ConnectionQueryBaseRecord()
-            {
-                AssignmentId = reviRegnConnection.AssignmentId,
-                DelegationId = reviRegnConnection.DelegationId,
-                FromId = innehaverConnection.ToId,
-                ToId = reviRegnConnection.ToId,
-                RoleId = reviRegnConnection.RoleId,
-                ViaId = innehaverConnection.FromId,
-                ViaRoleId = innehaverConnection.RoleId,
-                IsKeyRoleAccess = reviRegnConnection.IsKeyRoleAccess,
-                IsRoleMap = reviRegnConnection.IsRoleMap,
-                IsMainUnitAccess = reviRegnConnection.IsMainUnitAccess,
-                Reason = ConnectionReason.Hierarchy,
-            };
-
-        var query = doChildNesting
-            ? filter.IncludeSubConnections ? a2.Concat(fromChildren).Concat(innehaverConnections) : a2.Concat(fromChildren)
-            : filter.IncludeSubConnections ? a2.Concat(innehaverConnections) : a2;
-
-        return
-            query
-            .FromIdContains(fromSet, applyFromFilter)
-            .ViaIdContains(viaSet)
-            .ViaRoleIdContains(viaRoleSet)
-            .RoleIdContains(roleSet)
-            .RoleIdExcludes(roleSetExclude);
-    }
-
-    private IQueryable<ConnectionQueryBaseRecord> BuildBaseQueryToOthers(AppDbContext db, ConnectionQueryFilter filter)
-    {
-        /* Senario: Tilgangsstyrer i Bakerhansen Bergen BEDR (FromId) som er underenhet av Bakerhansen AS
-
-       Oppslag skal finne:
-           - Direkte tilganger gitt til BDO AS fra Bakerhansen Bergen BEDR
-           - Direkte tilganger gitt til BDO AS fra hovedenheten Bakerhansen AS 
-           - Andre direkte tilganger gjennom Rettighetshaver, ER-roller eller Altinn 2-roller
-
-           - Nøkkelroller tilganger: Daglig leder i BDO AS arve tilganger gitt til BDO AS
-               - Personer med nøkkelrolle skal returneres som sub-connections
-
-           - Klientdelegeringer: Agent for BDO AS som har mottatt klientdelegeringer:
-               - Direkte fra Bakerhansen Bergen BEDR til Agent
-               - Fra Hovedenhet Bakerhansen AS til Agent
-
-           Scenario: Innehaver av Enk (For 1. mars og tilgangsstyringsside for privatpersoner)
-           - Revisor/Regnskapsfører forhold via ENK skal også dukke opp med tilgang til personen som er innehaver
-               - Selve Revisor/Regnskapsfører org
-               - Nøkkelrolle personer for Revi/regn
-               - Agenter med mottatt klientdelegering for Enk
-       */
-
-        var fromId = filter.FromIds.First();
-        var toSet = filter.ToIds?.Count > 0 ? new HashSet<Guid>(filter.ToIds) : null;
-        var (viaSet, viaRoleSet, roleSet, roleSetExclude) = BuildFilterSets(filter);
-
-        /*
-        Direct Assignments
-        */
-
-        var direct =
-            from childAss in db.Assignments
-            where childAss.FromId == fromId
-            select new ConnectionQueryBaseRecord()
-            {
-                AssignmentId = childAss.Id,
-                DelegationId = null,
-                FromId = childAss.FromId,
-                ToId = childAss.ToId,
-                RoleId = childAss.RoleId,
-                ViaId = null,
-                ViaRoleId = null,
-                IsRoleMap = false,
-                IsKeyRoleAccess = false,
-                IsMainUnitAccess = false,
-                Reason = ConnectionReason.Assignment
-            };
-
-        /*
-        If FromId is a subunit, this will get mainunit assignments
-        */
-        var mainAssignments =
-            from e in db.Entities
-            where e.Id == fromId
-            join ass in db.Assignments on e.ParentId equals ass.FromId
-            select new ConnectionQueryBaseRecord()
-            {
-                AssignmentId = ass.Id,
-                DelegationId = null,
-                FromId = e.Id,      // Subunit (from-party)
-                ToId = ass.ToId,    // BDO / mottaker av tilgang fra hovedenhet
-                RoleId = ass.RoleId,// Regnskapsfører / rolle-tilgang gitt fra hovedenheten
-                ViaId = ass.FromId, // Hovedenheten til from-party
-                ViaRoleId = null,
-                IsRoleMap = false,
-                IsKeyRoleAccess = false,
-                IsMainUnitAccess = true,
-                Reason = ConnectionReason.Hierarchy
-            };
-
-        /*
-        Combine direct and mainunit assignments based on filter request
-        */
-        var allAssignments = filter.IncludeMainUnitConnections ? direct.Union(mainAssignments) : direct;
-
-        /*
-        Add RoleMap roles to allAssignments 
-        */
-        var roleMapAssignments =
-           from assignment in allAssignments
-           join rolemap in db.RoleMaps on assignment.RoleId equals rolemap.HasRoleId
-           select new ConnectionQueryBaseRecord()
-           {
-               AssignmentId = assignment.AssignmentId,
-               DelegationId = null,
-               FromId = assignment.FromId,
-               ToId = assignment.ToId,
-               RoleId = rolemap.GetRoleId,
-               ViaId = assignment.ViaId,
-               ViaRoleId = assignment.ViaRoleId,
-               IsRoleMap = true,
-               IsKeyRoleAccess = assignment.IsKeyRoleAccess,
-               IsMainUnitAccess = assignment.IsMainUnitAccess,
-               Reason = ConnectionReason.RoleMap
-           };
-
-        /*
-        Add Delegations from AllAssignments
-        */
-        var clientDelegations =
-           from delegation in db.Delegations
-           join fromAssignment in allAssignments on delegation.FromId equals fromAssignment.AssignmentId
-           join toAssignment in db.Assignments on delegation.ToId equals toAssignment.Id
-           select new ConnectionQueryBaseRecord()
-           {
-               AssignmentId = null,
-               DelegationId = delegation.Id,
-               FromId = fromAssignment.FromId,
-               ToId = toAssignment.ToId,
-               RoleId = fromAssignment.RoleId,
-               ViaId = fromAssignment.ToId,
-               ViaRoleId = toAssignment.RoleId,
-               IsRoleMap = false,
-               IsKeyRoleAccess = false,
-               IsMainUnitAccess = false,
-               Reason = ConnectionReason.Delegation
-           };
-
-        /*
-        Add KeyRoles on allAssignments
-        */
-        var keyRoleAssignments =
-            from all in allAssignments.Concat(roleMapAssignments) // Must include RoleMap assignments
-            join fromEntity in db.Entities on all.FromId equals fromEntity.Id
-            join toEntity in db.Entities on all.ToId equals toEntity.Id
-            join keyRoleAssignment in db.Assignments on all.ToId equals keyRoleAssignment.FromId            
-            join role in db.Roles on keyRoleAssignment.RoleId equals role.Id
-            where 
-                role.IsKeyRole && 
-                !(fromEntity.VariantId == EntityVariantConstants.IKS.Id && all.RoleId == RoleConstants.ParticipantSharedResponsibility.Id) &&
-                !(toEntity.VariantId == EntityVariantConstants.IKS.Id && keyRoleAssignment.RoleId == RoleConstants.ParticipantSharedResponsibility.Id)
-            select new ConnectionQueryBaseRecord()
-            {
-                AssignmentId = all.AssignmentId,
-                DelegationId = null,
-                FromId = all.FromId,
-                ToId = keyRoleAssignment.ToId,
-                RoleId = all.RoleId,
-                ViaId = keyRoleAssignment.FromId,
-                ViaRoleId = keyRoleAssignment.RoleId,
-                IsKeyRoleAccess = true,
-                IsRoleMap = all.IsRoleMap,
-                IsMainUnitAccess = all.IsMainUnitAccess,
-                Reason = ConnectionReason.KeyRole
-            };
-
-        /*
-        Combine everything
-        */
-        IQueryable<ConnectionQueryBaseRecord> allCombined = allAssignments.Union(roleMapAssignments);
-        if (filter.IncludeDelegation)
-        {
-            allCombined = allCombined.Union(clientDelegations);
-        }
-
-        if (filter.IncludeKeyRole)
-        {
-            allCombined = allCombined.Union(keyRoleAssignments);
-        }
-
-        return allCombined
-            .ToIdContains(toSet)
-            .ViaIdContains(viaSet)
-            .ViaRoleIdContains(viaRoleSet)
-            .RoleIdContains(roleSet)
-            .RoleIdExcludes(roleSetExclude);
-    }
-
     private static List<ConnectionQueryExtendedRecord> Attach<T>(IEnumerable<ConnectionQueryExtendedRecord> results, ConnectionIndex<T> index, Func<T, Guid> idSelector, Action<ConnectionQueryExtendedRecord, List<T>> assign)
     {
         foreach (var dto in results)
@@ -647,109 +248,4 @@ public class ConnectionQuery(AppDbContext db)
         IsMainUnitAccess = x.IsMainUnitAccess,
         IsRoleMap = x.IsRoleMap
     };
-}
-
-internal static class ConnectionQueryExtensions
-{
-    internal static IQueryable<ConnectionQueryBaseRecord> ToIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
-    {
-        if (ids is null || ids.Count == 0)
-        {
-            return query;
-        }
-
-        if (ids.Count == 1)
-        {
-            var id = ids.First();
-            return query.Where(t => t.ToId == id);
-        }
-
-        return query.Where(t => ids.Contains(t.ToId));
-    }
-
-    internal static IQueryable<ConnectionQueryBaseRecord> FromIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids, bool applyFromFilter = true)
-    {
-        if (!applyFromFilter || ids is null || ids.Count == 0)
-        {
-            return query;
-        }
-
-        if (ids.Count == 1)
-        {
-            var id = ids.First();
-            return query.Where(t => t.FromId == id);
-        }
-
-        return query.Where(t => ids.Contains(t.FromId));
-    }
-
-    internal static IQueryable<ConnectionQueryBaseRecord> ViaIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
-    {
-        if (ids is null || ids.Count == 0)
-        {
-            return query;
-        }
-
-        if (ids.Count == 1)
-        {
-            var id = ids.First();
-            return query.Where(t => t.ViaId.HasValue && t.ViaId.Value == id);
-        }
-
-        return query.Where(t => t.ViaId.HasValue && ids.Contains(t.ViaId.Value));
-    }
-
-    internal static IQueryable<ConnectionQueryBaseRecord> RoleIdExcludes(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
-    {
-        if (ids is null || ids.Count == 0)
-        {
-            return query;
-        }
-
-        if (ids.Count == 1)
-        {
-            var id = ids.First();
-            return query.Where(t => t.RoleId != id);
-        }
-
-        return query.Where(t => !ids.Contains(t.RoleId));
-    }
-
-    internal static IQueryable<ConnectionQueryBaseRecord> RoleIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
-    {
-        if (ids is null || ids.Count == 0)
-        {
-            return query;
-        }
-
-        if (ids.Count == 1)
-        {
-            var id = ids.First();
-            return query.Where(t => t.RoleId == id);
-        }
-
-        return query.Where(t => ids.Contains(t.RoleId));
-    }
-
-    internal static IQueryable<ConnectionQueryBaseRecord> ViaRoleIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
-    {
-        if (ids is null || ids.Count == 0)
-        {
-            return query;
-        }
-
-        if (ids.Count == 1)
-        {
-            var id = ids.First();
-            return query.Where(t => t.ViaRoleId.HasValue && t.ViaRoleId == id);
-        }
-
-        return query.Where(t => t.ViaRoleId.HasValue && ids.Contains(t.ViaRoleId.Value));
-    }
-}
-
-public enum ConnectionQueryDirection
-{
-    FromOthers,
-    ToOthers
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryDirection.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryDirection.cs
@@ -1,0 +1,10 @@
+﻿namespace Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
+
+/// <summary>
+/// The ConnectionQuery supports two directions of queries: FromOthers and ToOthers. This enum is used to specify the direction of the query.
+/// </summary>
+public enum ConnectionQueryDirection
+{
+    FromOthers,
+    ToOthers
+}

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryExtensions.cs
@@ -7,7 +7,7 @@ namespace Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
 /// </summary>
 internal static class ConnectionQueryExtensions
 {
-    internal static IQueryable<ConnectionQueryBaseRecord> ToIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
+    internal static IQueryable<ConnectionQueryBaseRecord> ToIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid>? ids)
     {
         if (ids is null || ids.Count == 0)
         {
@@ -23,7 +23,7 @@ internal static class ConnectionQueryExtensions
         return query.Where(t => ids.Contains(t.ToId));
     }
 
-    internal static IQueryable<ConnectionQueryBaseRecord> FromIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids, bool applyFromFilter = true)
+    internal static IQueryable<ConnectionQueryBaseRecord> FromIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid>? ids, bool applyFromFilter = true)
     {
         if (!applyFromFilter || ids is null || ids.Count == 0)
         {
@@ -39,7 +39,7 @@ internal static class ConnectionQueryExtensions
         return query.Where(t => ids.Contains(t.FromId));
     }
 
-    internal static IQueryable<ConnectionQueryBaseRecord> ViaIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
+    internal static IQueryable<ConnectionQueryBaseRecord> ViaIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid>? ids)
     {
         if (ids is null || ids.Count == 0)
         {
@@ -55,7 +55,7 @@ internal static class ConnectionQueryExtensions
         return query.Where(t => t.ViaId.HasValue && ids.Contains(t.ViaId.Value));
     }
 
-    internal static IQueryable<ConnectionQueryBaseRecord> RoleIdExcludes(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
+    internal static IQueryable<ConnectionQueryBaseRecord> RoleIdExcludes(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid>? ids)
     {
         if (ids is null || ids.Count == 0)
         {
@@ -71,7 +71,7 @@ internal static class ConnectionQueryExtensions
         return query.Where(t => !ids.Contains(t.RoleId));
     }
 
-    internal static IQueryable<ConnectionQueryBaseRecord> RoleIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
+    internal static IQueryable<ConnectionQueryBaseRecord> RoleIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid>? ids)
     {
         if (ids is null || ids.Count == 0)
         {
@@ -87,7 +87,7 @@ internal static class ConnectionQueryExtensions
         return query.Where(t => ids.Contains(t.RoleId));
     }
 
-    internal static IQueryable<ConnectionQueryBaseRecord> ViaRoleIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
+    internal static IQueryable<ConnectionQueryBaseRecord> ViaRoleIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid>? ids)
     {
         if (ids is null || ids.Count == 0)
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryExtensions.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryExtensions.cs
@@ -1,0 +1,105 @@
+﻿using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
+
+namespace Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
+
+/// <summary>
+/// Provides extension methods for filtering connection query records based on various criteria such as IDs and roles.
+/// </summary>
+internal static class ConnectionQueryExtensions
+{
+    internal static IQueryable<ConnectionQueryBaseRecord> ToIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
+    {
+        if (ids is null || ids.Count == 0)
+        {
+            return query;
+        }
+
+        if (ids.Count == 1)
+        {
+            var id = ids.First();
+            return query.Where(t => t.ToId == id);
+        }
+
+        return query.Where(t => ids.Contains(t.ToId));
+    }
+
+    internal static IQueryable<ConnectionQueryBaseRecord> FromIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids, bool applyFromFilter = true)
+    {
+        if (!applyFromFilter || ids is null || ids.Count == 0)
+        {
+            return query;
+        }
+
+        if (ids.Count == 1)
+        {
+            var id = ids.First();
+            return query.Where(t => t.FromId == id);
+        }
+
+        return query.Where(t => ids.Contains(t.FromId));
+    }
+
+    internal static IQueryable<ConnectionQueryBaseRecord> ViaIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
+    {
+        if (ids is null || ids.Count == 0)
+        {
+            return query;
+        }
+
+        if (ids.Count == 1)
+        {
+            var id = ids.First();
+            return query.Where(t => t.ViaId.HasValue && t.ViaId.Value == id);
+        }
+
+        return query.Where(t => t.ViaId.HasValue && ids.Contains(t.ViaId.Value));
+    }
+
+    internal static IQueryable<ConnectionQueryBaseRecord> RoleIdExcludes(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
+    {
+        if (ids is null || ids.Count == 0)
+        {
+            return query;
+        }
+
+        if (ids.Count == 1)
+        {
+            var id = ids.First();
+            return query.Where(t => t.RoleId != id);
+        }
+
+        return query.Where(t => !ids.Contains(t.RoleId));
+    }
+
+    internal static IQueryable<ConnectionQueryBaseRecord> RoleIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
+    {
+        if (ids is null || ids.Count == 0)
+        {
+            return query;
+        }
+
+        if (ids.Count == 1)
+        {
+            var id = ids.First();
+            return query.Where(t => t.RoleId == id);
+        }
+
+        return query.Where(t => ids.Contains(t.RoleId));
+    }
+
+    internal static IQueryable<ConnectionQueryBaseRecord> ViaRoleIdContains(this IQueryable<ConnectionQueryBaseRecord> query, HashSet<Guid> ids)
+    {
+        if (ids is null || ids.Count == 0)
+        {
+            return query;
+        }
+
+        if (ids.Count == 1)
+        {
+            var id = ids.First();
+            return query.Where(t => t.ViaRoleId.HasValue && t.ViaRoleId == id);
+        }
+
+        return query.Where(t => t.ViaRoleId.HasValue && ids.Contains(t.ViaRoleId.Value));
+    }
+}


### PR DESCRIPTION
### Summary

Extracts the two large base-query-building methods (`BuildBaseQueryFromOthers` / `BuildBaseQueryToOthers`) and their supporting code out of `ConnectionQuery` into dedicated files, improving separation of concerns and readability.

### Changes

**New files:**

- **`ConnectionBaseQueryBuilder.cs`** — New `internal` class containing:
  - `FromOthers()` — builds the base `IQueryable` for "connections from others" (direct assignments, key-role expansion, role-map joins, delegations, child/hierarchy nesting, innehaver connections)
  - `ToOthers()` — builds the base `IQueryable` for "connections to others" (direct + main-unit assignments, role-map joins, delegations, key-role expansion)
  - `BuildFilterSets()` — shared helper that constructs the filter `HashSet`s (via, viaRole, role, roleExclude) used by both directions
  - `PostgresPlanHintTakeLimit` constant and `ReviRegnRoleSet` — moved from `ConnectionQuery`

- **`ConnectionQueryExtensions.cs`** — Extension methods (`ToIdContains`, `FromIdContains`, `ViaIdContains`, `RoleIdContains`, `RoleIdExcludes`, `ViaRoleIdContains`) extracted from the bottom of `ConnectionQuery` into their own file

- **`ConnectionQueryDirection.cs`** — `ConnectionQueryDirection` enum (`FromOthers`, `ToOthers`) extracted into its own file

**Modified files:**

- **`ConnectionQuery.cs`** — Removed the extracted methods, constants, extensions, and enum. Now instantiates `ConnectionBaseQueryBuilder` and delegates base-query construction to it. All public API signatures remain unchanged.

### No behavioral changes

This is a pure structural refactor. No SQL/query logic was modified. Existing integration tests pass without changes.

Closes #3779 — as a part of #3775.