### PR TITLE
feat: move the body-carrying v2 client delegation deletes to POST action endpoints

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Controllers/V2/ClientDelegationController.cs
@@ -132,7 +132,7 @@ public class ClientDelegationController(
         return NoContent();
     }
 
-    [HttpDelete("my/clients/accesspackages")]
+    [HttpPost("my/clients/accesspackages/delete")]
     [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
     [ProducesResponseType<List<DelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
@@ -168,7 +168,7 @@ public class ClientDelegationController(
         return Ok(result.Value);
     }
 
-    [HttpDelete("my/clients/resources")]
+    [HttpPost("my/clients/resources/delete")]
     [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_MYCLIENTS_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
     [ProducesResponseType<List<ContractsV2.ResourceDelegationDto>>(StatusCodes.Status200OK, MediaTypeNames.Application.Json)]
@@ -407,7 +407,7 @@ public class ClientDelegationController(
         return Ok(result.Value);
     }
 
-    [HttpDelete("agents/accesspackages")]
+    [HttpPost("agents/accesspackages/delete")]
     [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE)]
     [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]
@@ -499,7 +499,7 @@ public class ClientDelegationController(
         return Ok(result.Value);
     }
 
-    [HttpDelete("agents/resources")]
+    [HttpPost("agents/resources/delete")]
     [Authorize(Policy = AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE)]
     [Authorize(Policy = AuthzConstants.POLICY_CLIENTDELEGATION_WRITE)]
     [AuditJWTClaimToDb(Claim = AltinnCoreClaimTypes.PartyUuid, System = AuditDefaults.EnduserApi)]

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -1340,7 +1340,7 @@ public class ClientDelegationControllerTest
 
     #endregion
 
-    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages
+    #region POST accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages/delete
 
     /// <summary>
     /// <see cref="ClientDelegationController.DeleteAgentAccessPackage(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
@@ -1418,7 +1418,7 @@ public class ClientDelegationControllerTest
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Delete Delegation
-            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}")
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{Route}/agents/accesspackages/delete?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}")
             {
                 Content = JsonContent.Create(new DelegationBatchInputDto()
                 {
@@ -1453,7 +1453,7 @@ public class ClientDelegationControllerTest
         {
             var client = CreateClient();
 
-            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/accesspackages?party={Guid.NewGuid()}&client={Guid.NewGuid()}&agent={Guid.NewGuid()}")
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{Route}/agents/accesspackages/delete?party={Guid.NewGuid()}&client={Guid.NewGuid()}&agent={Guid.NewGuid()}")
             {
                 Content = JsonContent.Create(new DelegationBatchInputDto()
                 {
@@ -1481,7 +1481,7 @@ public class ClientDelegationControllerTest
     }
     #endregion
 
-    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/my/clients/accesspackages
+    #region POST accessmanagement/api/v2/enduser/clientdelegations/my/clients/accesspackages/delete
 
     /// <summary>
     /// <see cref="ClientDelegationController.DeleteMyPackagesToClientViaProvider(Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
@@ -1513,7 +1513,7 @@ public class ClientDelegationControllerTest
         {
             var client = CreateClient();
 
-            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/my/clients/accesspackages?provider={Guid.NewGuid()}&client={Guid.NewGuid()}")
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{Route}/my/clients/accesspackages/delete?provider={Guid.NewGuid()}&client={Guid.NewGuid()}")
             {
                 Content = JsonContent.Create(new DelegationBatchInputDto()
                 {
@@ -1641,7 +1641,7 @@ public class ClientDelegationControllerTest
         {
             var client = CreateClient();
 
-            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}")
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{Route}/agents/accesspackages/delete?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={TestEntities.PersonPaula}")
             {
                 Content = JsonContent.Create(new DelegationBatchInputDto()
                 {
@@ -2168,7 +2168,7 @@ public class ClientDelegationControllerTest
 
     #endregion
 
-    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/agents/resources
+    #region POST accessmanagement/api/v2/enduser/clientdelegations/agents/resources/delete
 
     /// <summary>
     /// <see cref="ClientDelegationController.DeleteAgentResource(Guid, Guid, Guid, ContractsV2.ResourceDelegationBatchInputDto, CancellationToken)"/>
@@ -2333,7 +2333,7 @@ public class ClientDelegationControllerTest
 
         private static async Task<List<ContractsV2.ResourceDelegationDto>> DeleteResource(HttpClient client, Guid agent)
         {
-            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/agents/resources?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={agent}")
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{Route}/agents/resources/delete?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationNordisAS}&agent={agent}")
             {
                 Content = JsonContent.Create(new ContractsV2.ResourceDelegationBatchInputDto()
                 {
@@ -2356,7 +2356,7 @@ public class ClientDelegationControllerTest
     }
     #endregion
 
-    #region DELETE accessmanagement/api/v2/enduser/clientdelegations/my/clients/resources
+    #region POST accessmanagement/api/v2/enduser/clientdelegations/my/clients/resources/delete
 
     /// <summary>
     /// <see cref="ClientDelegationController.DeleteMyResourcesToClientViaProvider(Guid, Guid, ContractsV2.ResourceDelegationBatchInputDto, CancellationToken)"/>
@@ -2534,7 +2534,7 @@ public class ClientDelegationControllerTest
         {
             var client = CreateClient();
 
-            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/my/clients/resources?provider={Guid.NewGuid()}&client={Guid.NewGuid()}")
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{Route}/my/clients/resources/delete?provider={Guid.NewGuid()}&client={Guid.NewGuid()}")
             {
                 Content = JsonContent.Create(new ContractsV2.ResourceDelegationBatchInputDto()
                 {
@@ -2561,7 +2561,7 @@ public class ClientDelegationControllerTest
 
         private static async Task<List<ContractsV2.ResourceDelegationDto>> DeleteMyResource(HttpClient client, Guid clientId)
         {
-            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{Route}/my/clients/resources?provider={TestEntities.OrganizationVerdiqAS}&client={clientId}")
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{Route}/my/clients/resources/delete?provider={TestEntities.OrganizationVerdiqAS}&client={clientId}")
             {
                 Content = JsonContent.Create(new ContractsV2.ResourceDelegationBatchInputDto()
                 {


### PR DESCRIPTION
Closes #3823

The four /v2/ client delegation deletes that carry a request body become POST action endpoints:

| Before | After |
| --- | --- |
| `DELETE my/clients/accesspackages` | `POST my/clients/accesspackages/delete` |
| `DELETE my/clients/resources` | `POST my/clients/resources/delete` |
| `DELETE agents/accesspackages` | `POST agents/accesspackages/delete` |
| `DELETE agents/resources` | `POST agents/resources/delete` |

DELETE with a body is handled inconsistently by gateways, proxies, caching layers and generated clients. A dropped body is hard to spot because the request still looks correct from the caller side, and depending on how the server reads the payload it can mean deleting nothing or deleting more than the caller asked for. #2272 raised this originally.

The DELETE forms are removed rather than kept alongside the new ones. /v2/ is not exposed through APIM yet, so there are no callers to migrate and no deprecation path is needed. Doing this later would mean carrying both shapes for good.

Only verbs and routes change. Scopes, audit attributes, payloads, validation, cascade handling and response shapes are all unchanged, and the integration tests are the same tests pointed at the new routes. `POST agents/accesspackages` and `POST agents/resources` already existed as the delegation endpoints, so the `/delete` suffix is what separates the two.

The four v2 deletes that only take query parameters (`my/clientproviders`, `my/clients`, `agents`, `agents/clients`) keep DELETE, since they carry no body and the problem does not apply to them. v1 keeps its DELETE with body endpoints unchanged.

Full Enduser API suite green at 471 tests, including the swagger doc split assertions.
