### PR TITLE
test: cover client relation types and list filters in the client delegation scenarios

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/01_GIVEN_NoRightholderRelationExists.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/01_GIVEN_NoRightholderRelationExists.bru
@@ -1,0 +1,43 @@
+meta {
+  name: 01_GIVEN_NoRightholderRelationExists
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{clientB}}&from={{clientB}}&to={{party}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  from: {{clientB}}
+  to: {{party}}
+  cascade: true
+}
+
+docs {
+  GIVEN no rightholder relation exists between the rightholder client and the
+  facilitator.
+
+  Reset step: removes any leftover rightholder assignment from earlier runs,
+  including grants hanging on it. The delete is idempotent and returns 204 either
+  way.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("GIVEN no rightholder relation exists, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/02_AND_ClientAddsFacilitatorAsRightholder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/02_AND_ClientAddsFacilitatorAsRightholder.bru
@@ -1,0 +1,41 @@
+meta {
+  name: 02_AND_ClientAddsFacilitatorAsRightholder
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{clientB}}&to={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  to: {{party}}
+}
+
+docs {
+  AND the rightholder client adds the facilitator as rightholder through the v1
+  connections API.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("AND the client adds the facilitator as rightholder, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the created assignment carries the rettighetshaver role", function() {
+    expect(res.getBody().roleId.toLowerCase()).to.equal("42cae370-2dc1-4fdc-9c67-c2f4b0f0f829");
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/03_AND_ClientDelegatesPackageToFacilitator.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/03_AND_ClientDelegatesPackageToFacilitator.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 03_AND_ClientDelegatesPackageToFacilitator
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/accesspackages?party={{clientB}}&to={{party}}&package={{package}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  to: {{party}}
+  package: {{package}}
+}
+
+docs {
+  AND the rightholder client delegates a package to the facilitator through the
+  v1 connections API.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.skattegrunnlag);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("AND the client delegates the package to the facilitator, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+    expect(res.getBody()).to.be.ok;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/04_AND_ClientChecksDelegableRightsForResource.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/04_AND_ClientChecksDelegableRightsForResource.bru
@@ -1,0 +1,51 @@
+meta {
+  name: 04_AND_ClientChecksDelegableRightsForResource
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources/delegationcheck?party={{clientB}}&resource={{resource}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  resource: {{resource}}
+}
+
+docs {
+  AND the rightholder client checks which rights on the single resource it can
+  delegate. The read right key is captured for the grant in the next step.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+script:post-response {
+  const body = res.getBody();
+  const readRight = (body.rights || []).find(r => r.right.action.value === "read");
+  if (readRight) {
+    bru.setVar("cdv2_resourceReadRightKey", readRight.right.key);
+  }
+}
+
+tests {
+  test("AND the delegation check request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the read right on the resource is delegable for the client", function() {
+    const readRight = res.getBody().rights.find(r => r.right.action.value === "read");
+    expect(readRight, "expected a read right in the delegation check response").to.not.be.undefined;
+    expect(readRight.result).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/05_AND_ClientGrantsResourceToFacilitator.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/05_AND_ClientGrantsResourceToFacilitator.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 05_AND_ClientGrantsResourceToFacilitator
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources/rights?party={{clientB}}&to={{party}}&resource={{resource}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  to: {{party}}
+  resource: {{resource}}
+}
+
+body:json {
+  {
+    "DirectRightKeys": ["{{cdv2_resourceReadRightKey}}"]
+  }
+}
+
+docs {
+  AND the rightholder client grants the facilitator the read right on the single
+  resource, using the right key captured from the delegation check. Expects 201.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("AND the client grants the facilitator the resource, the request returns 201", function() {
+    expect(res.status).to.equal(201);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/06_THEN_ClientListShowsCcrClientThroughRole.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/06_THEN_ClientListShowsCcrClientThroughRole.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 06_THEN_ClientListShowsCcrClientThroughRole
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  THEN the client list shows the CCR client through the regnskapsforer role, with
+  the delegable packages the role carries.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the client list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the CCR client appears through the regnskapsforer role with role packages", function() {
+    const clientA = td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === clientA);
+    expect(entry, "expected the CCR client in the client list").to.not.be.undefined;
+    const roleAccess = entry.access.find(a => a.role.code === "regnskapsforer");
+    expect(roleAccess, "expected a regnskapsforer access element").to.not.be.undefined;
+    const urns = roleAccess.packages.map(p => p.urn);
+    expect(urns).to.include(td.clientDelegationV2.packages.regnskapsforerLonn);
+    expect(urns).to.include(td.clientDelegationV2.packages.regnskapsforerMedSignering);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/07_AND_ClientListShowsRightholderClientWithGrants.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/07_AND_ClientListShowsRightholderClientWithGrants.bru
@@ -1,0 +1,47 @@
+meta {
+  name: 07_AND_ClientListShowsRightholderClientWithGrants
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+docs {
+  AND the client list shows the rightholder client with the individually granted
+  package and single resource under the rettighetshaver role.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the client list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the rightholder client appears with the granted package and resource", function() {
+    const clientB = td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === clientB);
+    expect(entry, "expected the rightholder client in the client list").to.not.be.undefined;
+    const roleAccess = entry.access.find(a => a.role.code === "rettighetshaver");
+    expect(roleAccess, "expected a rettighetshaver access element").to.not.be.undefined;
+    expect(roleAccess.packages.map(p => p.urn)).to.include(td.clientDelegationV2.packages.skattegrunnlag);
+    expect(roleAccess.resources.map(r => r.refId)).to.include(td.clientDelegationV2.singleResource);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/08_AND_RoleFilterReturnsCcrClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/08_AND_RoleFilterReturnsCcrClient.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 08_AND_RoleFilterReturnsCcrClient
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}&roles=regnskapsforer
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  roles: regnskapsforer
+}
+
+docs {
+  AND filtering the client list on the regnskapsforer role returns the CCR
+  client, and every returned client holds that role.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the role filtered client list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the CCR client is returned and every client holds the role", function() {
+    const data = res.getBody().data;
+    const clientA = td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid.toLowerCase();
+    expect(data.some(item => item.client.id.toLowerCase() === clientA)).to.be.true;
+    data.forEach(item => {
+      expect(item.access.some(a => a.role.code === "regnskapsforer"),
+        `expected ${item.client.name} to hold the regnskapsforer role`).to.be.true;
+    });
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/09_AND_PackageFilterReturnsRightholderClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/09_AND_PackageFilterReturnsRightholderClient.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 09_AND_PackageFilterReturnsRightholderClient
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}&packages={{package}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  packages: {{package}}
+}
+
+docs {
+  AND filtering the client list on the individually granted package returns the
+  rightholder client. The CCR client does not hold this package, so it is not in
+  the result.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.skattegrunnlag);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the package filtered client list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the rightholder client is returned and the CCR client is not", function() {
+    const data = res.getBody().data;
+    const clientA = td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid.toLowerCase();
+    const clientB = td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase();
+    expect(data.some(item => item.client.id.toLowerCase() === clientB)).to.be.true;
+    expect(data.some(item => item.client.id.toLowerCase() === clientA)).to.be.false;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/09_AND_PackageFilterReturnsRightholderClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/09_AND_PackageFilterReturnsRightholderClient.bru
@@ -45,4 +45,12 @@ tests {
     expect(data.some(item => item.client.id.toLowerCase() === clientB)).to.be.true;
     expect(data.some(item => item.client.id.toLowerCase() === clientA)).to.be.false;
   });
+
+  test("AND every returned client holds the filtered package", function() {
+    const packageUrn = td.clientDelegationV2.packages.skattegrunnlag;
+    res.getBody().data.forEach(item => {
+      const urns = item.access.flatMap(a => a.packages.map(p => p.urn));
+      expect(urns, `expected ${item.client.name} to hold ${packageUrn}`).to.include(packageUrn);
+    });
+  });
 }

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/10_AND_ResourceFilterReturnsRightholderClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/10_AND_ResourceFilterReturnsRightholderClient.bru
@@ -45,4 +45,12 @@ tests {
     expect(data.some(item => item.client.id.toLowerCase() === clientB)).to.be.true;
     expect(data.some(item => item.client.id.toLowerCase() === clientA)).to.be.false;
   });
+
+  test("AND every returned client holds the filtered resource", function() {
+    const refId = td.clientDelegationV2.singleResource;
+    res.getBody().data.forEach(item => {
+      const refIds = item.access.flatMap(a => a.resources.map(r => r.refId));
+      expect(refIds, `expected ${item.client.name} to hold ${refId}`).to.include(refId);
+    });
+  });
 }

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/10_AND_ResourceFilterReturnsRightholderClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/10_AND_ResourceFilterReturnsRightholderClient.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 10_AND_ResourceFilterReturnsRightholderClient
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}&resources={{resource}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  resources: {{resource}}
+}
+
+docs {
+  AND filtering the client list on the granted single resource returns the
+  rightholder client. The CCR client has no grant for this resource, so it is
+  not in the result.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the resource filtered client list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the rightholder client is returned and the CCR client is not", function() {
+    const data = res.getBody().data;
+    const clientA = td.REGN_Organisasjon.REGN_Org_Clients.client_A.partyUuid.toLowerCase();
+    const clientB = td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase();
+    expect(data.some(item => item.client.id.toLowerCase() === clientB)).to.be.true;
+    expect(data.some(item => item.client.id.toLowerCase() === clientA)).to.be.false;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/11_AND_UnknownRoleFilterReturnsEmptyList.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/11_AND_UnknownRoleFilterReturnsEmptyList.bru
@@ -1,0 +1,42 @@
+meta {
+  name: 11_AND_UnknownRoleFilterReturnsEmptyList
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}&roles={{unknownRole}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  roles: {{unknownRole}}
+}
+
+docs {
+  AND filtering the client list on a role that does not exist returns an empty
+  list with 200, not an error.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("unknownRole", td.clientDelegationV2.unknown.roleCode);
+
+  await loginAs(td.REGN_Organisasjon.dagligleder);
+}
+
+tests {
+  test("AND the unknown role filtered request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the result is an empty list", function() {
+    const data = res.getBody().data;
+    expect(data).to.be.an("array").that.is.empty;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/12_CLEANUP_PackageIsRemovedFromFacilitator.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/12_CLEANUP_PackageIsRemovedFromFacilitator.bru
@@ -1,0 +1,39 @@
+meta {
+  name: 12_CLEANUP_PackageIsRemovedFromFacilitator
+  type: http
+  seq: 12
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/accesspackages?party={{clientB}}&from={{clientB}}&to={{party}}&package={{package}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  from: {{clientB}}
+  to: {{party}}
+  package: {{package}}
+}
+
+docs {
+  CLEANUP: the rightholder client removes the package grant from the facilitator.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.skattegrunnlag);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("CLEANUP the package grant removal returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/13_CLEANUP_ResourceGrantIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/13_CLEANUP_ResourceGrantIsRemoved.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 13_CLEANUP_ResourceGrantIsRemoved
+  type: http
+  seq: 13
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections/resources?party={{clientB}}&from={{clientB}}&to={{party}}&resource={{resource}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  from: {{clientB}}
+  to: {{party}}
+  resource: {{resource}}
+}
+
+docs {
+  CLEANUP: the rightholder client removes the single resource grant from the
+  facilitator.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+  bru.setVar("resource", td.clientDelegationV2.singleResource);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("CLEANUP the resource grant removal returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/14_CLEANUP_RightholderRelationIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/14_CLEANUP_RightholderRelationIsRemoved.bru
@@ -1,0 +1,39 @@
+meta {
+  name: 14_CLEANUP_RightholderRelationIsRemoved
+  type: http
+  seq: 14
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v1/enduser/connections?party={{clientB}}&from={{clientB}}&to={{party}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{clientB}}
+  from: {{clientB}}
+  to: {{party}}
+  cascade: true
+}
+
+docs {
+  CLEANUP: the rightholder client removes the rightholder relation to the
+  facilitator.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("clientB", td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid);
+  bru.setVar("party", td.REGN_Organisasjon.partyUuid);
+
+  await loginAs(td.REGN_Organisasjon.REGN_Org_Clients.client_B.dagligleder);
+}
+
+tests {
+  test("CLEANUP the rightholder relation removal returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/folder.bru
@@ -1,0 +1,21 @@
+meta {
+  name: 10_ClientListRelationTypes
+  seq: 10
+}
+
+docs {
+  Scenario: The client list shows every client relation type and honors the filters
+
+    Given no rightholder relation exists between the rightholder client and the facilitator
+    And the rightholder client adds the facilitator as rightholder
+    And the rightholder client delegates a package to the facilitator
+    And the rightholder client checks which rights on the single resource it can delegate
+    And the rightholder client grants the facilitator the single resource
+    Then the client list shows the CCR client through its role with the role packages
+    And the client list shows the rightholder client with the granted package and resource
+    And filtering on the accountant role returns the CCR client
+    And filtering on the granted package returns the rightholder client
+    And filtering on the granted resource returns the rightholder client
+    And filtering on an unknown role returns an empty list
+    And the package grant, the resource grant and the rightholder relation are cleaned up
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/01_GIVEN_AgentHasNoRegistration.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/01_GIVEN_AgentHasNoRegistration.bru
@@ -1,0 +1,39 @@
+meta {
+  name: 01_GIVEN_AgentHasNoRegistration
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  GIVEN the forretningsforer facilitator has no agent registration for the agent
+  person. Reset step, idempotent 204.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("GIVEN the facilitator has no registered agent, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/02_AND_AgentIsRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/02_AND_AgentIsRegistered.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 02_AND_AgentIsRegistered
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+body:json {
+  {
+    "personIdentifier": "{{agentPid}}",
+    "lastName": "{{agentLastName}}"
+  }
+}
+
+docs {
+  AND the agent person is registered as agent for the forretningsforer
+  facilitator by person number.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("agentPid", td.REGN_Organisasjon.REGN_Agent.personidentity);
+  bru.setVar("agentLastName", td.REGN_Organisasjon.REGN_Agent.etternavn);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("AND registering the agent returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/03_THEN_BrlClientCarriesEiendomPackage.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/03_THEN_BrlClientCarriesEiendomPackage.bru
@@ -1,0 +1,49 @@
+meta {
+  name: 03_THEN_BrlClientCarriesEiendomPackage
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}&roles=forretningsforer
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  roles: forretningsforer
+}
+
+docs {
+  THEN the BRL client carries the eiendom package through the forretningsforer
+  role, since the package is scoped to the ESEK and BRL unit types.
+}
+
+script:pre-request {
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the role filtered client list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the BRL client carries the eiendom package", function() {
+    const brl = su.brl_type_client_org.partyuuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === brl);
+    expect(entry, "expected the BRL client in the forretningsforer client list").to.not.be.undefined;
+    expect(entry.client.variant).to.equal("BRL");
+    const roleAccess = entry.access.find(a => a.role.code === "forretningsforer");
+    expect(roleAccess, "expected a forretningsforer access element").to.not.be.undefined;
+    expect(roleAccess.packages.map(p => p.urn)).to.include(td.clientDelegationV2.packages.forretningsforerEiendom);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/04_AND_EsekClientCarriesEiendomPackage.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/04_AND_EsekClientCarriesEiendomPackage.bru
@@ -1,0 +1,49 @@
+meta {
+  name: 04_AND_EsekClientCarriesEiendomPackage
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}&roles=forretningsforer
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  roles: forretningsforer
+}
+
+docs {
+  AND the ESEK client carries the eiendom package through the forretningsforer
+  role.
+}
+
+script:pre-request {
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the role filtered client list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the ESEK client carries the eiendom package", function() {
+    const esek = su.esek_type_client_org.partyuuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === esek);
+    expect(entry, "expected the ESEK client in the forretningsforer client list").to.not.be.undefined;
+    expect(entry.client.variant).to.equal("ESEK");
+    const roleAccess = entry.access.find(a => a.role.code === "forretningsforer");
+    expect(roleAccess, "expected a forretningsforer access element").to.not.be.undefined;
+    expect(roleAccess.packages.map(p => p.urn)).to.include(td.clientDelegationV2.packages.forretningsforerEiendom);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/05_AND_BblClientCarriesNoForretningsforerPackages.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/05_AND_BblClientCarriesNoForretningsforerPackages.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 05_AND_BblClientCarriesNoForretningsforerPackages
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}&roles=forretningsforer
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  roles: forretningsforer
+}
+
+docs {
+  AND the BBL client carries no packages through the forretningsforer role,
+  because its unit type is outside the ESEK and BRL scope of the eiendom
+  package.
+}
+
+script:pre-request {
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("AND the role filtered client list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("AND the BBL client carries no forretningsforer packages", function() {
+    const bbl = td.clientDelegationV2.forretningsforerBblClient.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === bbl);
+    expect(entry, "expected the BBL client in the forretningsforer client list").to.not.be.undefined;
+    const roleAccess = entry.access.find(a => a.role.code === "forretningsforer");
+    expect(roleAccess, "expected a forretningsforer access element").to.not.be.undefined;
+    expect(roleAccess.packages).to.be.an("array").that.is.empty;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/06_WHEN_EiendomIsDelegatedForBrlClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/06_WHEN_EiendomIsDelegatedForBrlClient.bru
@@ -1,0 +1,57 @@
+meta {
+  name: 06_WHEN_EiendomIsDelegatedForBrlClient
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "forretningsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the eiendom package is delegated to the agent for the BRL client.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("client", su.brl_type_client_org.partyuuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.forretningsforerEiendom);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("WHEN the eiendom package is delegated for the BRL client, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the delegation row reports a change", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(1);
+    expect(body[0].changed).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/07_AND_EiendomIsDelegatedForEsekClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/07_AND_EiendomIsDelegatedForEsekClient.bru
@@ -1,0 +1,57 @@
+meta {
+  name: 07_AND_EiendomIsDelegatedForEsekClient
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "forretningsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  AND the eiendom package is delegated to the agent for the ESEK client.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("client", su.esek_type_client_org.partyuuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.forretningsforerEiendom);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("AND the eiendom package is delegated for the ESEK client, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the delegation row reports a change", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(1);
+    expect(body[0].changed).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/08_WHEN_EiendomIsDelegatedForBblClientThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/08_WHEN_EiendomIsDelegatedForBblClientThenRequestFails.bru
@@ -1,0 +1,61 @@
+meta {
+  name: 08_WHEN_EiendomIsDelegatedForBblClientThenRequestFails
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "forretningsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the eiendom package is delegated for the BBL client, the request fails.
+
+  The package is scoped to the ESEK and BRL unit types, so a client with another
+  unit type cannot receive it even though it holds the forretningsforer role.
+  Expects 400 with validation error AM.VLD-00026.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("client", td.clientDelegationV2.forretningsforerBblClient.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.forretningsforerEiendom);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("WHEN the eiendom package is delegated for the BBL client, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body reports validation error AM.VLD-00026", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00026")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/09_THEN_AgentPackageListShowsBothPropertyClients.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/09_THEN_AgentPackageListShowsBothPropertyClients.bru
@@ -1,0 +1,52 @@
+meta {
+  name: 09_THEN_AgentPackageListShowsBothPropertyClients
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  THEN the agent package list shows both the BRL and the ESEK client with the
+  eiendom package.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent package list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN both property clients are listed with the eiendom package", function() {
+    const data = res.getBody().data;
+    const eiendom = td.clientDelegationV2.packages.forretningsforerEiendom;
+    [su.brl_type_client_org, su.esek_type_client_org].forEach(client => {
+      const entry = data.find(item => item.client.id.toLowerCase() === client.partyuuid.toLowerCase());
+      expect(entry, `expected ${client.name} in the agent package list`).to.not.be.undefined;
+      const urns = entry.access.flatMap(a => a.packages.map(p => p.urn));
+      expect(urns).to.include(eiendom);
+    });
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/10_CLEANUP_BrlDelegationIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/10_CLEANUP_BrlDelegationIsRemoved.bru
@@ -1,0 +1,41 @@
+meta {
+  name: 10_CLEANUP_BrlDelegationIsRemoved
+  type: http
+  seq: 10
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/clients?party={{party}}&client={{client}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  CLEANUP: the BRL client is removed from the agent with cascade, which removes
+  the eiendom delegation with it.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("client", su.brl_type_client_org.partyuuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("CLEANUP removing the BRL client from the agent returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/11_CLEANUP_EsekDelegationIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/11_CLEANUP_EsekDelegationIsRemoved.bru
@@ -1,0 +1,41 @@
+meta {
+  name: 11_CLEANUP_EsekDelegationIsRemoved
+  type: http
+  seq: 11
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/clients?party={{party}}&client={{client}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  CLEANUP: the ESEK client is removed from the agent with cascade, which removes
+  the eiendom delegation with it.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("client", su.esek_type_client_org.partyuuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("CLEANUP removing the ESEK client from the agent returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/12_CLEANUP_AgentIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/12_CLEANUP_AgentIsRemoved.bru
@@ -1,0 +1,39 @@
+meta {
+  name: 12_CLEANUP_AgentIsRemoved
+  type: http
+  seq: 12
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  CLEANUP: the agent registration for the forretningsforer facilitator is
+  removed.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const su = require(`./testdata/systemuser-clientdelegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", su.regnskapsforer.partyuuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(su.regnskapsforer.dagl);
+}
+
+tests {
+  test("CLEANUP the agent removal returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/folder.bru
@@ -1,0 +1,24 @@
+meta {
+  name: 11_ForretningsforerVariantPackages
+  seq: 11
+}
+
+docs {
+  Scenario: Forretningsforer package access depends on the client unit type
+
+    Given the facilitator has no agent registration for the agent person
+    And the agent person is registered as agent
+    Then the BRL client carries the eiendom package through the forretningsforer role
+    And the ESEK client carries the eiendom package through the forretningsforer role
+    And the BBL client carries no packages through the forretningsforer role
+    When the eiendom package is delegated to the agent for the BRL client
+    And the eiendom package is delegated to the agent for the ESEK client
+    When the eiendom package is delegated for the BBL client the request fails
+    Then the agent package list shows both property clients
+    And the delegations and the agent registration are cleaned up
+
+  The facilitator and its forretningsforer clients come from the register test
+  data behind testdata/systemuser-clientdelegation. No NUF unit holds a
+  forretningsforer relation to the facilitator in AT22 or TT02, so the NUF
+  scoped packages are not covered here.
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/at22.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/at22.js
@@ -84,6 +84,14 @@
         ansvarligRevisor: "urn:altinn:accesspackage:ansvarlig-revisor",
         klientadministrator: "urn:altinn:accesspackage:klientadministrator",
         skattegrunnlag: "urn:altinn:accesspackage:skattegrunnlag",
+        forretningsforerEiendom: "urn:altinn:accesspackage:forretningsforer-eiendom",
+      },
+      // Forretningsforer client of the systemuser-clientdelegation facilitator whose
+      // unit type (BBL) is outside the ESEK/BRL scope of forretningsforer-eiendom.
+      forretningsforerBblClient: {
+        name: "USELVSTENDIG FLAT PUMA BBL",
+        orgno: "210815872",
+        partyUuid: "7f059b2b-f6d2-409b-83fd-194f1aaab90d",
       },
       unknown: {
         partyUuid: "11111111-1111-1111-1111-111111111111",

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/tt02.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/tt02.js
@@ -84,6 +84,14 @@
         ansvarligRevisor: "urn:altinn:accesspackage:ansvarlig-revisor",
         klientadministrator: "urn:altinn:accesspackage:klientadministrator",
         skattegrunnlag: "urn:altinn:accesspackage:skattegrunnlag",
+        forretningsforerEiendom: "urn:altinn:accesspackage:forretningsforer-eiendom",
+      },
+      // Forretningsforer client of the systemuser-clientdelegation facilitator whose
+      // unit type (BBL) is outside the ESEK/BRL scope of forretningsforer-eiendom.
+      forretningsforerBblClient: {
+        name: "USELVSTENDIG FLAT PUMA BBL",
+        orgno: "210815872",
+        partyUuid: "bd95521a-17e9-4817-8207-735ef015bf53",
       },
       unknown: {
         partyUuid: "11111111-1111-1111-1111-111111111111",


### PR DESCRIPTION
Adds two scenarios to the ClientDelegationsV2 Bruno suite.

`10_ClientListRelationTypes` establishes all three client relation types against the facilitator (packages through the CCR regnskapsforer role, an individually granted package, and a granted single resource, the latter two set up through the v1 connections API) and verifies that `GET clients` shows each of them with the right access. It also covers the list filters: `roles` returns the CCR client, `packages` and `resources` return only clients that hold the filtered value, and an unknown role gives an empty 200 list.

`11_ForretningsforerVariantPackages` verifies that forretningsforer package access follows the client unit type. The register test data behind the systemuser fixtures already carries what this needs in both AT22 and TT02: the facilitator has forretningsforer relations to a BRL and an ESEK client, which both surface `forretningsforer-eiendom`, and to a BBL client, which surfaces the role with no packages. The scenario asserts all three list outcomes, delegates the package for both eligible clients, and asserts the 400 rejection for the BBL client. No NUF unit holds a forretningsforer relation to the facilitator in either environment, so the NUF scoped packages stay uncovered until register test data provides such a relation; that remains on the issue.

Writing scenario 11 uncovered a bug: package level deletes of variant scoped delegations report no change and leave the delegation behind, because the delete path resolves the RolePackage row without the variant filter the delegate path uses. Filed as #3848; the scenario cleans up through the cascade removal of the client relation until that is fixed.

Verified against AT22: the full eleven scenario suite passes in one run (118 requests, 195 asserts).

Related to #3846
