### PR TITLE
fix: drop the deleted Migration folder from the Authorization Dockerfile

### DIFF
--- a/src/apps/Altinn.Authorization/Dockerfile
+++ b/src/apps/Altinn.Authorization/Dockerfile
@@ -10,8 +10,6 @@ EXPOSE 5050
 WORKDIR /app
 COPY --from=build /app .
 
-COPY src/apps/Altinn.Authorization/src/Altinn.Authorization/Migration ./Migration
-
 # setup the user and group
 # the user will have no password, using shell /bin/false and using the group dotnet
 RUN addgroup -g 3000 dotnet && adduser -u 1000 -G dotnet -D -s /bin/false dotnet


### PR DESCRIPTION
## What

Removes the `Migration` folder COPY from the Altinn.Authorization Dockerfile. That folder held Yuniql SQL scripts and was deleted in #3605 when the delegation schema moved to an EF Core baseline migration, so the COPY had no source and broke every container build.

The schema is now applied by `MigrateAsync` at startup from the EF migration compiled into the assembly, so nothing in the running container needs to read from `/app/Migration`.

## Verification

Built the image locally with podman against a clean export of the tree (no bin/obj, no .git): succeeds in 4m01s, including pulling both base images and a fresh NuGet restore.

Closes #3844
