### PR TITLE
fix: register api versioning in the standalone enduser host

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/AccessManagementEnduserHost.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/AccessManagementEnduserHost.cs
@@ -1,7 +1,10 @@
 ﻿using Altinn.AccessManagement.Api.Enduser.Validation;
 using Altinn.Authorization.Host.Startup;
+using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Filters;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Altinn.AccessManagement.Api.Enduser;
 
@@ -38,6 +41,38 @@ public static partial class AccessManagementEnduserHost
     /// <param name="builder">The web application builder to configure with OpenAPI and Swagger services. Cannot be null.</param>
     public static void ConfigureOpenAPI(this WebApplicationBuilder builder)
     {
+        // The v2 routes carry a v{version:apiVersion} segment, so the constraint has to be
+        // registered here as well as in the combined host. Without it the route table cannot
+        // be built and swagger generation fails.
+        builder.Services.AddApiVersioning(options =>
+        {
+            // Existing routes carry a literal "v1" segment and no api version attribute,
+            // so unspecified requests must keep resolving to 1.0. The url segment reader
+            // keeps ?api-version=... query parameters inert on those routes.
+            options.DefaultApiVersion = new ApiVersion(1.0);
+            options.AssumeDefaultVersionWhenUnspecified = true;
+            options.ApiVersionReader = new UrlSegmentApiVersionReader();
+        })
+        .AddMvc()
+        .AddApiExplorer(options =>
+        {
+            // Formats the version as "'v'major[.minor][-status]" so group names
+            // line up with the swagger document names ("v1", "v2", ...).
+            options.GroupNameFormat = "'v'VVV";
+            options.SubstituteApiVersionInUrl = true;
+        });
+
+        var applicationName = builder.Environment.ApplicationName;
+        builder.Services.AddOptions<SwaggerGenOptions>()
+            .Configure((SwaggerGenOptions options, IApiVersionDescriptionProvider provider) =>
+            {
+                // One swagger document per discovered api version, matching the combined host.
+                foreach (var description in provider.ApiVersionDescriptions)
+                {
+                    options.SwaggerDoc(description.GroupName, new OpenApiInfo { Title = applicationName, Version = description.ApiVersion.ToString() });
+                }
+            });
+
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen(options =>
         {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/AccessManagementEnduserHost.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/AccessManagementEnduserHost.cs
@@ -76,6 +76,10 @@ public static partial class AccessManagementEnduserHost
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen(options =>
         {
+            // Endpoints without a version group (minimal endpoints) belong to the v1 document.
+            // Without this they land in every document, including v2.
+            options.DocInclusionPredicate((documentName, apiDescription) => (apiDescription.GroupName ?? "v1") == documentName);
+
             options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
             {
                 Description = "Standard Authorization header using the Bearer scheme. Example: \"bearer {token}\"",

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Program.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Api.Enduser/Program.cs
@@ -12,7 +12,13 @@ if (app.Environment.IsDevelopment())
 {
     // Enable Swagger
     app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseSwaggerUI(options =>
+    {
+        foreach (var description in app.DescribeApiVersions())
+        {
+            options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json", description.GroupName.ToUpperInvariant());
+        }
+    });
 }
 
 app.UseHttpsRedirection();


### PR DESCRIPTION
Closes #3830

Running `Altinn.AccessManagement.Api.Enduser` on its own and requesting its swagger document returned 500 with `The constraint reference 'apiVersion' could not be resolved to a type`.

The v2 client delegation routes carry a `v{version:apiVersion}` segment. The constraint behind it is registered by `AddApiVersioning`, which the combined `AccessManagementHost` calls and the standalone enduser host did not. The host starts and reports listening either way, so the failure only shows up when the api explorer walks the route table on the first swagger request, which makes it look environment specific when it is not.

The enduser host now registers the same versioning setup as the combined host, with the same options: `UrlSegmentApiVersionReader` only and default version 1.0 assumed when unspecified, so v1 routes resolve exactly as before. It emits one swagger document per discovered version, and `UseSwaggerUI` enumerates `DescribeApiVersions()` so v2 is reachable from the picker rather than only the default document.

Deployed builds go through the combined host and were never affected by this.

Verified against a running instance of the project: `/swagger/v1/swagger.json` returns 200 with 38 paths and none containing `/v2/`, and `/swagger/v2/swagger.json` returns 200 with 13 paths, all under clientdelegations, covering all 19 v2 operations. Those are the same invariants `SwaggerDocTest` asserts. `Altinn.AccessManagement.Enduser.Api.Tests` is green at 462 tests.
