### PR TITLE
test: add BDD Bruno scenario suites for the v2 client delegation API

### DIFF
--- a/docs/testing/BRUNO_API_TESTS.md
+++ b/docs/testing/BRUNO_API_TESTS.md
@@ -62,8 +62,10 @@ The reference is `test/EnduserAPI/ClientDelegationsV2/` (v2 client delegation):
   how the APIs compose.
 - Personas map to testdata entries, and each step mints its own token through a suite
   `helpers.js` (`loginAs(persona, scopes?)`), so a scenario can switch between the
-  facilitator, the client, and the agent per step. Negative steps assert the full problem
-  body: status, `code`, `validationErrors[].code`, and the parameter the error points at.
+  facilitator, the client, and the agent per step. Validation negatives (400) assert the
+  full problem body: status, `code`, `validationErrors[].code`, and the parameter the
+  error points at. Authorization negatives (401/403) assert the status only, since those
+  responses carry no problem body.
 
 ## Using them as a spec for C# tests
 

--- a/docs/testing/BRUNO_API_TESTS.md
+++ b/docs/testing/BRUNO_API_TESTS.md
@@ -42,6 +42,29 @@ tests     { test("…", () => { expect(res.status).to.equal(200); … }) }
 The `tests { … }` block is the behavioral assertion (status code, body fields, error
 codes). That is the contract worth mirroring in a C# integration test.
 
+## BDD scenario suites
+
+Newer suites are structured as BDD scenarios instead of flat per-endpoint request lists.
+The reference is `test/EnduserAPI/ClientDelegationsV2/` (v2 client delegation):
+
+- One folder per scenario. `folder.bru` holds the Gherkin text in a `docs` block, and the
+  step files are named `NN_GIVEN|WHEN|THEN|AND|CLEANUP_...` with `seq` matching the step
+  order.
+- Every scenario starts from a known state: the GIVEN steps are idempotent reset requests
+  (deletes that return 204 whether or not anything exists), so leftovers from earlier or
+  crashed runs never break a scenario. Fixtures are shared across suites, so a scenario
+  must not assume the absence of state it did not itself remove.
+- Every scenario removes what it created (CLEANUP steps), so the whole suite can run
+  repeatedly against a shared environment and scenarios can run standalone.
+- Setup that crosses APIs is expressed as explicit GIVEN steps. The client delegation
+  scenarios establish rightholder relations, package grants, and single-resource grants
+  through the v1 connections API before exercising the v2 endpoints, which also documents
+  how the APIs compose.
+- Personas map to testdata entries, and each step mints its own token through a suite
+  `helpers.js` (`loginAs(persona, scopes?)`), so a scenario can switch between the
+  facilitator, the client, and the agent per step. Negative steps assert the full problem
+  body: status, `code`, `validationErrors[].code`, and the parameter the error points at.
+
 ## Using them as a spec for C# tests
 
 - **Endpoint inventory**: which endpoints exist, with their routes and verbs.

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/01_GIVEN_NoAgentRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/01_GIVEN_NoAgentRegistered.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 01_GIVEN_NoAgentRegistered
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  GIVEN the facilitator has no agent registration for the agent person.
+
+  Reset step: removes any leftover agent assignment from earlier runs, including
+  delegations hanging on it. The delete is idempotent and returns 204 either way.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("GIVEN the facilitator has no registered agent, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/02_WHEN_AgentIsRegisteredByPersonNumber.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/02_WHEN_AgentIsRegisteredByPersonNumber.bru
@@ -1,0 +1,64 @@
+meta {
+  name: 02_WHEN_AgentIsRegisteredByPersonNumber
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+body:json {
+  {
+    "personIdentifier": "{{agentPid}}",
+    "lastName": "{{agentLastName}}"
+  }
+}
+
+docs {
+  WHEN the facilitator registers the person as agent by person number and last name.
+
+  Expects 200 with the created assignment: fromId is the facilitator, toId is the
+  agent person, roleId is the agent role. The assignment id is captured for the
+  idempotency step later in the scenario.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agentPid", td.REGN_Organisasjon.REGN_Agent.personidentity);
+  bru.setVar("agentLastName", td.REGN_Organisasjon.REGN_Agent.etternavn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+script:post-response {
+  const body = res.getBody();
+  if (body && body.id) {
+    bru.setVar("cdv2_agentAssignmentId", body.id);
+  }
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("WHEN the agent is registered, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the assignment connects the facilitator to the agent with the agent role", function() {
+    const body = res.getBody();
+    expect(body.fromId.toLowerCase()).to.equal(td.REGN_Organisasjon.partyUuid.toLowerCase());
+    expect(body.toId.toLowerCase()).to.equal(td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase());
+    expect(body.roleId.toLowerCase()).to.equal("ff4c33f5-03f7-4445-85ed-1e60b8aafb30");
+    expect(body.id).to.be.a("string").that.is.not.empty;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/03_THEN_AgentAppearsInAgentList.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/03_THEN_AgentAppearsInAgentList.bru
@@ -1,0 +1,46 @@
+meta {
+  name: 03_THEN_AgentAppearsInAgentList
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  THEN the agent appears in the facilitator's agent list with the agent role
+  and no delegations yet.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the agent appears in the agent list with the agent role", function() {
+    const agentUuid = td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.agent.id.toLowerCase() === agentUuid);
+    expect(entry, "expected the registered agent in the agent list").to.not.be.undefined;
+    expect(entry.agent.type).to.equal("Person");
+    expect(entry.agent.personIdentifier).to.equal(td.REGN_Organisasjon.REGN_Agent.personidentity);
+    expect(entry.access.some(a => a.role.code === "agent")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/04_AND_RegisteringSameAgentAgainReturnsSameAssignment.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/04_AND_RegisteringSameAgentAgainReturnsSameAssignment.bru
@@ -1,0 +1,41 @@
+meta {
+  name: 04_AND_RegisteringSameAgentAgainReturnsSameAssignment
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  AND registering the same agent again, this time by party uuid, returns the
+  existing assignment instead of creating a duplicate.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND re-registering the agent returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the assignment id is unchanged", function() {
+    expect(res.getBody().id).to.equal(bru.getVar("cdv2_agentAssignmentId"));
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/05_WHEN_AgentIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/05_WHEN_AgentIsRemoved.bru
@@ -1,0 +1,37 @@
+meta {
+  name: 05_WHEN_AgentIsRemoved
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  WHEN the facilitator removes the agent. The agent has no delegations, so the
+  removal succeeds without cascade.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN the agent is removed, the request returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/06_THEN_AgentListNoLongerContainsAgent.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/06_THEN_AgentListNoLongerContainsAgent.bru
@@ -1,0 +1,42 @@
+meta {
+  name: 06_THEN_AgentListNoLongerContainsAgent
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  THEN the agent list no longer contains the removed agent.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the removed agent is no longer in the agent list", function() {
+    const agentUuid = td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.agent.id.toLowerCase() === agentUuid);
+    expect(entry, "expected the agent to be gone from the agent list").to.be.undefined;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/01_AgentLifecycle/folder.bru
@@ -1,0 +1,15 @@
+meta {
+  name: 01_AgentLifecycle
+  seq: 1
+}
+
+docs {
+  Scenario: The facilitator registers and removes an agent
+
+    Given the facilitator has no agent registration for the agent person
+    When the facilitator registers the person as agent by person number
+    Then the agent appears in the facilitator's agent list
+    And registering the same agent again returns the same assignment
+    When the facilitator removes the agent
+    Then the agent list no longer contains the agent
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/01_GIVEN_NoAgentRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/01_GIVEN_NoAgentRegistered.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 01_GIVEN_NoAgentRegistered
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  GIVEN the facilitator has no agent registration for the agent person.
+
+  Reset step: removes any leftover agent assignment from earlier runs, including
+  delegations hanging on it. The delete is idempotent and returns 204 either way.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("GIVEN the facilitator has no registered agent, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/02_AND_AgentIsRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/02_AND_AgentIsRegistered.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 02_AND_AgentIsRegistered
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+body:json {
+  {
+    "personIdentifier": "{{agentPid}}",
+    "lastName": "{{agentLastName}}"
+  }
+}
+
+docs {
+  AND the agent person is registered as agent by person number and last name.
+
+  Setup step for the delegation scenario. Expects 200 with the created assignment.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agentPid", td.REGN_Organisasjon.REGN_Agent.personidentity);
+  bru.setVar("agentLastName", td.REGN_Organisasjon.REGN_Agent.etternavn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND registering the agent returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/03_AND_ClientListShowsDelegablePackages.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/03_AND_ClientListShowsDelegablePackages.bru
@@ -1,0 +1,51 @@
+meta {
+  name: 03_AND_ClientListShowsDelegablePackages
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  AND the client list shows the CCR client with its delegable packages.
+
+  Expects 200 and a client list entry for the CCR client with the accountant role
+  and both accountant packages available for delegation.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the client list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the CCR client is listed with both accountant packages delegable", function() {
+    const client = td.REGN_Organisasjon.REGN_Org_Clients.client_A;
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === client.partyUuid.toLowerCase());
+    expect(entry, "expected the CCR client in the client list").to.not.be.undefined;
+    expect(entry.client.organizationIdentifier).to.equal(client.orgno);
+    const access = entry.access.find(a => a.role.code === "regnskapsforer");
+    expect(access, "expected an access element with the regnskapsforer role").to.not.be.undefined;
+    const urns = access.packages.map(p => p.urn);
+    expect(urns).to.include(td.clientDelegationV2.packages.regnskapsforerLonn);
+    expect(urns).to.include(td.clientDelegationV2.packages.regnskapsforerMedSignering);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/04_WHEN_PackagesAreDelegatedToAgent.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/04_WHEN_PackagesAreDelegatedToAgent.bru
@@ -1,0 +1,73 @@
+meta {
+  name: 04_WHEN_PackagesAreDelegatedToAgent
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": [
+          "{{packageLonn}}",
+          "{{packageMedSignering}}"
+        ]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN both accountant packages are delegated to the agent for the CCR client.
+
+  Expects 200 with one delegation row per package, each marked as changed, going
+  from the client to the agent via the facilitator.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("packageLonn", td.clientDelegationV2.packages.regnskapsforerLonn);
+  bru.setVar("packageMedSignering", td.clientDelegationV2.packages.regnskapsforerMedSignering);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("WHEN the packages are delegated, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN both delegations are created from the client to the agent via the facilitator", function() {
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid.toLowerCase();
+    const agentUuid = td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase();
+    const partyUuid = td.REGN_Organisasjon.partyUuid.toLowerCase();
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(2);
+    body.forEach(row => {
+      expect(row.changed).to.be.true;
+      expect(row.fromId.toLowerCase()).to.equal(clientUuid);
+      expect(row.toId.toLowerCase()).to.equal(agentUuid);
+      expect(row.viaId.toLowerCase()).to.equal(partyUuid);
+    });
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/05_THEN_DelegatedPackagesAreListedForAgent.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/05_THEN_DelegatedPackagesAreListedForAgent.bru
@@ -1,0 +1,51 @@
+meta {
+  name: 05_THEN_DelegatedPackagesAreListedForAgent
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  THEN the delegated packages are listed for the agent. The agent's access
+  package list has an entry for the CCR client with the accountant role and
+  both delegated packages.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent access package list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN both delegated packages are listed for the agent on the CCR client", function() {
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === clientUuid);
+    expect(entry, "expected the CCR client in the agent's access package list").to.not.be.undefined;
+    const access = entry.access.find(a => a.role.code === "regnskapsforer");
+    expect(access, "expected an access element with the regnskapsforer role").to.not.be.undefined;
+    const urns = access.packages.map(p => p.urn);
+    expect(urns).to.include(td.clientDelegationV2.packages.regnskapsforerLonn);
+    expect(urns).to.include(td.clientDelegationV2.packages.regnskapsforerMedSignering);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/06_AND_DelegatedPackagesAreListedForClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/06_AND_DelegatedPackagesAreListedForClient.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 06_AND_DelegatedPackagesAreListedForClient
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients/accesspackages?party={{party}}&client={{client}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+}
+
+docs {
+  AND the delegated packages are listed for the client. The client's access
+  package list has an entry for the agent with both delegated packages.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the client access package list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND both delegated packages are listed for the agent on the client", function() {
+    const agentUuid = td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.agent.id.toLowerCase() === agentUuid);
+    expect(entry, "expected the agent in the client's access package list").to.not.be.undefined;
+    const urns = entry.access.flatMap(a => a.packages.map(p => p.urn));
+    expect(urns).to.include(td.clientDelegationV2.packages.regnskapsforerLonn);
+    expect(urns).to.include(td.clientDelegationV2.packages.regnskapsforerMedSignering);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/07_AND_DelegatingSamePackagesAgainReportsNoChange.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/07_AND_DelegatingSamePackagesAgainReportsNoChange.bru
@@ -1,0 +1,63 @@
+meta {
+  name: 07_AND_DelegatingSamePackagesAgainReportsNoChange
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": [
+          "{{packageLonn}}",
+          "{{packageMedSignering}}"
+        ]
+      }
+    ]
+  }
+}
+
+docs {
+  AND delegating the same packages again reports no change. The request is
+  idempotent and returns the same two rows with changed set to false.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("packageLonn", td.clientDelegationV2.packages.regnskapsforerLonn);
+  bru.setVar("packageMedSignering", td.clientDelegationV2.packages.regnskapsforerMedSignering);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND re-delegating the same packages returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND every delegation row reports no change", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(2);
+    body.forEach(row => {
+      expect(row.changed).to.be.false;
+    });
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/08_WHEN_RemovingAgentWithoutCascadeThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/08_WHEN_RemovingAgentWithoutCascadeThenRequestFails.bru
@@ -1,0 +1,47 @@
+meta {
+  name: 08_WHEN_RemovingAgentWithoutCascadeThenRequestFails
+  type: http
+  seq: 8
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=false
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: false
+}
+
+docs {
+  WHEN removing the agent without cascade the request fails. The agent still
+  holds package delegations, so the delete is rejected with a 400 validation
+  error pointing at the cascade parameter.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN removing the agent without cascade, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body reports validation error AM.VLD-00031 on the cascade parameter", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00031")).to.be.true;
+    const err = body.validationErrors.find(e => e.code === "AM.VLD-00031");
+    expect(JSON.stringify(err.paths)).to.include("cascade");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/09_WHEN_PackageDelegationsAreRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/09_WHEN_PackageDelegationsAreRemoved.bru
@@ -1,0 +1,63 @@
+meta {
+  name: 09_WHEN_PackageDelegationsAreRemoved
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages/delete?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": [
+          "{{packageLonn}}",
+          "{{packageMedSignering}}"
+        ]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the package delegations are removed. Both accountant package delegations
+  are deleted for the agent on the CCR client, and every row reports a change.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("packageLonn", td.clientDelegationV2.packages.regnskapsforerLonn);
+  bru.setVar("packageMedSignering", td.clientDelegationV2.packages.regnskapsforerMedSignering);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN the package delegations are removed, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN every removal row reports a change", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").that.is.not.empty;
+    body.forEach(row => {
+      expect(row.changed).to.be.true;
+    });
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/10_THEN_AgentPackageListIsEmpty.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/10_THEN_AgentPackageListIsEmpty.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 10_THEN_AgentPackageListIsEmpty
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  THEN the agent package list is empty. After the removal the agent's access
+  package list no longer has an entry for the CCR client.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent access package list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the CCR client is no longer in the agent's access package list", function() {
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === clientUuid);
+    expect(entry, "expected the CCR client to be gone from the agent's access package list").to.be.undefined;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/11_CLEANUP_AgentIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/11_CLEANUP_AgentIsRemoved.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 11_CLEANUP_AgentIsRemoved
+  type: http
+  seq: 11
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  CLEANUP the agent registration is cleaned up. Removes the agent assignment
+  created by this scenario so later scenarios start from a clean state.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("CLEANUP the agent removal returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/02_DelegateClientPackagesToAgent/folder.bru
@@ -1,0 +1,20 @@
+meta {
+  name: 02_DelegateClientPackagesToAgent
+  seq: 2
+}
+
+docs {
+  Scenario: The facilitator delegates CCR client packages to an agent
+
+    Given the facilitator has no agent registration for the agent person
+    And the agent person is registered as agent
+    And the client list shows the CCR client with its delegable packages
+    When both accountant packages are delegated to the agent for the client
+    Then the delegated packages are listed for the agent
+    And the delegated packages are listed for the client
+    And delegating the same packages again reports no change
+    When removing the agent without cascade the request fails
+    When the package delegations are removed
+    Then the agent package list is empty
+    And the agent registration is cleaned up
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/01_GIVEN_NoAgentRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/01_GIVEN_NoAgentRegistered.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 01_GIVEN_NoAgentRegistered
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  GIVEN the facilitator has no agent registration for the agent person.
+
+  Reset step: removes any leftover agent assignment from earlier runs, including
+  delegations hanging on it. The delete is idempotent and returns 204 either way.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("GIVEN the facilitator has no registered agent, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/02_AND_AgentIsRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/02_AND_AgentIsRegistered.bru
@@ -1,0 +1,55 @@
+meta {
+  name: 02_AND_AgentIsRegistered
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+body:json {
+  {
+    "personIdentifier": "{{agentPid}}",
+    "lastName": "{{agentLastName}}"
+  }
+}
+
+docs {
+  AND the agent person is registered as agent by person number and last name.
+
+  Setup step: the validation cases need a registered agent so that only the
+  deliberately invalid part of each request makes it fail.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agentPid", td.REGN_Organisasjon.REGN_Agent.personidentity);
+  bru.setVar("agentLastName", td.REGN_Organisasjon.REGN_Agent.etternavn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND registering the agent returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the assignment connects the facilitator to the agent with the agent role", function() {
+    const body = res.getBody();
+    expect(body.fromId.toLowerCase()).to.equal(td.REGN_Organisasjon.partyUuid.toLowerCase());
+    expect(body.toId.toLowerCase()).to.equal(td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase());
+    expect(body.roleId.toLowerCase()).to.equal("ff4c33f5-03f7-4445-85ed-1e60b8aafb30");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/03_WHEN_RoleIsUnknownThenDelegationFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/03_WHEN_RoleIsUnknownThenDelegationFails.bru
@@ -1,0 +1,64 @@
+meta {
+  name: 03_WHEN_RoleIsUnknownThenDelegationFails
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "{{roleCode}}",
+        "packages": [
+          "{{packageUrn}}"
+        ]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN a package is delegated under a role code that does not exist.
+
+  Expects 400 with error code STD-00000 and validation error AM.VLD-00029
+  whose paths point at the role field.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("roleCode", td.clientDelegationV2.unknown.roleCode);
+  bru.setVar("packageUrn", td.clientDelegationV2.packages.regnskapsforerLonn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN a package is delegated under an unknown role, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN validation error AM.VLD-00029 points at the role", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    const err = body.validationErrors.find(e => e.code === "AM.VLD-00029");
+    expect(err, "expected validation error AM.VLD-00029").to.not.be.undefined;
+    expect(JSON.stringify(err.paths)).to.include("role");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/04_WHEN_PackageIsUnknownThenDelegationFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/04_WHEN_PackageIsUnknownThenDelegationFails.bru
@@ -1,0 +1,63 @@
+meta {
+  name: 04_WHEN_PackageIsUnknownThenDelegationFails
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": [
+          "{{packageUrn}}"
+        ]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN a package urn that does not exist is delegated under the regnskapsforer role.
+
+  Expects 400 with error code STD-00000 and validation error AM.VLD-00030
+  whose paths point at the packages field.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("packageUrn", td.clientDelegationV2.unknown.packageUrn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN an unknown package is delegated, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN validation error AM.VLD-00030 points at the packages", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    const err = body.validationErrors.find(e => e.code === "AM.VLD-00030");
+    expect(err, "expected validation error AM.VLD-00030").to.not.be.undefined;
+    expect(JSON.stringify(err.paths)).to.include("packages");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/05_WHEN_PackageIsNotDelegableThenDelegationFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/05_WHEN_PackageIsNotDelegableThenDelegationFails.bru
@@ -1,0 +1,61 @@
+meta {
+  name: 05_WHEN_PackageIsNotDelegableThenDelegationFails
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": [
+          "{{packageUrn}}"
+        ]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the klientadministrator package, which is not delegable to agents, is
+  delegated under the regnskapsforer role.
+
+  Expects 400 with error code STD-00000 and validation error AM.VLD-00033.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("packageUrn", td.clientDelegationV2.packages.klientadministrator);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN a package that is not delegable is delegated, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN validation error AM.VLD-00033 identifies the non delegable package", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00033")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/06_WHEN_PackageIsNotHeldThroughRoleThenDelegationFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/06_WHEN_PackageIsNotHeldThroughRoleThenDelegationFails.bru
@@ -1,0 +1,61 @@
+meta {
+  name: 06_WHEN_PackageIsNotHeldThroughRoleThenDelegationFails
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": [
+          "{{packageUrn}}"
+        ]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the ansvarlig-revisor package, a delegable auditor package the regnskapsforer
+  role does not carry, is delegated under the regnskapsforer role.
+
+  Expects 400 with error code STD-00000 and validation error AM.VLD-00026.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("packageUrn", td.clientDelegationV2.packages.ansvarligRevisor);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN a package the client role does not carry is delegated, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN validation error AM.VLD-00026 identifies the package outside the role", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00026")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/07_WHEN_ClientIsUnknownThenDelegationFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/07_WHEN_ClientIsUnknownThenDelegationFails.bru
@@ -1,0 +1,64 @@
+meta {
+  name: 07_WHEN_ClientIsUnknownThenDelegationFails
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": [
+          "{{packageUrn}}"
+        ]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the client query parameter is a uuid no party has, while the body is a
+  valid regnskapsforer package delegation.
+
+  Expects 400 with error code STD-00000 and validation error AM.VLD-00006
+  whose paths point at the client parameter.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.clientDelegationV2.unknown.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("packageUrn", td.clientDelegationV2.packages.regnskapsforerLonn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN the client uuid is unknown, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN validation error AM.VLD-00006 points at the client", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    const err = body.validationErrors.find(e => e.code === "AM.VLD-00006");
+    expect(err, "expected validation error AM.VLD-00006").to.not.be.undefined;
+    expect(JSON.stringify(err.paths)).to.include("client");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/08_WHEN_AgentIsUnknownThenDelegationFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/08_WHEN_AgentIsUnknownThenDelegationFails.bru
@@ -1,0 +1,64 @@
+meta {
+  name: 08_WHEN_AgentIsUnknownThenDelegationFails
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": [
+          "{{packageUrn}}"
+        ]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the agent query parameter is a uuid no party has, while the body is a
+  valid regnskapsforer package delegation.
+
+  Expects 400 with error code STD-00000 and validation error AM.VLD-00006
+  whose paths point at the agent parameter.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.clientDelegationV2.unknown.partyUuid);
+  bru.setVar("packageUrn", td.clientDelegationV2.packages.regnskapsforerLonn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN the agent uuid is unknown, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN validation error AM.VLD-00006 points at the agent", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    const err = body.validationErrors.find(e => e.code === "AM.VLD-00006");
+    expect(err, "expected validation error AM.VLD-00006").to.not.be.undefined;
+    expect(JSON.stringify(err.paths)).to.include("agent");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/09_WHEN_AgentIsNotRegisteredThenDelegationFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/09_WHEN_AgentIsNotRegisteredThenDelegationFails.bru
@@ -1,0 +1,65 @@
+meta {
+  name: 09_WHEN_AgentIsNotRegisteredThenDelegationFails
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": [
+          "{{packageUrn}}"
+        ]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the agent query parameter is an existing person who is not registered as
+  agent of the facilitator, while the body is a valid regnskapsforer package
+  delegation.
+
+  Expects 400 with error code STD-00000 and validation error AM.VLD-00032
+  whose paths point at the agent parameter.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REVI_Organisasjon.dagligleder.partyUuid);
+  bru.setVar("packageUrn", td.clientDelegationV2.packages.regnskapsforerLonn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN the agent person is not registered, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN validation error AM.VLD-00032 points at the agent", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    const err = body.validationErrors.find(e => e.code === "AM.VLD-00032");
+    expect(err, "expected validation error AM.VLD-00032").to.not.be.undefined;
+    expect(JSON.stringify(err.paths)).to.include("agent");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/10_WHEN_ValueListIsEmptyThenNothingIsDelegated.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/10_WHEN_ValueListIsEmptyThenNothingIsDelegated.bru
@@ -1,0 +1,52 @@
+meta {
+  name: 10_WHEN_ValueListIsEmptyThenNothingIsDelegated
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": []
+  }
+}
+
+docs {
+  WHEN the value list in the body is empty.
+
+  Expects 200 with an empty result array: nothing is delegated and nothing fails.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN the value list is empty, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN nothing is delegated and the result is an empty array", function() {
+    const body = res.getBody();
+    expect(Array.isArray(body)).to.be.true;
+    expect(body.length).to.equal(0);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/11_CLEANUP_AgentIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/11_CLEANUP_AgentIsRemoved.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 11_CLEANUP_AgentIsRemoved
+  type: http
+  seq: 11
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  CLEANUP the agent registration is removed, with cascade in case a validation
+  step unexpectedly delegated something, so the scenario leaves no traces.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("CLEANUP removing the agent registration returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/03_PackageDelegationValidation/folder.bru
@@ -1,0 +1,20 @@
+meta {
+  name: 03_PackageDelegationValidation
+  seq: 3
+}
+
+docs {
+  Scenario: Package delegation rejects invalid input
+
+    Given the facilitator has no agent registration for the agent person
+    And the agent person is registered as agent
+    When a package is delegated under an unknown role the request fails
+    When an unknown package is delegated the request fails
+    When a package that is not delegable is delegated the request fails
+    When a package the client role does not carry is delegated the request fails
+    When the client uuid is unknown the request fails
+    When the agent uuid is unknown the request fails
+    When the agent person is not registered the request fails
+    When the value list is empty nothing is delegated
+    And the agent registration is cleaned up
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/04_AgentRegistrationValidation/01_WHEN_OrganisationIsRegisteredAsAgentThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/04_AgentRegistrationValidation/01_WHEN_OrganisationIsRegisteredAsAgentThenRequestFails.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 01_WHEN_OrganisationIsRegisteredAsAgentThenRequestFails
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  WHEN the facilitator tries to register an organisation as agent.
+
+  Expects 400 with validation error AM.VLD-00008, because only persons can be
+  registered as agents.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REVI_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN an organisation is registered as agent, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body reports validation error AM.VLD-00008", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00008")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/04_AgentRegistrationValidation/02_WHEN_AgentUuidIsUnknownThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/04_AgentRegistrationValidation/02_WHEN_AgentUuidIsUnknownThenRequestFails.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 02_WHEN_AgentUuidIsUnknownThenRequestFails
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  WHEN the facilitator tries to register an agent using a party uuid that does
+  not exist.
+
+  Expects 400 with validation error AM.VLD-00006 pointing at the agent
+  parameter.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.clientDelegationV2.unknown.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN the agent uuid is unknown, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body reports validation error AM.VLD-00006 on the agent parameter", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    const err = body.validationErrors.find(e => e.code === "AM.VLD-00006");
+    expect(err, "expected validation error AM.VLD-00006").to.not.be.undefined;
+    expect(JSON.stringify(err.paths)).to.include("agent");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/04_AgentRegistrationValidation/03_WHEN_NoAgentIsGivenThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/04_AgentRegistrationValidation/03_WHEN_NoAgentIsGivenThenRequestFails.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 03_WHEN_NoAgentIsGivenThenRequestFails
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  WHEN the facilitator tries to register an agent without an agent query
+  parameter and without person details in the body.
+
+  Expects 400 with a validation error on the agent input. The error comes from
+  the standard required-field descriptor, so no specific error code is
+  asserted.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN neither agent nor person details are given, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body reports a validation error on the agent input", function() {
+    const errors = res.getBody().validationErrors;
+    expect(errors).to.be.an("array").that.is.not.empty;
+    expect(JSON.stringify(errors.flatMap(e => e.paths))).to.include("agent");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/04_AgentRegistrationValidation/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/04_AgentRegistrationValidation/folder.bru
@@ -1,0 +1,12 @@
+meta {
+  name: 04_AgentRegistrationValidation
+  seq: 4
+}
+
+docs {
+  Scenario: Agent registration rejects invalid input
+
+    When an organisation is registered as agent the request fails
+    When the agent uuid is unknown the request fails
+    When neither agent nor person details are given the request fails
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/01_GIVEN_NoRightholderRelationExists.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/01_GIVEN_NoRightholderRelationExists.bru
@@ -1,0 +1,42 @@
+meta {
+  name: 01_GIVEN_NoRightholderRelationExists
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{clientB}}&from={{clientB}}&to={{party}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  from: {{clientB}}
+  to: {{party}}
+  cascade: true
+}
+
+docs {
+  GIVEN no rightholder relation exists between the client and the facilitator.
+
+  Reset step: removes any leftover rightholder connection from earlier runs,
+  including package grants hanging on it. The delete is idempotent and returns
+  204 either way.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("GIVEN no rightholder relation exists, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/02_AND_ClientAddsFacilitatorAsRightholder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/02_AND_ClientAddsFacilitatorAsRightholder.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 02_AND_ClientAddsFacilitatorAsRightholder
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{clientB}}&to={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  to: {{party}}
+}
+
+docs {
+  AND the client adds the facilitator as rightholder.
+
+  Expects 200 with the created assignment: fromId is the client, toId is the
+  facilitator, roleId is the rettighetshaver role.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the client adds the facilitator as rightholder, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the assignment connects the client to the facilitator with the rettighetshaver role", function() {
+    const body = res.getBody();
+    expect(body.roleId.toLowerCase()).to.equal("42cae370-2dc1-4fdc-9c67-c2f4b0f0f829");
+    expect(body.fromId.toLowerCase()).to.equal(td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase());
+    expect(body.toId.toLowerCase()).to.equal(td.REGN_Organisasjon.partyUuid.toLowerCase());
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/03_AND_ClientDelegatesPackageToFacilitator.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/03_AND_ClientDelegatesPackageToFacilitator.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 03_AND_ClientDelegatesPackageToFacilitator
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/accesspackages?party={{clientB}}&to={{party}}&package={{package}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  to: {{party}}
+  package: {{package}}
+}
+
+docs {
+  AND the client delegates the skattegrunnlag package to the facilitator on the
+  rightholder relation.
+
+  Expects 200 with the created package grant.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.skattegrunnlag);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("AND the client delegates the package to the facilitator, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the response contains the created package grant", function() {
+    expect(res.getBody(), "expected the package grant in the response").to.be.ok;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/04_AND_NoAgentRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/04_AND_NoAgentRegistered.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 04_AND_NoAgentRegistered
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  AND the facilitator has no agent registration for the agent person yet.
+
+  Reset step: removes any leftover agent assignment from earlier runs, including
+  delegations hanging on it. The delete is idempotent and returns 204 either way.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND the facilitator has no registered agent, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/05_AND_AgentIsRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/05_AND_AgentIsRegistered.bru
@@ -1,0 +1,46 @@
+meta {
+  name: 05_AND_AgentIsRegistered
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+body:json {
+  {
+    "personIdentifier": "{{agentPid}}",
+    "lastName": "{{agentLastName}}"
+  }
+}
+
+docs {
+  AND the facilitator registers the person as agent by person number and last
+  name, so the rightholder package can be delegated to the agent.
+
+  Expects 200 with the created assignment.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agentPid", td.REGN_Organisasjon.REGN_Agent.personidentity);
+  bru.setVar("agentLastName", td.REGN_Organisasjon.REGN_Agent.etternavn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND the agent is registered, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/06_WHEN_RightholderPackageIsDelegatedToAgent.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/06_WHEN_RightholderPackageIsDelegatedToAgent.bru
@@ -1,0 +1,67 @@
+meta {
+  name: 06_WHEN_RightholderPackageIsDelegatedToAgent
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{clientB}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{clientB}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "rettighetshaver",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the rightholder package is delegated to the agent for the client.
+
+  Expects 200 with a single delegation row: fromId is the client, toId is the
+  agent, viaId is the facilitator, roleId is the rettighetshaver role and the
+  row is marked as changed.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.skattegrunnlag);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("WHEN the rightholder package is delegated to the agent, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the delegation row connects the client to the agent through the facilitator", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(1);
+    const row = body[0];
+    expect(row.changed).to.equal(true);
+    expect(row.roleId.toLowerCase()).to.equal("42cae370-2dc1-4fdc-9c67-c2f4b0f0f829");
+    expect(row.fromId.toLowerCase()).to.equal(td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase());
+    expect(row.toId.toLowerCase()).to.equal(td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase());
+    expect(row.viaId.toLowerCase()).to.equal(td.REGN_Organisasjon.partyUuid.toLowerCase());
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/07_THEN_AgentPackageListShowsRightholderClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/07_THEN_AgentPackageListShowsRightholderClient.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 07_THEN_AgentPackageListShowsRightholderClient
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  THEN the agent package list shows the rightholder client with the delegated
+  skattegrunnlag package on the rettighetshaver role.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent package list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the rightholder client appears with the delegated package", function() {
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === clientUuid);
+    expect(entry, "expected the rightholder client in the agent package list").to.not.be.undefined;
+    const access = entry.access.find(a => a.role.code === "rettighetshaver");
+    expect(access, "expected an access element with the rettighetshaver role").to.not.be.undefined;
+    expect(access.packages.map(p => p.urn)).to.include(td.clientDelegationV2.packages.skattegrunnlag);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/08_WHEN_RemovingClientFromAgentWithoutCascadeThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/08_WHEN_RemovingClientFromAgentWithoutCascadeThenRequestFails.bru
@@ -1,0 +1,51 @@
+meta {
+  name: 08_WHEN_RemovingClientFromAgentWithoutCascadeThenRequestFails
+  type: http
+  seq: 8
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/clients?party={{party}}&client={{clientB}}&agent={{agent}}&cascade=false
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{clientB}}
+  agent: {{agent}}
+  cascade: false
+}
+
+docs {
+  WHEN removing the client from the agent without cascade while the package
+  delegation still exists.
+
+  Expects 400 with validation error AM.VLD-00031, because the delegation must
+  be removed first or the cascade flag must be set.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN the client is removed from the agent without cascade, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body reports validation error AM.VLD-00031 on the cascade parameter", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00031")).to.be.true;
+    const err = body.validationErrors.find(e => e.code === "AM.VLD-00031");
+    expect(JSON.stringify(err.paths)).to.include("cascade");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/09_WHEN_ClientIsRemovedFromAgentWithCascade.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/09_WHEN_ClientIsRemovedFromAgentWithCascade.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 09_WHEN_ClientIsRemovedFromAgentWithCascade
+  type: http
+  seq: 9
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/clients?party={{party}}&client={{clientB}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{clientB}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  WHEN the client is removed from the agent with cascade, so the package
+  delegation is removed together with the client relation.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN the client is removed from the agent with cascade, the request returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/10_THEN_AgentPackageListIsEmpty.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/10_THEN_AgentPackageListIsEmpty.bru
@@ -1,0 +1,44 @@
+meta {
+  name: 10_THEN_AgentPackageListIsEmpty
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  THEN the agent package list no longer contains the rightholder client.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent package list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the rightholder client is no longer in the agent package list", function() {
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === clientUuid);
+    expect(entry, "expected the rightholder client to be gone from the agent package list").to.be.undefined;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/11_CLEANUP_PackageIsRemovedFromFacilitator.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/11_CLEANUP_PackageIsRemovedFromFacilitator.bru
@@ -1,0 +1,39 @@
+meta {
+  name: 11_CLEANUP_PackageIsRemovedFromFacilitator
+  type: http
+  seq: 11
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/accesspackages?party={{clientB}}&from={{clientB}}&to={{party}}&package={{package}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  from: {{clientB}}
+  to: {{party}}
+  package: {{package}}
+}
+
+docs {
+  CLEANUP the package grant from the client to the facilitator is removed.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.skattegrunnlag);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("CLEANUP the package is removed from the facilitator, the delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/12_CLEANUP_RightholderRelationIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/12_CLEANUP_RightholderRelationIsRemoved.bru
@@ -1,0 +1,39 @@
+meta {
+  name: 12_CLEANUP_RightholderRelationIsRemoved
+  type: http
+  seq: 12
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{clientB}}&from={{clientB}}&to={{party}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  from: {{clientB}}
+  to: {{party}}
+  cascade: true
+}
+
+docs {
+  CLEANUP the rightholder relation between the client and the facilitator is
+  removed, including anything still hanging on it.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("CLEANUP the rightholder relation is removed, the delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/13_CLEANUP_AgentIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/13_CLEANUP_AgentIsRemoved.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 13_CLEANUP_AgentIsRemoved
+  type: http
+  seq: 13
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  CLEANUP the agent registration is removed from the facilitator, including any
+  delegations still hanging on it.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("CLEANUP the agent is removed, the delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/05_RightholderClientPackages/folder.bru
@@ -1,0 +1,19 @@
+meta {
+  name: 05_RightholderClientPackages
+  seq: 5
+}
+
+docs {
+  Scenario: A rightholder client's package travels through the facilitator to an agent
+
+    Given no rightholder relation exists between the client and the facilitator
+    And the client adds the facilitator as rightholder
+    And the client delegates a package to the facilitator
+    And the facilitator has a registered agent
+    When the rightholder package is delegated to the agent for the client
+    Then the agent package list shows the rightholder client
+    When removing the client from the agent without cascade the request fails
+    When the client is removed from the agent with cascade
+    Then the agent package list is empty
+    And the package grant, the rightholder relation and the agent registration are cleaned up
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/01_GIVEN_NoRightholderRelationExists.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/01_GIVEN_NoRightholderRelationExists.bru
@@ -1,0 +1,42 @@
+meta {
+  name: 01_GIVEN_NoRightholderRelationExists
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{clientB}}&from={{clientB}}&to={{party}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  from: {{clientB}}
+  to: {{party}}
+  cascade: true
+}
+
+docs {
+  GIVEN no rightholder relation exists between the client and the facilitator.
+
+  Reset step: the client's manager removes any leftover rightholder connection to
+  the facilitator, including delegations hanging on it. The delete is idempotent
+  and returns 204 either way.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("GIVEN no rightholder relation exists, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/02_AND_ClientAddsFacilitatorAsRightholder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/02_AND_ClientAddsFacilitatorAsRightholder.bru
@@ -1,0 +1,42 @@
+meta {
+  name: 02_AND_ClientAddsFacilitatorAsRightholder
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{clientB}}&to={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  to: {{party}}
+}
+
+docs {
+  AND the client adds the facilitator as rightholder through the v1 connections API.
+
+  Expects 200 with the created assignment carrying the rettighetshaver role.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("AND the client adds the facilitator as rightholder, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the created assignment carries the rettighetshaver role", function() {
+    expect(res.getBody().roleId.toLowerCase()).to.equal("42cae370-2dc1-4fdc-9c67-c2f4b0f0f829");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/03_AND_ClientChecksDelegableRightsForResource.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/03_AND_ClientChecksDelegableRightsForResource.bru
@@ -1,0 +1,56 @@
+meta {
+  name: 03_AND_ClientChecksDelegableRightsForResource
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources/delegationcheck?party={{clientB}}&resource={{resource}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  resource: {{resource}}
+}
+
+docs {
+  AND the client checks which rights on the single resource it can delegate.
+
+  The delegation check returns the delegable rights with the opaque right keys the
+  grant endpoint expects. The read right must be delegable for the client's
+  dagligleder, and its key is captured for the next step.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+script:post-response {
+  const body = res.getBody();
+  const readRight = (body.rights || []).find(r => r.right.action.value === "read");
+  if (readRight) {
+    bru.setVar("cdv2_resourceReadRightKey", readRight.right.key);
+  }
+}
+
+tests {
+  test("AND the delegation check request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the read right on the resource is delegable for the client", function() {
+    const body = res.getBody();
+    const readRight = body.rights.find(r => r.right.action.value === "read");
+    expect(readRight, "expected a read right in the delegation check response").to.not.be.undefined;
+    expect(readRight.result).to.be.true;
+    expect(readRight.right.key).to.be.a("string").that.is.not.empty;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/03_AND_ClientGrantsResourceToFacilitator.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/03_AND_ClientGrantsResourceToFacilitator.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 03_AND_ClientGrantsResourceToFacilitator
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources/rights?party={{clientB}}&to={{party}}&resource={{resource}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  to: {{party}}
+  resource: {{resource}}
+}
+
+body:json {
+  {
+    "DirectRightKeys": ["urn:altinn:resource:{{resource}}:urn:oasis:names:tc:xacml:1.0:action:action-id:read"]
+  }
+}
+
+docs {
+  AND the client grants the facilitator the read right on the single resource
+  through the v1 connections API. Expects 201.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("resource", td.resources.clientDelgResourceId);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("AND the client grants the facilitator the resource, the request returns 201", function() {
+    expect(res.status).to.equal(201);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/04_AND_ClientGrantsResourceToFacilitator.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/04_AND_ClientGrantsResourceToFacilitator.bru
@@ -1,7 +1,7 @@
 meta {
-  name: 03_AND_ClientGrantsResourceToFacilitator
+  name: 04_AND_ClientGrantsResourceToFacilitator
   type: http
-  seq: 3
+  seq: 4
 }
 
 post {
@@ -18,13 +18,14 @@ params:query {
 
 body:json {
   {
-    "DirectRightKeys": ["urn:altinn:resource:{{resource}}:urn:oasis:names:tc:xacml:1.0:action:action-id:read"]
+    "DirectRightKeys": ["{{cdv2_resourceReadRightKey}}"]
   }
 }
 
 docs {
   AND the client grants the facilitator the read right on the single resource
-  through the v1 connections API. Expects 201.
+  through the v1 connections API, using the right key captured from the
+  delegation check. Expects 201.
 }
 
 script:pre-request {
@@ -33,7 +34,7 @@ script:pre-request {
 
   bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
   bru.setVar("party", td.REGN_Organisasjon.partyUuid);
-  bru.setVar("resource", td.resources.clientDelgResourceId);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
 
   await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
 }

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/04_AND_NoAgentRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/04_AND_NoAgentRegistered.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 04_AND_NoAgentRegistered
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  AND the facilitator has no agent registration for the agent person.
+
+  Reset step: removes any leftover agent assignment from earlier runs, including
+  delegations hanging on it. The delete is idempotent and returns 204 either way.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND the facilitator has no registered agent, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/05_AND_NoAgentRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/05_AND_NoAgentRegistered.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 05_AND_NoAgentRegistered
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  AND the facilitator has no agent registration for the agent person.
+
+  Reset step: removes any leftover agent assignment from earlier runs, including
+  delegations hanging on it. The delete is idempotent and returns 204 either way.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND the facilitator has no registered agent, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/06_AND_AgentIsRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/06_AND_AgentIsRegistered.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 06_AND_AgentIsRegistered
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+body:json {
+  {
+    "personIdentifier": "{{agentPid}}",
+    "lastName": "{{agentLastName}}"
+  }
+}
+
+docs {
+  AND the facilitator registers the person as agent by person number and last name,
+  so the delegation steps have an agent to target. Expects 200 with the created
+  assignment.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agentPid", td.REGN_Organisasjon.REGN_Agent.personidentity);
+  bru.setVar("agentLastName", td.REGN_Organisasjon.REGN_Agent.etternavn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND the agent is registered, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/07_WHEN_ResourceIsDelegatedToAgent.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/07_WHEN_ResourceIsDelegatedToAgent.bru
@@ -1,0 +1,68 @@
+meta {
+  name: 07_WHEN_ResourceIsDelegatedToAgent
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/resources?party={{party}}&client={{clientB}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{clientB}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "rettighetshaver",
+        "resources": ["{{resource}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the resource is delegated to the agent for the client.
+
+  Expects 200 with one delegation row: changed is true, the roleId is the
+  rettighetshaver role, fromId is the client, toId is the agent and viaId is
+  the facilitator.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("WHEN the resource is delegated to the agent, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the response contains one changed delegation row for the rettighetshaver role", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(1);
+    const row = body[0];
+    expect(row.changed).to.be.true;
+    expect(row.roleId.toLowerCase()).to.equal("42cae370-2dc1-4fdc-9c67-c2f4b0f0f829");
+    expect(row.fromId.toLowerCase()).to.equal(td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase());
+    expect(row.toId.toLowerCase()).to.equal(td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase());
+    expect(row.viaId.toLowerCase()).to.equal(td.REGN_Organisasjon.partyUuid.toLowerCase());
+    expect(row.resourceId).to.be.a("string").that.is.not.empty;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/08_THEN_AgentResourceListShowsClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/08_THEN_AgentResourceListShowsClient.bru
@@ -1,0 +1,49 @@
+meta {
+  name: 08_THEN_AgentResourceListShowsClient
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/resources?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  THEN the agent resource list shows the client with the delegated resource under
+  the rettighetshaver role.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent resource list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the client appears with the delegated resource under the rettighetshaver role", function() {
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase();
+    const resourceRefId = td.clientDelegationV2.singleResource;
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === clientUuid);
+    expect(entry, "expected the client in the agent resource list").to.not.be.undefined;
+    const access = entry.access.find(a => a.role.code === "rettighetshaver");
+    expect(access, "expected a rettighetshaver access element").to.not.be.undefined;
+    expect(access.resources.some(r => r.refId === resourceRefId)).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/09_AND_ClientResourceListShowsAgent.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/09_AND_ClientResourceListShowsAgent.bru
@@ -1,0 +1,46 @@
+meta {
+  name: 09_AND_ClientResourceListShowsAgent
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients/resources?party={{party}}&client={{clientB}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{clientB}}
+}
+
+docs {
+  AND the client resource list shows the agent with the delegated resource.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the client resource list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the agent appears with the delegated resource", function() {
+    const agentUuid = td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase();
+    const resourceRefId = td.clientDelegationV2.singleResource;
+    const entry = res.getBody().data.find(item => item.agent.id.toLowerCase() === agentUuid);
+    expect(entry, "expected the agent in the client resource list").to.not.be.undefined;
+    expect(entry.access.some(a => a.resources.some(r => r.refId === resourceRefId))).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/10_AND_AgentSeesResourceOnMyClients.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/10_AND_AgentSeesResourceOnMyClients.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 10_AND_AgentSeesResourceOnMyClients
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients
+  body: none
+  auth: inherit
+}
+
+docs {
+  AND the agent sees the resource on the my clients endpoint: the facilitator
+  appears as provider, the client appears under it, and the client's access
+  contains the resource under the rettighetshaver role.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsRead);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the my clients request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the client's access under the facilitator contains the delegated resource", function() {
+    const providerUuid = td.REGN_Organisasjon.partyUuid.toLowerCase();
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase();
+    const resourceRefId = td.clientDelegationV2.singleResource;
+    const providerEntry = res.getBody().data.find(item => item.provider.id.toLowerCase() === providerUuid);
+    expect(providerEntry, "expected the facilitator as provider on my clients").to.not.be.undefined;
+    const clientEntry = providerEntry.clients.find(c => c.client.id.toLowerCase() === clientUuid);
+    expect(clientEntry, "expected the client under the facilitator").to.not.be.undefined;
+    const access = clientEntry.access.find(a => a.role.code === "rettighetshaver");
+    expect(access, "expected a rettighetshaver access element").to.not.be.undefined;
+    expect(access.resources.some(r => r.refId === resourceRefId)).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/11_WHEN_UnknownResourceIsDelegatedThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/11_WHEN_UnknownResourceIsDelegatedThenRequestFails.bru
@@ -1,0 +1,58 @@
+meta {
+  name: 11_WHEN_UnknownResourceIsDelegatedThenRequestFails
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/resources?party={{party}}&client={{clientB}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{clientB}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "rettighetshaver",
+        "resources": ["{{unknownResource}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN an unknown resource is delegated the request fails.
+
+  Expects 400 with validation error AM.VLD-00012 for the unknown resource.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("unknownResource", td.clientDelegationV2.unknown.resourceRefId);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN an unknown resource is delegated, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body flags the unknown resource with AM.VLD-00012", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00012")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/12_WHEN_ResourceNotGrantedForClientThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/12_WHEN_ResourceNotGrantedForClientThenRequestFails.bru
@@ -1,0 +1,60 @@
+meta {
+  name: 12_WHEN_ResourceNotGrantedForClientThenRequestFails
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/resources?party={{party}}&client={{clientA}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{clientA}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "resources": ["{{resource}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN a resource the facilitator does not hold for a client is delegated the
+  request fails. The resource was granted on the client_B relation only, so
+  delegating it for client_A is rejected.
+
+  Expects 400 with validation error AM.VLD-00026.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("clientA", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN a resource not granted for the client is delegated, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body flags the missing resource grant with AM.VLD-00026", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00026")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/13_WHEN_AgentRemovesOwnResourceDelegation.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/13_WHEN_AgentRemovesOwnResourceDelegation.bru
@@ -1,0 +1,55 @@
+meta {
+  name: 13_WHEN_AgentRemovesOwnResourceDelegation
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients/resources/delete?provider={{party}}&client={{clientB}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  provider: {{party}}
+  client: {{clientB}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "rettighetshaver",
+        "resources": ["{{resource}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the agent removes its own resource delegation through the my clients
+  endpoint. Expects 200 with every returned row reporting changed true.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsWrite);
+}
+
+tests {
+  test("WHEN the agent removes its own resource delegation, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN every returned row reports a change", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").that.is.not.empty;
+    expect(body.every(row => row.changed === true)).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/14_THEN_AgentResourceListIsEmpty.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/14_THEN_AgentResourceListIsEmpty.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 14_THEN_AgentResourceListIsEmpty
+  type: http
+  seq: 14
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/resources?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  THEN the agent resource list is empty: the client no longer appears after the
+  agent removed the delegation.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent resource list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the client is no longer in the agent resource list", function() {
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === clientUuid);
+    expect(entry, "expected the client to be gone from the agent resource list").to.be.undefined;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/15_AND_RemovingResourceAgainReportsNoChange.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/15_AND_RemovingResourceAgainReportsNoChange.bru
@@ -1,0 +1,56 @@
+meta {
+  name: 15_AND_RemovingResourceAgainReportsNoChange
+  type: http
+  seq: 15
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/resources/delete?party={{party}}&client={{clientB}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{clientB}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "rettighetshaver",
+        "resources": ["{{resource}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  AND removing the resource again reports no change: the delegation is already
+  gone, so the delete is a no-op. Expects 200 with every returned row reporting
+  changed false.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND removing the resource again returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND no returned row reports a change", function() {
+    expect(res.getBody().every(row => row.changed === false)).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/16_CLEANUP_ResourceGrantIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/16_CLEANUP_ResourceGrantIsRemoved.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 16_CLEANUP_ResourceGrantIsRemoved
+  type: http
+  seq: 16
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources?party={{clientB}}&from={{clientB}}&to={{party}}&resource={{resource}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  from: {{clientB}}
+  to: {{party}}
+  resource: {{resource}}
+}
+
+docs {
+  CLEANUP the resource grant from the client to the facilitator is removed
+  through the v1 connections API. Expects 204.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("CLEANUP the resource grant is removed with 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/17_CLEANUP_RightholderRelationIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/17_CLEANUP_RightholderRelationIsRemoved.bru
@@ -1,0 +1,39 @@
+meta {
+  name: 17_CLEANUP_RightholderRelationIsRemoved
+  type: http
+  seq: 17
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{clientB}}&from={{clientB}}&to={{party}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  from: {{clientB}}
+  to: {{party}}
+  cascade: true
+}
+
+docs {
+  CLEANUP the rightholder relation between the client and the facilitator is
+  removed, including anything hanging on it. Expects 204.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("CLEANUP the rightholder relation is removed with 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/18_CLEANUP_AgentIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/18_CLEANUP_AgentIsRemoved.bru
@@ -1,7 +1,7 @@
 meta {
-  name: 04_AND_NoAgentRegistered
+  name: 18_CLEANUP_AgentIsRemoved
   type: http
-  seq: 4
+  seq: 18
 }
 
 delete {
@@ -17,10 +17,8 @@ params:query {
 }
 
 docs {
-  AND the facilitator has no agent registration for the agent person.
-
-  Reset step: removes any leftover agent assignment from earlier runs, including
-  delegations hanging on it. The delete is idempotent and returns 204 either way.
+  CLEANUP the agent registration is removed, including any remaining delegations,
+  so the scenario leaves no state behind. Expects 204.
 }
 
 script:pre-request {
@@ -34,7 +32,7 @@ script:pre-request {
 }
 
 tests {
-  test("AND the facilitator has no registered agent, the reset delete returns 204", function() {
+  test("CLEANUP the agent registration is removed with 204", function() {
     expect(res.status).to.equal(204);
   });
 }

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/folder.bru
@@ -1,0 +1,23 @@
+meta {
+  name: 06_ResourceDelegationToAgent
+  seq: 6
+}
+
+docs {
+  Scenario: A single resource travels from the client through the facilitator to an agent
+
+    Given no rightholder relation exists between the client and the facilitator
+    And the client adds the facilitator as rightholder
+    And the client grants the facilitator a single resource
+    And the facilitator has a registered agent
+    When the resource is delegated to the agent for the client
+    Then the agent resource list shows the client
+    And the client resource list shows the agent
+    And the agent sees the resource on the my clients endpoint
+    When an unknown resource is delegated the request fails
+    When a resource the facilitator does not hold for a client is delegated the request fails
+    When the agent removes its own resource delegation
+    Then the agent resource list is empty
+    And removing the resource again reports no change
+    And the resource grant, the rightholder relation and the agent registration are cleaned up
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/06_ResourceDelegationToAgent/folder.bru
@@ -8,7 +8,8 @@ docs {
 
     Given no rightholder relation exists between the client and the facilitator
     And the client adds the facilitator as rightholder
-    And the client grants the facilitator a single resource
+    And the client checks which rights on the single resource it can delegate
+    And the client grants the facilitator the single resource
     And the facilitator has a registered agent
     When the resource is delegated to the agent for the client
     Then the agent resource list shows the client

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/01_GIVEN_NoAgentRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/01_GIVEN_NoAgentRegistered.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 01_GIVEN_NoAgentRegistered
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  GIVEN the facilitator has no agent registration for the agent person.
+
+  Reset step: removes any leftover agent assignment from earlier runs, including
+  delegations hanging on it. The delete is idempotent and returns 204 either way.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("GIVEN the facilitator has no registered agent, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/02_AND_AgentIsRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/02_AND_AgentIsRegistered.bru
@@ -1,0 +1,55 @@
+meta {
+  name: 02_AND_AgentIsRegistered
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+body:json {
+  {
+    "personIdentifier": "{{agentPid}}",
+    "lastName": "{{agentLastName}}"
+  }
+}
+
+docs {
+  AND the facilitator registers the person as agent by person number and last name.
+
+  Expects 200 with the created assignment: fromId is the facilitator, toId is the
+  agent person, roleId is the agent role.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("agentPid", td.REGN_Organisasjon.REGN_Agent.personidentity);
+  bru.setVar("agentLastName", td.REGN_Organisasjon.REGN_Agent.etternavn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the agent registration returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the assignment connects the facilitator to the agent with the agent role", function() {
+    const body = res.getBody();
+    expect(body.fromId.toLowerCase()).to.equal(td.REGN_Organisasjon.partyUuid.toLowerCase());
+    expect(body.toId.toLowerCase()).to.equal(td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase());
+    expect(body.roleId.toLowerCase()).to.equal("ff4c33f5-03f7-4445-85ed-1e60b8aafb30");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/03_AND_PackageIsDelegatedToAgent.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/03_AND_PackageIsDelegatedToAgent.bru
@@ -1,0 +1,59 @@
+meta {
+  name: 03_AND_PackageIsDelegatedToAgent
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  AND the facilitator delegates the client package to the agent, so the agent has
+  an access to manage through the my endpoints.
+
+  Expects 200 with a single delegation row where changed is true.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.regnskapsforerLonn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND the package delegation returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the delegation reports one changed row", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(1);
+    expect(body[0].changed).to.equal(true);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/04_WHEN_AgentListsProviders.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/04_WHEN_AgentListsProviders.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 04_WHEN_AgentListsProviders
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clientproviders
+  body: none
+  auth: inherit
+}
+
+docs {
+  WHEN the agent lists its providers. The facilitator appears as a provider with
+  a timestamp for when the agent was added.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsRead);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("WHEN the agent lists its providers, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the facilitator appears as a provider with an added timestamp", function() {
+    const providerUuid = td.REGN_Organisasjon.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.provider.id.toLowerCase() === providerUuid);
+    expect(entry, "expected the facilitator in the provider list").to.not.be.undefined;
+    expect(entry.providerAddedAt).to.be.a("string").that.is.not.empty;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/05_AND_AgentListsClients.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/05_AND_AgentListsClients.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 05_AND_AgentListsClients
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients
+  body: none
+  auth: inherit
+}
+
+docs {
+  AND the agent lists its clients. The facilitator appears as provider, the client
+  is listed under it, and the delegated package shows on the regnskapsforer role.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsRead);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the my clients request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the client is listed under the facilitator with the delegated package", function() {
+    const providerUuid = td.REGN_Organisasjon.partyUuid.toLowerCase();
+    const providerEntry = res.getBody().data.find(item => item.provider.id.toLowerCase() === providerUuid);
+    expect(providerEntry, "expected the facilitator in the my clients list").to.not.be.undefined;
+
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid.toLowerCase();
+    const clientEntry = providerEntry.clients.find(item => item.client.id.toLowerCase() === clientUuid);
+    expect(clientEntry, "expected the client under the facilitator").to.not.be.undefined;
+
+    const access = clientEntry.access.find(a => a.role.code === "regnskapsforer");
+    expect(access, "expected an access on the regnskapsforer role").to.not.be.undefined;
+    expect(access.packages.some(p => p.urn === td.clientDelegationV2.packages.regnskapsforerLonn)).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/06_AND_ProviderFilterMatchesProvider.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/06_AND_ProviderFilterMatchesProvider.bru
@@ -1,0 +1,43 @@
+meta {
+  name: 06_AND_ProviderFilterMatchesProvider
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients?provider={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  provider: {{party}}
+}
+
+docs {
+  AND filtering the my clients list on the provider returns the clients for that
+  provider.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsRead);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the provider filtered my clients request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the filtered result contains the provider", function() {
+    const providerUuid = td.REGN_Organisasjon.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.provider.id.toLowerCase() === providerUuid);
+    expect(entry, "expected the facilitator in the filtered my clients list").to.not.be.undefined;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/07_AND_UnknownProviderFilterReturnsNothing.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/07_AND_UnknownProviderFilterReturnsNothing.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 07_AND_UnknownProviderFilterReturnsNothing
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients?provider={{unknownParty}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  provider: {{unknownParty}}
+}
+
+docs {
+  AND filtering the my clients list on an unknown provider returns an empty list.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("unknownParty", td.clientDelegationV2.unknown.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsRead);
+}
+
+tests {
+  test("AND the unknown provider filtered request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the filtered result is empty", function() {
+    expect(res.getBody().data).to.be.an("array").that.is.empty;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/08_WHEN_AgentRemovesOwnPackageDelegation.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/08_WHEN_AgentRemovesOwnPackageDelegation.bru
@@ -1,0 +1,57 @@
+meta {
+  name: 08_WHEN_AgentRemovesOwnPackageDelegation
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients/accesspackages/delete?provider={{party}}&client={{client}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  provider: {{party}}
+  client: {{client}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the agent removes its own package delegation for the client through the
+  my endpoint.
+
+  Expects 200 where every returned row reports changed true.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.regnskapsforerLonn);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsWrite);
+}
+
+tests {
+  test("WHEN the agent removes its own package delegation, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN every returned row reports a change", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").that.is.not.empty;
+    expect(body.every(row => row.changed === true)).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/09_THEN_MyClientsNoLongerShowTheClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/09_THEN_MyClientsNoLongerShowTheClient.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 09_THEN_MyClientsNoLongerShowTheClient
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients
+  body: none
+  auth: inherit
+}
+
+docs {
+  THEN the my clients list no longer shows the client after the agent removed its
+  only package delegation for it.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsRead);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the my clients request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the client is no longer in the my clients list", function() {
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid.toLowerCase();
+    const clients = res.getBody().data.flatMap(item => item.clients);
+    const entry = clients.find(item => item.client.id.toLowerCase() === clientUuid);
+    expect(entry, "expected the client to be gone from the my clients list").to.be.undefined;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/10_AND_PackageIsDelegatedAgain.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/10_AND_PackageIsDelegatedAgain.bru
@@ -1,0 +1,59 @@
+meta {
+  name: 10_AND_PackageIsDelegatedAgain
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  AND the facilitator delegates the package to the agent again, so the client
+  removal steps have a delegation to cascade over.
+
+  Expects 200 where every returned row reports changed true.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.regnskapsforerLonn);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND re-delegating the package returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND every returned row reports a change", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").that.is.not.empty;
+    expect(body.every(row => row.changed === true)).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/11_WHEN_AgentRemovesClientWithoutCascadeThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/11_WHEN_AgentRemovesClientWithoutCascadeThenRequestFails.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 11_WHEN_AgentRemovesClientWithoutCascadeThenRequestFails
+  type: http
+  seq: 11
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients?provider={{party}}&client={{client}}&cascade=false
+  body: none
+  auth: inherit
+}
+
+params:query {
+  provider: {{party}}
+  client: {{client}}
+  cascade: false
+}
+
+docs {
+  WHEN the agent removes the client without cascade while a package delegation
+  still exists, the request fails.
+
+  Expects 400 with validation error AM.VLD-00031 pointing at the cascade parameter.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsWrite);
+}
+
+tests {
+  test("WHEN the agent removes the client without cascade, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error identifies the missing cascade flag", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00031")).to.be.true;
+    const err = body.validationErrors.find(e => e.code === "AM.VLD-00031");
+    expect(JSON.stringify(err.paths)).to.include("cascade");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/12_WHEN_AgentRemovesClientWithCascade.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/12_WHEN_AgentRemovesClientWithCascade.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 12_WHEN_AgentRemovesClientWithCascade
+  type: http
+  seq: 12
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients?provider={{party}}&client={{client}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  provider: {{party}}
+  client: {{client}}
+  cascade: true
+}
+
+docs {
+  WHEN the agent removes the client with cascade, the package delegation is
+  removed together with the client connection and the request returns 204.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("client", td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsWrite);
+}
+
+tests {
+  test("WHEN the agent removes the client with cascade, the request returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/13_THEN_MyClientsAreEmptyForTheProvider.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/13_THEN_MyClientsAreEmptyForTheProvider.bru
@@ -1,0 +1,44 @@
+meta {
+  name: 13_THEN_MyClientsAreEmptyForTheProvider
+  type: http
+  seq: 13
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients?provider={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  provider: {{party}}
+}
+
+docs {
+  THEN the my clients list is empty for the provider after the cascading client
+  removal.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsRead);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the provider filtered my clients request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the removed client is not in the my clients list", function() {
+    const clientUuid = td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid.toLowerCase();
+    const clients = res.getBody().data.flatMap(item => item.clients);
+    const entry = clients.find(item => item.client.id.toLowerCase() === clientUuid);
+    expect(entry, "expected the client to be gone from the my clients list").to.be.undefined;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/14_WHEN_AgentLeavesTheProvider.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/14_WHEN_AgentLeavesTheProvider.bru
@@ -1,0 +1,35 @@
+meta {
+  name: 14_WHEN_AgentLeavesTheProvider
+  type: http
+  seq: 14
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clientproviders?provider={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  provider: {{party}}
+}
+
+docs {
+  WHEN the agent leaves the provider, removing its own agent assignment at the
+  facilitator. The request returns 204.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsWrite);
+}
+
+tests {
+  test("WHEN the agent leaves the provider, the request returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/15_THEN_MyProviderListIsEmpty.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/15_THEN_MyProviderListIsEmpty.bru
@@ -1,0 +1,37 @@
+meta {
+  name: 15_THEN_MyProviderListIsEmpty
+  type: http
+  seq: 15
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clientproviders
+  body: none
+  auth: inherit
+}
+
+docs {
+  THEN the my provider list no longer contains the facilitator after the agent
+  left the provider.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  await loginAs(td.REGN_Organisasjon.REGN_Agent, scopes.myclientsRead);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the provider list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the facilitator is no longer in the provider list", function() {
+    const providerUuid = td.REGN_Organisasjon.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.provider.id.toLowerCase() === providerUuid);
+    expect(entry, "expected the facilitator to be gone from the provider list").to.be.undefined;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/16_AND_FacilitatorAgentListIsEmpty.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/16_AND_FacilitatorAgentListIsEmpty.bru
@@ -1,0 +1,43 @@
+meta {
+  name: 16_AND_FacilitatorAgentListIsEmpty
+  type: http
+  seq: 16
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  AND the facilitator's agent list no longer contains the agent after the agent
+  left the provider.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the agent list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the agent is no longer in the facilitator's agent list", function() {
+    const agentUuid = td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.agent.id.toLowerCase() === agentUuid);
+    expect(entry, "expected the agent to be gone from the agent list").to.be.undefined;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/07_AgentSelfService/folder.bru
@@ -1,0 +1,23 @@
+meta {
+  name: 07_AgentSelfService
+  seq: 7
+}
+
+docs {
+  Scenario: The agent manages its own client accesses through the my endpoints
+
+    Given the facilitator has a registered agent with a delegated client package
+    When the agent lists its providers
+    And the agent lists its clients
+    And filtering on the provider returns the clients
+    And filtering on an unknown provider returns nothing
+    When the agent removes its own package delegation
+    Then the my clients list no longer shows the client
+    And the package is delegated again
+    When the agent removes the client without cascade the request fails
+    When the agent removes the client with cascade
+    Then the my clients list is empty for the provider
+    When the agent leaves the provider
+    Then the my provider list is empty
+    And the facilitator agent list is empty
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/01_GIVEN_SystemUserHasNoAgentAssignment.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/01_GIVEN_SystemUserHasNoAgentAssignment.bru
@@ -1,0 +1,41 @@
+meta {
+  name: 01_GIVEN_SystemUserHasNoAgentAssignment
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  GIVEN the system user has no agent assignment.
+
+  Reset step: removes any leftover agent assignment for the system user from
+  earlier runs, including delegations hanging on it. The delete is idempotent
+  and returns 204 either way.
+}
+
+script:pre-request {
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("agent", su.regnskapsforer.systemuser.id);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("GIVEN the system user has no agent assignment, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/02_WHEN_PackageIsDelegatedToSystemUser.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/02_WHEN_PackageIsDelegatedToSystemUser.bru
@@ -1,0 +1,62 @@
+meta {
+  name: 02_WHEN_PackageIsDelegatedToSystemUser
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN a client package is delegated to the system user.
+
+  Expects 200 with a single delegation row where changed is true. The system
+  user has no agent assignment at this point; for system users the agent
+  assignment is created automatically as part of the delegation, so no
+  separate registration step is needed.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("client", su.regnskapsforer.client_org.partyuuid);
+  bru.setVar("agent", su.regnskapsforer.systemuser.id);
+  bru.setVar("package", td.clientDelegationV2.packages.regnskapsforerMedSignering);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("WHEN the package is delegated to the system user, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the response contains one delegation row with changed true", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(1);
+    expect(body[0].changed).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/03_THEN_SystemUserAppearsAsAgent.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/03_THEN_SystemUserAppearsAsAgent.bru
@@ -1,0 +1,44 @@
+meta {
+  name: 03_THEN_SystemUserAppearsAsAgent
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  THEN the system user appears as agent in the facilitator's agent list with
+  the agent role, created automatically by the delegation in the previous step.
+}
+
+script:pre-request {
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the system user appears in the agent list with the agent role", function() {
+    const systemUserId = su.regnskapsforer.systemuser.id.toLowerCase();
+    const entry = res.getBody().data.find(item => item.agent.id.toLowerCase() === systemUserId);
+    expect(entry, "expected the system user in the agent list").to.not.be.undefined;
+    expect(entry.access.some(a => a.role.code === "agent")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/04_AND_SystemUserPackageListShowsClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/04_AND_SystemUserPackageListShowsClient.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 04_AND_SystemUserPackageListShowsClient
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  AND the system user's package list shows the client org with the delegated
+  package among its package urns.
+}
+
+script:pre-request {
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("agent", su.regnskapsforer.systemuser.id);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the system user package list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the client entry includes the delegated package urn", function() {
+    const clientUuid = su.regnskapsforer.client_org.partyuuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === clientUuid);
+    expect(entry, "expected the client org in the system user package list").to.not.be.undefined;
+    const packageUrn = td.clientDelegationV2.packages.regnskapsforerMedSignering;
+    expect(entry.access.some(a => a.packages.some(p => p.urn === packageUrn))).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/05_AND_ThePersonIsNotRegisteredAsAgent.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/05_AND_ThePersonIsNotRegisteredAsAgent.bru
@@ -1,0 +1,41 @@
+meta {
+  name: 05_AND_ThePersonIsNotRegisteredAsAgent
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  AND the person is not registered as agent for the facilitator.
+
+  Reset step: other suites share these fixtures and may leave an agent
+  registration behind for the person. The delete is idempotent and returns 204
+  either way, so the next step starts from the intended state.
+}
+
+script:pre-request {
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("agent", su.regnskapsforer.non_systemuser.partyuuid);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("AND the person has no agent registration, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/05_WHEN_DelegatingToUnregisteredPersonThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/05_WHEN_DelegatingToUnregisteredPersonThenRequestFails.bru
@@ -1,0 +1,60 @@
+meta {
+  name: 05_WHEN_DelegatingToUnregisteredPersonThenRequestFails
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN a package is delegated to an unregistered person, the request fails.
+
+  Unlike system users, persons are not auto-registered as agents by the
+  delegation. Expects 400 with validation error AM.VLD-00032.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("client", su.regnskapsforer.client_org.partyuuid);
+  bru.setVar("agent", su.regnskapsforer.non_systemuser.partyuuid);
+  bru.setVar("package", td.clientDelegationV2.packages.regnskapsforerMedSignering);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("WHEN the package is delegated to an unregistered person, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body reports validation error AM.VLD-00032", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00032")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/06_CLEANUP_PackageDelegationIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/06_CLEANUP_PackageDelegationIsRemoved.bru
@@ -1,0 +1,58 @@
+meta {
+  name: 06_CLEANUP_PackageDelegationIsRemoved
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages/delete?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "regnskapsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  CLEANUP the package delegation to the system user is removed. Expects 200
+  with every row reporting changed true.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("client", su.regnskapsforer.client_org.partyuuid);
+  bru.setVar("agent", su.regnskapsforer.systemuser.id);
+  bru.setVar("package", td.clientDelegationV2.packages.regnskapsforerMedSignering);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("CLEANUP the package delegation delete returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("CLEANUP every delegation row reports changed true", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").that.is.not.empty;
+    expect(body.every(row => row.changed === true)).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/06_WHEN_DelegatingToUnregisteredPersonThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/06_WHEN_DelegatingToUnregisteredPersonThenRequestFails.bru
@@ -1,7 +1,7 @@
 meta {
-  name: 05_WHEN_DelegatingToUnregisteredPersonThenRequestFails
+  name: 06_WHEN_DelegatingToUnregisteredPersonThenRequestFails
   type: http
-  seq: 5
+  seq: 6
 }
 
 post {

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/07_CLEANUP_PackageDelegationIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/07_CLEANUP_PackageDelegationIsRemoved.bru
@@ -1,7 +1,7 @@
 meta {
-  name: 06_CLEANUP_PackageDelegationIsRemoved
+  name: 07_CLEANUP_PackageDelegationIsRemoved
   type: http
-  seq: 6
+  seq: 7
 }
 
 post {

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/08_CLEANUP_SystemUserAgentIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/08_CLEANUP_SystemUserAgentIsRemoved.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 08_CLEANUP_SystemUserAgentIsRemoved
+  type: http
+  seq: 8
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  CLEANUP the system user's agent assignment is removed with cascade, leaving
+  the facilitator without the system user as agent. Expects 204.
+}
+
+script:pre-request {
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("agent", su.regnskapsforer.systemuser.id);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("CLEANUP the system user agent removal returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/folder.bru
@@ -1,0 +1,15 @@
+meta {
+  name: 08_SystemUserAgent
+  seq: 8
+}
+
+docs {
+  Scenario: The facilitator delegates a client package to an agent system user
+
+    Given the system user has no agent assignment
+    When a client package is delegated to the system user
+    Then the system user appears as agent
+    And the system user package list shows the client
+    When a package is delegated to an unregistered person the request fails
+    And the delegation and the agent assignment are cleaned up
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/08_SystemUserAgent/folder.bru
@@ -10,6 +10,7 @@ docs {
     When a client package is delegated to the system user
     Then the system user appears as agent
     And the system user package list shows the client
+    And the person is not registered as agent for the facilitator
     When a package is delegated to an unregistered person the request fails
     And the delegation and the agent assignment are cleaned up
 }

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/01_WHEN_NoTokenIsProvidedThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/01_WHEN_NoTokenIsProvidedThenRequestFails.bru
@@ -1,0 +1,32 @@
+meta {
+  name: 01_WHEN_NoTokenIsProvidedThenRequestFails
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}
+  body: none
+  auth: none
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  WHEN no token is provided, the client list request fails with 401. The request
+  is sent without a bearer token on purpose.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+}
+
+tests {
+  test("WHEN no token is provided, the request returns 401", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/02_WHEN_UserWithoutClientAdministrationAccessThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/02_WHEN_UserWithoutClientAdministrationAccessThenRequestFails.bru
@@ -1,0 +1,36 @@
+meta {
+  name: 02_WHEN_UserWithoutClientAdministrationAccessThenRequestFails
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  WHEN a user without client administration access for the facilitator party
+  requests the client list, the request fails with 403. The private person has
+  no role at the facilitator, so the PDP denies client administration.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.privatPerson);
+}
+
+tests {
+  test("WHEN the user has no client administration access, the request returns 403", function() {
+    expect(res.status).to.equal(403);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/03_WHEN_ScopeIsInsufficientThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/03_WHEN_ScopeIsInsufficientThenRequestFails.bru
@@ -1,0 +1,36 @@
+meta {
+  name: 03_WHEN_ScopeIsInsufficientThenRequestFails
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  WHEN the facilitator's manager calls with a token whose scope does not cover
+  client delegations, the request fails with 403 even though the user itself
+  has client administration access.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder, "altinn:instances.read");
+}
+
+tests {
+  test("WHEN the token scope is insufficient, the request returns 403", function() {
+    expect(res.status).to.equal(403);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/04_AND_DedicatedReadScopeGrantsAccess.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/04_AND_DedicatedReadScopeGrantsAccess.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 04_AND_DedicatedReadScopeGrantsAccess
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  AND the same request succeeds when the token carries the dedicated client
+  delegations read scope instead of the portal scope. Expects 200 with a data
+  array.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs, scopes } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder, scopes.clientdelegationsRead);
+}
+
+tests {
+  test("AND the dedicated read scope makes the request return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the response contains a data array", function() {
+    expect(res.getBody().data).to.be.an("array");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/05_WHEN_TokenCarriesNoPartyThenMyClientsRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/05_WHEN_TokenCarriesNoPartyThenMyClientsRequestFails.bru
@@ -1,0 +1,37 @@
+meta {
+  name: 05_WHEN_TokenCarriesNoPartyThenMyClientsRequestFails
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/my/clients
+  body: none
+  auth: inherit
+}
+
+docs {
+  WHEN the caller uses an enterprise token, the my clients request fails with
+  401. The token carries the correct my clients read scope, but an enterprise
+  token has no party uuid claim, and the my endpoints resolve the acting party
+  from the token.
+}
+
+script:pre-request {
+  const tokenGenerator = require("./TestToolsTokenGenerator.js");
+  const sharedtestdata = require("./testdata/sharedtestdata.js");
+
+  const token = await tokenGenerator.getToken({
+    auth_org: sharedtestdata.serviceOwners.digdir.org,
+    auth_orgNo: sharedtestdata.serviceOwners.digdir.orgno,
+    auth_tokenType: sharedtestdata.authTokenType.enterprise,
+    auth_scopes: sharedtestdata.auth_scopes.myclientsRead,
+  });
+  bru.setVar("bearerToken", token);
+}
+
+tests {
+  test("WHEN the token carries no party, the my clients request returns 401", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/06_WHEN_PartyParameterIsMissingThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/06_WHEN_PartyParameterIsMissingThenRequestFails.bru
@@ -1,0 +1,31 @@
+meta {
+  name: 06_WHEN_PartyParameterIsMissingThenRequestFails
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients
+  body: none
+  auth: inherit
+}
+
+docs {
+  WHEN the party query parameter is missing, the client list request fails with
+  403. The authorization policy handler needs the party to ask the PDP about
+  client administration and rejects the request before the controller binds
+  its parameters, so only the status is asserted.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("WHEN the party parameter is missing, the request returns 403", function() {
+    expect(res.status).to.equal(403);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/09_AuthorizationBoundaries/folder.bru
@@ -1,0 +1,15 @@
+meta {
+  name: 09_AuthorizationBoundaries
+  seq: 9
+}
+
+docs {
+  Scenario: The API rejects callers without the required authorization
+
+    When no token is provided the request fails
+    When the user has no client administration access for the party the request fails
+    When the token scope is insufficient the request fails
+    And the dedicated read scope grants access
+    When the token carries no party the my clients request fails
+    When the party parameter is missing the request fails
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/folder.bru
@@ -1,0 +1,36 @@
+meta {
+  name: ClientDelegationsV2
+  seq: 3
+}
+
+docs {
+  # Client delegation v2 scenarios
+
+  BDD scenarios for the enduser client delegation API at
+  `/accessmanagement/api/v2/enduser/clientdelegations`.
+
+  Each subfolder is one scenario. The files inside are the scenario steps, named
+  `NN_GIVEN|WHEN|THEN|AND|CLEANUP_...` and ordered by `seq`. A scenario always starts
+  from a known state (the GIVEN steps reset leftovers from earlier runs) and removes
+  everything it created, so the whole folder can run repeatedly against a shared
+  environment. Scenarios are independent of each other and can run standalone.
+
+  ## Personas and fixtures
+
+  Seed data comes from `testdata/klient-delegation/<env>.js`:
+
+  - Facilitator: REGN_Organisasjon (accounting firm), acting through its dagligleder.
+  - CCR client: client_A, tied to the facilitator through the regnskapsforer role.
+  - Rightholder client: client_B, which grants the facilitator packages and single
+    resources through the v1 connections API in the GIVEN steps.
+  - Agent: REGN_Agent, the person the facilitator delegates client access to. The
+    my/* scenarios authenticate as this person with the dedicated myclients scopes.
+
+  The system user scenario uses the canonical system user fixtures from
+  `testdata/systemuser-clientdelegation/<env>.js`.
+
+  ## Environments
+
+  Runs against AT22. TT02 does not route `/accessmanagement/api/v2/` yet, so the
+  suite cannot pass there until the v2 routes are exposed through the gateway.
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/helpers.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/helpers.js
@@ -1,0 +1,24 @@
+// Shared pre-request helpers for the ClientDelegationsV2 scenarios.
+// Requires inside a helper module resolve relative to this file, unlike requires in
+// .bru scripts, which resolve from the collection root.
+const tokenGenerator = require("../../../TestToolsTokenGenerator.js");
+const sharedtestdata = require("../../../testdata/sharedtestdata.js");
+
+const scopes = sharedtestdata.auth_scopes;
+
+// Mints a personal token for a testdata persona and stores it as the collection bearer token.
+// Tolerates the key spellings used across the testdata files (userId/userid, pid/personidentity,
+// partyUuid/partyuuid/userUuid) so personas from any fixture file can be used directly.
+async function loginAs(person, authScopes) {
+  const token = await tokenGenerator.getToken({
+    auth_userId: person.userId || person.userid,
+    auth_partyId: person.partyId || person.partyid,
+    auth_partyUuid: person.partyUuid || person.partyuuid || person.userUuid,
+    auth_ssn: person.pid || person.personidentity,
+    auth_tokenType: sharedtestdata.authTokenType.personal,
+    auth_scopes: authScopes || scopes.portalEnduser,
+  });
+  bru.setVar("bearerToken", token);
+}
+
+module.exports = { loginAs, scopes };

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/at22.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/at22.js
@@ -74,4 +74,20 @@
       partyId: 51177430,
       partyUuid: "7b7bc643-821f-4cb2-b874-9dc6eb58f5c5",
     },
+    // Fixtures for the v2 client delegation scenarios in test/EnduserAPI/ClientDelegationsV2.
+    clientDelegationV2: {
+      packages: {
+        regnskapsforerLonn: "urn:altinn:accesspackage:regnskapsforer-lonn",
+        regnskapsforerMedSignering: "urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet",
+        ansvarligRevisor: "urn:altinn:accesspackage:ansvarlig-revisor",
+        klientadministrator: "urn:altinn:accesspackage:klientadministrator",
+        skattegrunnlag: "urn:altinn:accesspackage:skattegrunnlag",
+      },
+      unknown: {
+        partyUuid: "11111111-1111-1111-1111-111111111111",
+        packageUrn: "urn:altinn:accesspackage:bruno-finnes-ikke",
+        resourceRefId: "bruno-finnes-ikke",
+        roleCode: "bruno-finnes-ikke",
+      },
+    },
   };

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/at22.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/at22.js
@@ -76,6 +76,8 @@
     },
     // Fixtures for the v2 client delegation scenarios in test/EnduserAPI/ClientDelegationsV2.
     clientDelegationV2: {
+      // Single resource whose policy lets a dagligleder delegate it onwards.
+      singleResource: "tilgangspakke_delegering_ressurs",
       packages: {
         regnskapsforerLonn: "urn:altinn:accesspackage:regnskapsforer-lonn",
         regnskapsforerMedSignering: "urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet",

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/tt02.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/tt02.js
@@ -74,4 +74,20 @@
       partyId: 51425503,
       partyUuid: "a4c0369b-2261-4123-ac03-e0028a64d265",
     },
+    // Fixtures for the v2 client delegation scenarios in test/EnduserAPI/ClientDelegationsV2.
+    clientDelegationV2: {
+      packages: {
+        regnskapsforerLonn: "urn:altinn:accesspackage:regnskapsforer-lonn",
+        regnskapsforerMedSignering: "urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet",
+        ansvarligRevisor: "urn:altinn:accesspackage:ansvarlig-revisor",
+        klientadministrator: "urn:altinn:accesspackage:klientadministrator",
+        skattegrunnlag: "urn:altinn:accesspackage:skattegrunnlag",
+      },
+      unknown: {
+        partyUuid: "11111111-1111-1111-1111-111111111111",
+        packageUrn: "urn:altinn:accesspackage:bruno-finnes-ikke",
+        resourceRefId: "bruno-finnes-ikke",
+        roleCode: "bruno-finnes-ikke",
+      },
+    },
 };

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/tt02.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/tt02.js
@@ -76,6 +76,8 @@
     },
     // Fixtures for the v2 client delegation scenarios in test/EnduserAPI/ClientDelegationsV2.
     clientDelegationV2: {
+      // Single resource whose policy lets a dagligleder delegate it onwards.
+      singleResource: "tilgangspakke_delegering_ressurs",
       packages: {
         regnskapsforerLonn: "urn:altinn:accesspackage:regnskapsforer-lonn",
         regnskapsforerMedSignering: "urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet",


### PR DESCRIPTION
Rebuilds the client delegation Bruno coverage as BDD scenario suites for the v2 enduser API, under `test/EnduserAPI/ClientDelegationsV2/`.

Nine scenario folders cover all 19 actions on `ClientDelegationController` (V2): agent lifecycle, package delegation for CCR clients, input validation, agent registration validation, the rightholder client path, single resource delegation, the agent's `my/*` endpoints, agent system users, and authorization boundaries. Each folder is one Gherkin scenario (in the `folder.bru` docs block) with step files named `NN_GIVEN|WHEN|THEN|CLEANUP_...`.

The suites fix the structural problems the v1 `KlientDelegation` folder has: every scenario resets its own state up front (idempotent deletes), removes everything it creates, asserts response fields and full problem bodies (status, `code`, `validationErrors[].code`, error pointer) instead of status only, and takes all values from testdata instead of hardcoded literals. Cross API data setup is part of the scenarios: rightholder relations, package grants and single resource grants go through the v1 connections API before the v2 endpoints are exercised.

Notes from the verification runs against AT22 (whole suite green twice in a row, 92 requests / 152 asserts per run):

- `devtest_gar_bruno_client_resource` cannot be used to seed single resource grants: its policy only grants access through the accountant and auditor packages, so a client dagligleder is not authorized to delegate it. The resource scenarios use `tilgangspakke_delegering_ressurs`, whose policy includes the `dagl` role, and fetch the right keys from the delegation check endpoint instead of hardcoding them.
- The my clientproviders assertions only touch fields that exist both before and after the flattening in #3833, so they pass against the current AT22 deploy and keep passing when that change rolls out.
- TT02 does not route `/accessmanagement/api/v2/` yet (404), so the suite can only pass in AT22 until the gateway exposes the v2 routes there.

The v1 `KlientDelegation` folder is untouched. `docs/testing/BRUNO_API_TESTS.md` gets a section describing the scenario pattern.

Closes #3826
