### PR TITLE
feat: flatten the my/clientproviders response

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -309,14 +309,6 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             {
                 Provider = DtoMapper.Convert(a.From),
                 ProviderAddedAt = a.Audit_ValidFrom,
-                Access = [
-                    new()
-                    {
-                        Role = DtoMapper.ConvertCompactRole(RoleConstants.Agent.Entity),
-                        Packages = [],
-                        Resources = [],
-                    }
-                ]
             }).ToList();
     }
 

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -337,10 +337,7 @@ public class ClientDelegationControllerTest
             var verdiq = result.Items.FirstOrDefault(p => p.Provider.Id == TestEntities.OrganizationVerdiqAS);
             Assert.NotNull(verdiq);
             Assert.NotNull(verdiq.Provider);
-
-            var access = Assert.Single(verdiq.Access);
-            Assert.Empty(access.Packages);
-            Assert.Empty(access.Resources);
+            Assert.NotEqual(default, verdiq.ProviderAddedAt);
         }
     }
     #endregion

--- a/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/MyClientProviderDto.cs
+++ b/src/libs/Altinn.Authorization.Api.Contracts/src/Altinn.Authorization.Api.Contracts/AccessManagement/V2/MyClientProviderDto.cs
@@ -19,10 +19,4 @@ public class MyClientProviderDto
     /// </summary>
     [JsonPropertyName("providerAddedAt")]
     public DateTimeOffset ProviderAddedAt { get; set; }
-
-    /// <summary>
-    /// Gets or sets a collection of all access information the agent has through the provider
-    /// </summary>
-    [JsonPropertyName("access")]
-    public List<RoleAccess> Access { get; set; } = [];
 }


### PR DESCRIPTION
Closes #3832

`GET my/clientproviders` returned a `RoleAccess` list per provider that `GetMyProvidersV2` built as a constant: one entry, role Agent, `Packages` and `Resources` always empty. The shape implied a caller could learn what a provider had granted, and carried nothing. The integration test asserted exactly that emptiness.

Reading it as the counterpart to `my/clients` does not hold either. `my/clients` already returns every provider the agent has, including providers with no delegated clients, with the clients nested underneath, so this was not the missing half of anything.

The response is now `{provider, providerAddedAt}`. `providerAddedAt` is the one thing only this endpoint returns, since `MyClientDto` carries no timestamp at any level.

The endpoint stays rather than being removed. It is the cheap way to answer "which providers am I an agent for", where `my/clients` joins delegations, packages and resources to answer a bigger question, and `DELETE my/clientproviders` keeps an obvious list to work from.

`RoleAccess` itself is untouched. `ClientDto` and `AgentDto` both use it for real data.

Dropping `access` is breaking for anyone reading it. /v2/ is not exposed through APIM yet and the frontend does not use this endpoint, so this is free now and would not be later. v1 has no equivalent endpoint and is unchanged.

`Altinn.AccessManagement.Enduser.Api.Tests` is green at 462 tests.
