### PR TITLE
feat: let agents remove received client-delegated resources in the v2 API

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
@@ -168,6 +168,42 @@ public class ClientDelegationController(
         return Ok(result.Value);
     }
 
+    [HttpDelete("my/clients/resources")]
+    [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_WRITE)]
+    [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
+    [ProducesResponseType<List<ContractsV2.ResourceDelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
+    [ProducesResponseType<AltinnProblemDetails>(StatusCodes.Status400BadRequest, MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DeleteMyResourcesToClientViaProvider(
+        [FromQuery(Name = "provider")][Required] Guid provider,
+        [FromQuery(Name = "client")][Required] Guid client,
+        [FromBody][Required] ContractsV2.ResourceDelegationBatchInputDto payload,
+        CancellationToken cancellationToken = default)
+    {
+        var authenticatedUser = AuthenticationHelper.GetAuthenticatedPartyUuid(httpContextAccessor.HttpContext);
+        if (authenticatedUser == Guid.Empty)
+        {
+            return Unauthorized();
+        }
+
+        // The agent is the authenticated user, so agent errors point at the provider
+        // parameter that names the relationship.
+        var result = await clientDelegationService.DeleteMyClientResources(
+            authenticatedUser,
+            provider,
+            client,
+            payload,
+            new ClientDelegationParameterNames(Party: "provider", Client: "client", Agent: "provider"),
+            cancellationToken);
+        if (result.IsProblem)
+        {
+            return result.Problem.ToActionResult();
+        }
+
+        return Ok(result.Value);
+    }
+
     #endregion
 
     #region Provider
@@ -479,7 +515,7 @@ public class ClientDelegationController(
         CancellationToken cancellationToken = default
     )
     {
-        var result = await clientDelegationService.RemoveAgentResourceDelegation(party, client, agent, payload, cancellationToken);
+        var result = await clientDelegationService.RemoveAgentResourceDelegation(party, client, agent, payload, ClientDelegationParameterNames.V2, cancellationToken);
         if (result.IsProblem)
         {
             return result.Problem.ToActionResult();

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -333,6 +333,12 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
     }
 
     /// <inheritdoc/>
+    public async Task<Result<List<ContractsV2.ResourceDelegationDto>>> DeleteMyClientResources(Guid partyUuid, Guid providerUuid, Guid fromUuid, ContractsV2.ResourceDelegationBatchInputDto payload, ClientDelegationParameterNames parameterNames, CancellationToken cancellationToken = default)
+    {
+        return await RemoveAgentResourceDelegation(providerUuid, fromUuid, partyUuid, payload, parameterNames, cancellationToken);
+    }
+
+    /// <inheritdoc/>
     public async Task<Result<List<ClientDto>>> GetClients(Guid partyUuid, List<string>? roles, List<string>? packages, CancellationToken cancellationToken = default)
     {
         roles ??= [];
@@ -1836,6 +1842,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         Guid fromUuid,
         Guid toUuid,
         ContractsV2.ResourceDelegationBatchInputDto payload,
+        ClientDelegationParameterNames parameterNames,
         CancellationToken cancellationToken = default)
     {
         ValidationErrorBuilder errorBuilder = default;
@@ -1901,7 +1908,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
-                "$QUERY/party",
+                $"$QUERY/{parameterNames.Party}",
                 [new($"{partyUuid}", "entity does not exist.")]
             );
         }
@@ -1910,7 +1917,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
-                $"$QUERY/client",
+                $"$QUERY/{parameterNames.Client}",
                 [new($"{fromUuid}", $"'{fromUuid}' is not a valid existing Client for '{partyUuid}'.")]
             );
         }
@@ -1919,7 +1926,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.EntityNotExists,
-                $"$QUERY/agent",
+                $"$QUERY/{parameterNames.Agent}",
                 [new($"{toUuid}", "entity does not exist.")]
             );
         }
@@ -1931,7 +1938,7 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
         {
             errorBuilder.Add(
                 ValidationErrors.MissingAssignment,
-                $"$QUERY/agent",
+                $"$QUERY/{parameterNames.Agent}",
                 [new(RoleConstants.Agent.Entity.Urn, $"The user '{toUuid}' is not a valid registered Agent for '{partyUuid}'.")]
             );
         }
@@ -2112,6 +2119,17 @@ public interface IClientDelegationService
         ClientDelegationParameterNames parameterNames,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Removes delegated single resources from a client relationship.
+    /// </summary>
+    Task<Result<List<ContractsV2.ResourceDelegationDto>>> DeleteMyClientResources(
+        Guid partyUuid,
+        Guid providerUuid,
+        Guid fromUuid,
+        ContractsV2.ResourceDelegationBatchInputDto payload,
+        ClientDelegationParameterNames parameterNames,
+        CancellationToken cancellationToken = default);
+
     #endregion
 
     #region Provider
@@ -2267,6 +2285,7 @@ public interface IClientDelegationService
         Guid fromUuid,
         Guid toUuid,
         ContractsV2.ResourceDelegationBatchInputDto payload,
+        ClientDelegationParameterNames parameterNames,
         CancellationToken cancellationToken = default);
 
     #endregion

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -2355,4 +2355,232 @@ public class ClientDelegationControllerTest
         }
     }
     #endregion
+
+    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/my/clients/resources
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DeleteMyResourcesToClientViaProvider(Guid, Guid, ContractsV2.ResourceDelegationBatchInputDto, CancellationToken)"/>
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteMyClientResources : IClassFixture<ApiFixture>
+    {
+        public DeleteMyClientResources(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DeleteMyClientResources>(db =>
+            {
+                // Paula is the agent on both delegations, since the endpoint always acts
+                // on behalf of the authenticated user.
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var accountantFromNordisToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationNordisAS.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var accountantFromOkernToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationOkernBorettslag.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.Accountant,
+                };
+
+                var assignmentResourceNordis = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromNordisToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                var assignmentResourceOkern = new AssignmentResource()
+                {
+                    AssignmentId = accountantFromOkernToVerdiq.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    PolicyPath = "mattilsynet-baker-konditorvare/delegationpolicy.xml",
+                    PolicyVersion = "1.0",
+                };
+
+                // From Nordis, Paula holds only the resource, so removing it deletes the delegation.
+                var delegationFromNordis = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromNordisToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var delegationResourceFromNordis = new DelegationResource()
+                {
+                    DelegationId = delegationFromNordis.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceNordis.Id,
+                };
+
+                // From Okern, Paula also holds a package, so removing the resource keeps the delegation.
+                var rolePackage = db.RolePackages.FirstOrDefault(r => r.RoleId == RoleConstants.Accountant && r.PackageId == PackageConstants.AccountantWithSigningRights);
+                var delegationFromOkern = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = accountantFromOkernToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                var delegationPackageFromOkern = new DelegationPackage()
+                {
+                    DelegationId = delegationFromOkern.Id,
+                    RolePackageId = rolePackage.Id,
+                    PackageId = PackageConstants.AccountantWithSigningRights,
+                };
+
+                var delegationResourceFromOkern = new DelegationResource()
+                {
+                    DelegationId = delegationFromOkern.Id,
+                    ResourceId = TestData.MattilsynetBakeryService.Id,
+                    AssignmentResourceId = assignmentResourceOkern.Id,
+                };
+
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.Assignments.Add(accountantFromNordisToVerdiq);
+                db.Assignments.Add(accountantFromOkernToVerdiq);
+                db.AssignmentResources.Add(assignmentResourceNordis);
+                db.AssignmentResources.Add(assignmentResourceOkern);
+                db.Delegations.Add(delegationFromNordis);
+                db.Delegations.Add(delegationFromOkern);
+                db.DelegationResources.Add(delegationResourceFromNordis);
+                db.DelegationPackages.Add(delegationPackageFromOkern);
+                db.DelegationResources.Add(delegationResourceFromOkern);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", AuthzConstants.SCOPE_PORTAL_ENDUSER));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DeleteMyClientResources_WhenLastAccessOnDelegation_Returns200WithRemovedDelegation()
+        {
+            var client = CreateClient();
+
+            var deleteResult = await DeleteMyResource(client, TestEntities.OrganizationNordisAS.Id);
+
+            var deleted = Assert.Single(deleteResult);
+            Assert.True(deleted.Changed);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, deleted.ResourceId);
+
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegation = await db.Delegations
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id
+                        && d.To.ToId == TestEntities.PersonPaula.Id
+                        && d.From.FromId == TestEntities.OrganizationNordisAS.Id)
+                    .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+                Assert.Null(delegation);
+            });
+
+            // Second removal is a no-op.
+            deleteResult = await DeleteMyResource(client, TestEntities.OrganizationNordisAS.Id);
+            deleted = Assert.Single(deleteResult);
+            Assert.False(deleted.Changed);
+        }
+
+        [Fact]
+        public async Task DeleteMyClientResources_WithRemainingPackage_Returns200WithKeptDelegation()
+        {
+            var client = CreateClient();
+
+            var deleteResult = await DeleteMyResource(client, TestEntities.OrganizationOkernBorettslag.Id);
+
+            var deleted = Assert.Single(deleteResult);
+            Assert.True(deleted.Changed);
+
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegation = await db.Delegations
+                    .Include(d => d.DelegationPackages)
+                    .Include(d => d.DelegationResources)
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id
+                        && d.To.ToId == TestEntities.PersonPaula.Id
+                        && d.From.FromId == TestEntities.OrganizationOkernBorettslag.Id)
+                    .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+                Assert.NotNull(delegation);
+                Assert.Empty(delegation.DelegationResources);
+                Assert.NotEmpty(delegation.DelegationPackages);
+            });
+        }
+
+        [Fact]
+        public async Task DeleteMyClientResources_WithUnknownProviderAndClient_Returns400WithProviderAndClientQueryPointers()
+        {
+            var client = CreateClient();
+
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/my/clients/resources?provider={Guid.NewGuid()}&client={Guid.NewGuid()}")
+            {
+                Content = JsonContent.Create(new ContractsV2.ResourceDelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Accountant.Entity.Code,
+                            Resources = [TestData.MattilsynetBakeryService.RefId],
+                        }
+                    ]
+                })
+            };
+
+            var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var data = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var problem = JsonSerializer.Deserialize<AltinnValidationProblemDetails>(data, SerializerOptions);
+
+            Assert.Contains(problem.Errors, e => e.Paths.Contains("$QUERY/provider"));
+            Assert.Single(problem.Errors, e => e.Paths.Contains("$QUERY/client"));
+            Assert.DoesNotContain(problem.Errors, e => e.Paths.Contains("$QUERY/party") || e.Paths.Contains("$QUERY/from") || e.Paths.Contains("$QUERY/to") || e.Paths.Contains("$QUERY/agent"));
+        }
+
+        private static async Task<List<ContractsV2.ResourceDelegationDto>> DeleteMyResource(HttpClient client, Guid clientId)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/my/clients/resources?provider={TestEntities.OrganizationVerdiqAS}&client={clientId}")
+            {
+                Content = JsonContent.Create(new ContractsV2.ResourceDelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.Accountant.Entity.Code,
+                            Resources = [TestData.MattilsynetBakeryService.RefId],
+                        }
+                    ]
+                })
+            };
+
+            var deleteResponse = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var deleteResponsePayload = await deleteResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+            return JsonSerializer.Deserialize<List<ContractsV2.ResourceDelegationDto>>(deleteResponsePayload);
+        }
+    }
+    #endregion
 }


### PR DESCRIPTION
Closes #3821

Adds `DELETE my/clients/resources`, the resource counterpart to `DELETE my/clients/accesspackages`. `GET my/clients` already returns client delegated single resources, so an agent could see them with no way to remove them; the only route was asking the provider to call `DELETE agents/resources`.

- The endpoint takes `provider` and `client` as query parameters and the authenticated party as the agent, with the `MYCLIENTS_WRITE` scope and the same audit attribute as the endpoints around it. It maps onto the existing `RemoveAgentResourceDelegation` through `DeleteMyClientResources`, the same way `DeleteMyClient` maps onto `RemoveAgentDelegation`
- `RemoveAgentResourceDelegation` now takes `ClientDelegationParameterNames` and builds its validation pointers from it. It hardcoded `party`, `client` and `agent` before, none of which the `my` route exposes for the party and agent, so 400s would have pointed at query parameters that are not on the route. The provider side endpoint passes `ClientDelegationParameterNames.V2` and its pointers are unchanged
- Cascade handling is unchanged: the delegation row is removed only when neither packages nor resources remain

New integration tests cover removal when the resource is the last access on the delegation (delegation removed, repeat call a no-op), the case where a package remains (delegation kept), and the 400 pointers on unknown provider and client. Full Enduser API suite is green at 471 tests, v1 untouched.

External exposure still waits on the /v2/ APIM rules, same as the rest of the v2 routes.
