### PR TITLE
fix: log the actual api version in request telemetry

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/AccessManagementHost.cs
@@ -95,6 +95,7 @@ internal static partial class AccessManagementHost
                     .WithTracing(tracing =>
                     {
                         tracing
+                            .AddProcessor(sp => new ApiVersionRouteProcessor(sp.GetRequiredService<IHttpContextAccessor>()))
                             .AddProcessor(sp => new NpgsqlProcessor(
                                 TimeSpan.FromMilliseconds(npgsqlMinDurationMs),
                                 sp.GetRequiredService<IHttpContextAccessor>()));

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Telemetry/ApiVersionRouteProcessor.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement/Telemetry/ApiVersionRouteProcessor.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using OpenTelemetry;
+
+namespace Altinn.AccessManagement.Telemetry;
+
+/// <summary>
+/// Replaces API version route parameters such as <c>{version:apiVersion}</c> in the recorded HTTP route
+/// with the version the request actually used, so telemetry groups requests per API version.
+/// Other route parameters are left as template placeholders.
+/// </summary>
+public sealed partial class ApiVersionRouteProcessor(IHttpContextAccessor httpContextAccessor) : BaseProcessor<Activity>
+{
+    private const string HttpRouteTag = "http.route";
+
+    /// <inheritdoc/>
+    public override void OnEnd(Activity activity)
+    {
+        if (activity.Kind != ActivityKind.Server)
+        {
+            return;
+        }
+
+        if (activity.GetTagItem(HttpRouteTag) is not string route || !route.Contains(":apiVersion}", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var routeValues = httpContextAccessor.HttpContext?.Request.RouteValues;
+        if (routeValues is null)
+        {
+            return;
+        }
+
+        var resolved = ApiVersionParameter().Replace(route, match =>
+        {
+            var name = match.Groups["name"].Value;
+            if (routeValues.TryGetValue(name, out var value) && value?.ToString() is { Length: > 0 } segment)
+            {
+                return segment;
+            }
+
+            return match.Value;
+        });
+
+        if (string.Equals(resolved, route, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        activity.SetTag(HttpRouteTag, resolved);
+        activity.DisplayName = activity.DisplayName.Replace(route, resolved, StringComparison.Ordinal);
+    }
+
+    [GeneratedRegex(@"\{(?<name>[^{}:]+):apiVersion\}")]
+    private static partial Regex ApiVersionParameter();
+}

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Telemetry/ApiVersionRouteProcessorIntegrationTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Telemetry/ApiVersionRouteProcessorIntegrationTests.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using Altinn.AccessManagement.Telemetry;
+using Asp.Versioning;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Altinn.AccessManagement.Tests.Integration.Telemetry;
+
+/// <summary>
+/// Runs <see cref="ApiVersionRouteProcessor"/> against a real ASP.NET Core request pipeline with
+/// OpenTelemetry instrumentation, to verify that the route recorded on the request activity is
+/// resolved to the version the caller used.
+/// </summary>
+[IntegrationTest]
+public class ApiVersionRouteProcessorIntegrationTests(ApiVersionRouteProcessorIntegrationTests.TelemetryHostFixture fixture) : IClassFixture<ApiVersionRouteProcessorIntegrationTests.TelemetryHostFixture>
+{
+    [Fact]
+    public void VersionedEndpoint_RecordsRouteWithResolvedVersion()
+    {
+        var request = fixture.RequestTo("/accessmanagement/api/v2/enduser/clientdelegations/my/clients");
+
+        request.GetTagItem("http.route").Should().Be("accessmanagement/api/v2/enduser/clientdelegations/my/clients");
+        request.DisplayName.Should().Be("GET accessmanagement/api/v2/enduser/clientdelegations/my/clients");
+    }
+
+    [Fact]
+    public void VersionedEndpointWithRouteParameter_KeepsOtherParametersAsPlaceholders()
+    {
+        var request = fixture.RequestTo("/accessmanagement/api/v2/enduser/clientdelegations/e5b6d1ad-8c4d-4e4a-9f6c-6dbb9b1a8d10");
+
+        request.GetTagItem("http.route").Should().Be("accessmanagement/api/v2/enduser/clientdelegations/{delegationId}");
+    }
+
+    [Fact]
+    public void UnversionedEndpoint_RecordsRouteUnchanged()
+    {
+        var request = fixture.RequestTo("/accessmanagement/api/v1/enduser/clientdelegations/clients");
+
+        request.GetTagItem("http.route").Should().Be("accessmanagement/api/v1/enduser/clientdelegations/clients");
+    }
+
+    /// <summary>
+    /// Hosts the endpoints under test, calls them all and shuts the host down again, so that every
+    /// request activity is completed and captured before any assertion runs.
+    /// </summary>
+    public sealed class TelemetryHostFixture : IAsyncLifetime
+    {
+        private static readonly string[] Paths =
+        [
+            "/accessmanagement/api/v2/enduser/clientdelegations/my/clients",
+            "/accessmanagement/api/v2/enduser/clientdelegations/e5b6d1ad-8c4d-4e4a-9f6c-6dbb9b1a8d10",
+            "/accessmanagement/api/v1/enduser/clientdelegations/clients",
+        ];
+
+        private readonly List<Activity> _exported = [];
+
+        public async ValueTask InitializeAsync()
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.WebHost.UseTestServer();
+            builder.Services.AddHttpContextAccessor();
+            builder.Services.AddApiVersioning(options =>
+            {
+                options.DefaultApiVersion = new ApiVersion(1.0);
+                options.AssumeDefaultVersionWhenUnspecified = true;
+                options.ApiVersionReader = new UrlSegmentApiVersionReader();
+            });
+
+            builder.Services.AddOpenTelemetry().WithTracing(tracing => tracing
+                .AddAspNetCoreInstrumentation()
+                .AddProcessor(sp => new ApiVersionRouteProcessor(sp.GetRequiredService<IHttpContextAccessor>()))
+                .AddProcessor(new CaptureProcessor(_exported)));
+
+            await using var app = builder.Build();
+            app.MapGet("accessmanagement/api/v{version:apiVersion}/enduser/clientdelegations/my/clients", () => Results.Ok());
+            app.MapGet("accessmanagement/api/v{version:apiVersion}/enduser/clientdelegations/{delegationId}", (string delegationId) => Results.Ok());
+            app.MapGet("accessmanagement/api/v1/enduser/clientdelegations/clients", () => Results.Ok());
+
+            await app.StartAsync(TestContext.Current.CancellationToken);
+
+            using (var client = app.GetTestClient())
+            {
+                foreach (var path in Paths)
+                {
+                    var response = await client.GetAsync(path, TestContext.Current.CancellationToken);
+                    response.EnsureSuccessStatusCode();
+                }
+            }
+
+            await app.StopAsync(TestContext.Current.CancellationToken);
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public Activity RequestTo(string path) =>
+            _exported.Should().ContainSingle(a => a.Kind == ActivityKind.Server && Equals(a.GetTagItem("url.path"), path)).Subject;
+
+        private sealed class CaptureProcessor(List<Activity> exported) : BaseProcessor<Activity>
+        {
+            public override void OnEnd(Activity activity) => exported.Add(activity);
+        }
+    }
+}

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Telemetry/ApiVersionRouteProcessorTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Unit/Telemetry/ApiVersionRouteProcessorTests.cs
@@ -1,0 +1,127 @@
+using System.Diagnostics;
+using Altinn.AccessManagement.Telemetry;
+using Microsoft.AspNetCore.Http;
+
+namespace Altinn.AccessManagement.Tests.Unit.Telemetry;
+
+/// <summary>
+/// Unit tests for <see cref="ApiVersionRouteProcessor"/>, which resolves API version route parameters
+/// in the route recorded on request telemetry.
+/// </summary>
+[UnitTest]
+public class ApiVersionRouteProcessorTests : IDisposable
+{
+    private const string ActivitySourceName = "Altinn.AccessManagement.Tests.ApiVersionRouteProcessor";
+
+    private readonly ActivityListener _listener;
+    private readonly ActivitySource _source = new(ActivitySourceName);
+
+    public ApiVersionRouteProcessorTests()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    [Fact]
+    public void OnEnd_VersionedRoute_ReplacesVersionParameterWithRequestedVersion()
+    {
+        const string Template = "accessmanagement/api/v{version:apiVersion}/enduser/clientdelegations/my/clients";
+        const string Expected = "accessmanagement/api/v2/enduser/clientdelegations/my/clients";
+
+        using var activity = StartServerActivity(Template);
+        Processor(("version", "2")).OnEnd(activity);
+
+        activity.GetTagItem("http.route").Should().Be(Expected);
+        activity.DisplayName.Should().Be($"GET {Expected}");
+    }
+
+    [Fact]
+    public void OnEnd_VersionedRouteWithOtherParameters_KeepsOtherParametersAsPlaceholders()
+    {
+        const string Template = "accessmanagement/api/v{version:apiVersion}/enduser/clientdelegations/{delegationId}";
+        const string Expected = "accessmanagement/api/v2/enduser/clientdelegations/{delegationId}";
+
+        using var activity = StartServerActivity(Template);
+        Processor(("version", "2"), ("delegationId", "e5b6d1ad-8c4d-4e4a-9f6c-6dbb9b1a8d10")).OnEnd(activity);
+
+        activity.GetTagItem("http.route").Should().Be(Expected);
+    }
+
+    [Fact]
+    public void OnEnd_UnversionedRoute_LeavesRouteUnchanged()
+    {
+        const string Template = "accessmanagement/api/v1/enduser/clientdelegations/clients";
+
+        using var activity = StartServerActivity(Template);
+        Processor(("version", "2")).OnEnd(activity);
+
+        activity.GetTagItem("http.route").Should().Be(Template);
+        activity.DisplayName.Should().Be($"GET {Template}");
+    }
+
+    [Fact]
+    public void OnEnd_NoHttpContext_LeavesRouteUnchanged()
+    {
+        const string Template = "accessmanagement/api/v{version:apiVersion}/enduser/clientdelegations/my/clients";
+
+        using var activity = StartServerActivity(Template);
+        new ApiVersionRouteProcessor(new HttpContextAccessor()).OnEnd(activity);
+
+        activity.GetTagItem("http.route").Should().Be(Template);
+    }
+
+    [Fact]
+    public void OnEnd_MissingVersionRouteValue_LeavesRouteUnchanged()
+    {
+        const string Template = "accessmanagement/api/v{version:apiVersion}/enduser/clientdelegations/my/clients";
+
+        using var activity = StartServerActivity(Template);
+        Processor().OnEnd(activity);
+
+        activity.GetTagItem("http.route").Should().Be(Template);
+    }
+
+    [Fact]
+    public void OnEnd_ClientActivity_LeavesRouteUnchanged()
+    {
+        const string Template = "accessmanagement/api/v{version:apiVersion}/enduser/clientdelegations/my/clients";
+
+        using var activity = _source.StartActivity($"GET {Template}", ActivityKind.Client);
+        activity.SetTag("http.route", Template);
+
+        Processor(("version", "2")).OnEnd(activity);
+
+        activity.GetTagItem("http.route").Should().Be(Template);
+    }
+
+    public void Dispose()
+    {
+        _source.Dispose();
+        _listener.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private Activity StartServerActivity(string route)
+    {
+        var activity = _source.StartActivity($"GET {route}", ActivityKind.Server);
+        activity.Should().NotBeNull();
+        activity.SetTag("http.route", route);
+        return activity;
+    }
+
+    private static ApiVersionRouteProcessor Processor(params (string Key, string Value)[] routeValues)
+    {
+        var httpContext = new DefaultHttpContext();
+        foreach (var (key, value) in routeValues)
+        {
+            httpContext.Request.RouteValues[key] = value;
+        }
+
+        return new ApiVersionRouteProcessor(new HttpContextAccessor { HttpContext = httpContext });
+    }
+}


### PR DESCRIPTION
Requests to the versioned enduser endpoints were reported to Application Insights under the raw route template, so every `/v2/` call ended up as `/accessmanagement/api/v{version:apiVersion}/...` instead of one entry per version.

The route on the request activity now goes through a trace processor that resolves `apiVersion` route parameters against the version the caller actually used. Other route parameters are left as template placeholders, so paths still group the way they do today.

Covered by unit tests for the processor and by an integration test that runs a real request pipeline with OpenTelemetry instrumentation and asserts the recorded route.

Fixes #3842
