### PR TITLE
feat: return the resource registry id on v2 client delegation resources

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapper.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Utils/Mappers/DtoMapper.cs
@@ -160,20 +160,6 @@ public partial class DtoMapper
         return null;
     }
 
-    public static CompactResourceDto ConvertCompactResource(ConnectionQueryResource resource)
-    {
-        if (resource is { })
-        {
-            return new CompactResourceDto()
-            {
-                Id = resource.Id,
-                Value = resource.Name
-            };
-        }
-
-        return null;
-    }
-
     public static CompactResourceDto ConvertCompactResource(Resource resource)
     {
         if (resource is { })
@@ -181,7 +167,7 @@ public partial class DtoMapper
             return new CompactResourceDto()
             {
                 Id = resource.Id,
-                Value = resource.Name
+                RefId = resource.RefId
             };
         }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -207,8 +207,9 @@ public class ClientDelegationControllerTest
             var access = verdiqClient.Access.FirstOrDefault(a => a.Role.Id == RoleConstants.Accountant);
             Assert.NotNull(access);
 
-            Assert.Single(access.Resources);
-            Assert.Equal(TestData.MattilsynetBakeryService.Id, access.Resources.FirstOrDefault()?.Id);
+            var accessResource = Assert.Single(access.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, accessResource.Id);
+            Assert.Equal(TestData.MattilsynetBakeryService.RefId, accessResource.RefId);
         }
 
         [Fact]
@@ -270,6 +271,7 @@ public class ClientDelegationControllerTest
             var verdiqResource = verdiqAccess.Resources.FirstOrDefault();
             Assert.NotNull(verdiqResource);
             Assert.Equal(TestData.MattilsynetBakeryService.Id, verdiqResource.Id);
+            Assert.Equal(TestData.MattilsynetBakeryService.RefId, verdiqResource.RefId);
         }
     }
     #endregion
@@ -539,8 +541,9 @@ public class ClientDelegationControllerTest
             var accountantAccess = nordisClient.Access.FirstOrDefault(a => a.Role.Id == RoleConstants.Accountant);
             Assert.NotNull(accountantAccess);
 
-            Assert.Single(accountantAccess.Resources);
-            Assert.Equal(TestData.MattilsynetBakeryService.Id, accountantAccess.Resources.FirstOrDefault()?.Id);
+            var accountantResource = Assert.Single(accountantAccess.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, accountantResource.Id);
+            Assert.Equal(TestData.MattilsynetBakeryService.RefId, accountantResource.RefId);
         }
 
         [Fact]
@@ -582,8 +585,9 @@ public class ClientDelegationControllerTest
             var accountantAccess = nordisClient.Access.FirstOrDefault(a => a.Role.Id == RoleConstants.Accountant);
             Assert.NotNull(accountantAccess);
 
-            Assert.Single(accountantAccess.Resources);
-            Assert.Equal(TestData.MattilsynetBakeryService.Id, accountantAccess.Resources.FirstOrDefault()?.Id);
+            var accountantResource = Assert.Single(accountantAccess.Resources);
+            Assert.Equal(TestData.MattilsynetBakeryService.Id, accountantResource.Id);
+            Assert.Equal(TestData.MattilsynetBakeryService.RefId, accountantResource.RefId);
         }
 
         [Fact]
@@ -617,6 +621,7 @@ public class ClientDelegationControllerTest
 
             var resource = Assert.Single(accountantAccess.Resources);
             Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
+            Assert.Equal(TestData.MattilsynetBakeryService.RefId, resource.RefId);
 
             Assert.Contains(accountantAccess.Packages, p => p.Id == PackageConstants.Customs.Id);
 
@@ -659,6 +664,7 @@ public class ClientDelegationControllerTest
 
             var resource = Assert.Single(accountantAccess.Resources);
             Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
+            Assert.Equal(TestData.MattilsynetBakeryService.RefId, resource.RefId);
 
             // No rightholder assignment holds the resource, so the combined filter matches nothing.
             response = await client.GetAsync($"{Route}/clients?party={TestEntities.OrganizationVerdiqAS.Id}&roles=rettighetshaver&resources={TestData.MattilsynetBakeryService.RefId}", TestContext.Current.CancellationToken);
@@ -694,6 +700,7 @@ public class ClientDelegationControllerTest
 
             var resource = Assert.Single(accountantAccess.Resources);
             Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
+            Assert.Equal(TestData.MattilsynetBakeryService.RefId, resource.RefId);
         }
     }
     #endregion
@@ -809,6 +816,7 @@ public class ClientDelegationControllerTest
 
             var resource = Assert.Single(accountantAccess.Resources);
             Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
+            Assert.Equal(TestData.MattilsynetBakeryService.RefId, resource.RefId);
         }
     }
     #endregion
@@ -1773,6 +1781,7 @@ public class ClientDelegationControllerTest
 
             var resource = Assert.Single(access.Resources);
             Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
+            Assert.Equal(TestData.MattilsynetBakeryService.RefId, resource.RefId);
         }
 
         [Fact]
@@ -1883,6 +1892,7 @@ public class ClientDelegationControllerTest
 
             var resource = Assert.Single(access.Resources);
             Assert.Equal(TestData.MattilsynetBakeryService.Id, resource.Id);
+            Assert.Equal(TestData.MattilsynetBakeryService.RefId, resource.RefId);
         }
     }
     #endregion

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/Compact/CompactResourceDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/Compact/CompactResourceDto.cs
@@ -3,7 +3,7 @@
 namespace Altinn.Authorization.Api.Contracts.AccessManagement;
 
 /// <summary>
-/// Compact versjon of resource
+/// Compact version of resource
 /// </summary>
 public class CompactResourceDto
 {
@@ -14,8 +14,8 @@ public class CompactResourceDto
     public Guid Id { get; set; }
 
     /// <summary>
-    /// Value
+    /// Reference identifier
     /// </summary>
-    [JsonPropertyName("value")]
-    public string Value { get; set; }
+    [JsonPropertyName("refId")]
+    public string RefId { get; set; }
 }


### PR DESCRIPTION
Closes #3828

The v2 write endpoints take resources as resource registry ids, but the listings returned the internal guid and the display name. A caller that delegated `app_ttd_am-automation-test-generic-app` got back `{ id: "0197a840-...", value: "Automatiseringstest for Access Management" }` and had no way to get from a listing to the id it needs for the delete. The BFF ran into this while integrating.

`CompactResourceDto` now carries `refId` instead of `value`. The model stays minimal like `CompactRoleDto` and `CompactPackageDto`, and the property is named as a subset of the full `ResourceDto` so consumers can deserialize into that model instead when they want more than the compact shape. The display name is dropped: consumers enrich resources from the registry on their own side, and a name here would need language handling the compact model has no answer for.

This affects `clients`, `agents`, `my/clients`, `agents/resources` and `clients/resources`. `CompactResourceDto` is only reachable through the v2 client delegation API, so no v1 response changes. The write responses still identify the resource by guid, which keeps `ResourceDelegationDto` and `DelegationDto` consistent with each other.

The unused `ConvertCompactResource(ConnectionQueryResource)` overload goes with it. Nothing bound to it, and the one loader that builds `ConnectionQueryResource` never sets `RefId`, so it would have returned null had anything started calling it.

Dropping `value` is breaking for anyone reading it. The BFF is the only consumer of these endpoints and does not use it yet, confirmed in the thread where this was designed.

The 471 tests in `Altinn.AccessManagement.Enduser.Api.Tests` pass locally. The v2 controller tests now assert `refId` alongside `id` everywhere a delegated resource is checked.
