### PR TITLE
fix: match delegation packages on delegation and package id when deleting

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -1719,9 +1719,6 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
                 continue;
             }
 
-            var rolePackages = await db.RolePackages.AsNoTracking().Where(t => t.RoleId == input.Role.Id && pkgIds.Contains(t.PackageId)).ToListAsync(cancellationToken);
-            var assignmentPackages = await db.AssignmentPackages.AsNoTracking().Where(t => t.AssignmentId == clientAssignment.Id && pkgIds.Contains(t.PackageId)).ToListAsync(cancellationToken);
-
             var delegation = await db.Delegations.AsNoTracking().FirstOrDefaultAsync(t => t.FromId == clientAssignment.Id && t.ToId == agentAssignment.Id && t.FacilitatorId == partyUuid, cancellationToken);
             if (delegation is null)
             {
@@ -1741,21 +1738,11 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             var existingDelegationPackages = await db.DelegationPackages.AsTracking().Where(t => t.DelegationId == delegation.Id).ToListAsync(cancellationToken);
             foreach (var pkgId in pkgIds)
             {
-                // A package can have several RolePackage rows scoped to different entity variants.
-                // The row is selected with the same variant filter as the delegate path so the
-                // resolved id matches the RolePackageId stored on the delegation package.
-                var rolePackageId = rolePackages
-                    .Where(r => r.PackageId == pkgId && (r.EntityVariantId == null || r.EntityVariantId == entities[fromUuid].VariantId))
-                    .OrderBy(r => r.EntityVariantId != null)
-                    .FirstOrDefault()?.Id;
-                var assignmentPackageId = assignmentPackages.FirstOrDefault(t => t.PackageId == pkgId)?.Id;
-
-                var toRemove = existingDelegationPackages.FirstOrDefault(
-                    t =>
-                    t.DelegationId == delegation.Id &&
-                    t.PackageId == pkgId &&
-                    t.RolePackageId == rolePackageId &&
-                    t.AssignmentPackageId == assignmentPackageId);
+                // (DelegationId, PackageId) is unique and the delegation is resolved from the
+                // caller's client assignment, agent assignment and facilitator for this role,
+                // so the package id alone identifies the row to remove regardless of which
+                // RolePackage or AssignmentPackage row backed the delegation.
+                var toRemove = existingDelegationPackages.FirstOrDefault(t => t.PackageId == pkgId);
 
                 if (toRemove is { })
                 {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/ClientDelegationService.cs
@@ -1741,7 +1741,13 @@ public class ClientDelegationService(AppDbContext db, IOptions<CoreAppsettings> 
             var existingDelegationPackages = await db.DelegationPackages.AsTracking().Where(t => t.DelegationId == delegation.Id).ToListAsync(cancellationToken);
             foreach (var pkgId in pkgIds)
             {
-                var rolePackageId = rolePackages.FirstOrDefault(r => r.PackageId == pkgId)?.Id;
+                // A package can have several RolePackage rows scoped to different entity variants.
+                // The row is selected with the same variant filter as the delegate path so the
+                // resolved id matches the RolePackageId stored on the delegation package.
+                var rolePackageId = rolePackages
+                    .Where(r => r.PackageId == pkgId && (r.EntityVariantId == null || r.EntityVariantId == entities[fromUuid].VariantId))
+                    .OrderBy(r => r.EntityVariantId != null)
+                    .FirstOrDefault()?.Id;
                 var assignmentPackageId = assignmentPackages.FirstOrDefault(t => t.PackageId == pkgId)?.Id;
 
                 var toRemove = existingDelegationPackages.FirstOrDefault(

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -1796,6 +1796,123 @@ public class ClientDelegationControllerTest
             });
         }
     }
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DeleteAgentAccessPackage(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
+    /// Removal of a delegation package whose stored RolePackageId points at a RolePackage row
+    /// scoped to a different entity variant than the client.
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteAgentAccessPackagesWithStaleRolePackageId : IClassFixture<ApiFixture>
+    {
+        public DeleteAgentAccessPackagesWithStaleRolePackageId(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DeleteAgentAccessPackagesWithStaleRolePackageId>(db =>
+            {
+                var businessManagerFromOkernToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationOkernBorettslag.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.BusinessManager,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                var delegationToPaula = new AccessMgmt.PersistenceEF.Models.Delegation()
+                {
+                    FromId = businessManagerFromOkernToVerdiq.Id,
+                    ToId = agentFromVerdiqToPaula.Id,
+                    FacilitatorId = TestEntities.OrganizationVerdiqAS.Id,
+                };
+
+                // The client is a BRL unit, but the stored RolePackageId references the ESEK
+                // scoped row. Rows with this shape exist in the database from before the
+                // delegate path filtered RolePackage rows on the client's entity variant.
+                var wrongVariantRolePackage = db.RolePackages.First(r =>
+                    r.RoleId == RoleConstants.BusinessManager
+                    && r.PackageId == PackageConstants.BusinessManagerRealEstate
+                    && r.EntityVariantId == EntityVariantConstants.ESEK.Id);
+
+                var delegationPackage = new DelegationPackage()
+                {
+                    DelegationId = delegationToPaula.Id,
+                    PackageId = PackageConstants.BusinessManagerRealEstate.Id,
+                    RolePackageId = wrongVariantRolePackage.Id,
+                };
+
+                db.Assignments.Add(businessManagerFromOkernToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+                db.Delegations.Add(delegationToPaula);
+                db.DelegationPackages.Add(delegationPackage);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DeleteAccessPackages_WithStoredWrongVariantRolePackageId_Returns200WithRemovedDelegation()
+        {
+            var client = CreateClient();
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{Route}/agents/accesspackages/delete?party={TestEntities.OrganizationVerdiqAS}&client={TestEntities.OrganizationOkernBorettslag}&agent={TestEntities.PersonPaula}")
+            {
+                Content = JsonContent.Create(new DelegationBatchInputDto()
+                {
+                    Values = [
+                        new()
+                        {
+                            Role = RoleConstants.BusinessManager.Entity.Code,
+                            Packages = [PackageConstants.BusinessManagerRealEstate.Entity.Urn]
+                        }
+                    ]
+                })
+            };
+
+            var deleteResponse = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            var deleteResponsePayload = await deleteResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+            var deleteResult = JsonSerializer.Deserialize<List<DelegationDto>>(deleteResponsePayload);
+            var deleteRow = Assert.Single(deleteResult);
+            Assert.True(deleteRow.Changed);
+
+            // The delegation package row is gone and the emptied delegation with it.
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegationPackages = await db.DelegationPackages
+                    .Where(dp => dp.Delegation.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id && dp.Delegation.To.ToId == TestEntities.PersonPaula.Id)
+                    .ToListAsync(TestContext.Current.CancellationToken);
+
+                var delegations = await db.Delegations
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id && d.To.ToId == TestEntities.PersonPaula.Id)
+                    .ToListAsync(TestContext.Current.CancellationToken);
+
+                Assert.Empty(delegationPackages);
+                Assert.Empty(delegations);
+            });
+        }
+    }
     #endregion
 
     #region GET accessmanagement/api/v2/enduser/clientdelegations/agents/resources

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.Enduser.Api.Tests/Integration/Controllers/V2/ClientDelegationControllerTest.cs
@@ -1684,6 +1684,118 @@ public class ClientDelegationControllerTest
             });
         }
     }
+
+    /// <summary>
+    /// <see cref="ClientDelegationController.DeleteAgentAccessPackage(Guid, Guid, Guid, DelegationBatchInputDto, CancellationToken)"/>
+    /// Removal of a package whose RolePackage rows are entity variant scoped, with one row per client unit type.
+    /// </summary>
+    [IntegrationTest]
+    public class DeleteAgentAccessPackagesWithVariantScopedRolePackage : IClassFixture<ApiFixture>
+    {
+        public DeleteAgentAccessPackagesWithVariantScopedRolePackage(ApiFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.EnsureSeedOnce<DeleteAgentAccessPackagesWithVariantScopedRolePackage>(db =>
+            {
+                var businessManagerFromOkernToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationOkernBorettslag.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.BusinessManager,
+                };
+
+                var businessManagerFromSolsidenToVerdiq = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationSolsidenSameie.Id,
+                    ToId = TestEntities.OrganizationVerdiqAS.Id,
+                    RoleId = RoleConstants.BusinessManager,
+                };
+
+                var agentFromVerdiqToPaula = new Assignment()
+                {
+                    FromId = TestEntities.OrganizationVerdiqAS.Id,
+                    ToId = TestEntities.PersonPaula,
+                    RoleId = RoleConstants.Agent,
+                };
+
+                db.Assignments.Add(businessManagerFromOkernToVerdiq);
+                db.Assignments.Add(businessManagerFromSolsidenToVerdiq);
+                db.Assignments.Add(agentFromVerdiqToPaula);
+
+                db.SaveChanges();
+            });
+        }
+
+        public ApiFixture Fixture { get; }
+
+        private HttpClient CreateClient()
+        {
+            var client = Fixture.Server.CreateClient();
+            var token = TestTokenGenerator.CreateToken(new ClaimsIdentity("mock"), claims =>
+            {
+                claims.Add(new Claim(AltinnCoreClaimTypes.PartyUuid, TestEntities.PersonPaula.Id.ToString()));
+                claims.Add(new Claim("scope", $"{AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_READ} {AuthzConstants.SCOPE_ENDUSER_CLIENTDELEGATION_WRITE}"));
+            });
+
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            return client;
+        }
+
+        [Fact]
+        public async Task DeleteAccessPackages_WithVariantScopedRolePackageRows_Returns200WithRemovedDelegationForEachClientVariant()
+        {
+            var client = CreateClient();
+            var payload = new DelegationBatchInputDto()
+            {
+                Values = [
+                    new()
+                    {
+                        Role = RoleConstants.BusinessManager.Entity.Code,
+                        Packages = [PackageConstants.BusinessManagerRealEstate.Entity.Urn]
+                    }
+                ]
+            };
+
+            // The BRL and ESEK clients hold the same package through different variant scoped RolePackage rows.
+            Guid[] clientOrgs = [TestEntities.OrganizationOkernBorettslag.Id, TestEntities.OrganizationSolsidenSameie.Id];
+            foreach (var clientOrg in clientOrgs)
+            {
+                var delegateResponse = await client.PostAsJsonAsync(
+                    $"{Route}/agents/accesspackages?party={TestEntities.OrganizationVerdiqAS}&client={clientOrg}&agent={TestEntities.PersonPaula}",
+                    payload,
+                    TestContext.Current.CancellationToken
+                );
+
+                Assert.Equal(HttpStatusCode.OK, delegateResponse.StatusCode);
+            }
+
+            foreach (var clientOrg in clientOrgs)
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, $"{Route}/agents/accesspackages/delete?party={TestEntities.OrganizationVerdiqAS}&client={clientOrg}&agent={TestEntities.PersonPaula}")
+                {
+                    Content = JsonContent.Create(payload)
+                };
+
+                var deleteResponse = await client.SendAsync(request, TestContext.Current.CancellationToken);
+                var deleteResponsePayload = await deleteResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+                Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+                var deleteResult = JsonSerializer.Deserialize<List<DelegationDto>>(deleteResponsePayload);
+                var deleteRow = Assert.Single(deleteResult);
+                Assert.True(deleteRow.Changed);
+            }
+
+            // Both delegations were emptied, so no delegation to the agent remains.
+            await Fixture.QueryDb(static async db =>
+            {
+                var delegations = await db.Delegations
+                    .Where(d => d.FacilitatorId == TestEntities.OrganizationVerdiqAS.Id && d.To.ToId == TestEntities.PersonPaula.Id)
+                    .ToListAsync(TestContext.Current.CancellationToken);
+
+                Assert.Empty(delegations);
+            });
+        }
+    }
     #endregion
 
     #region GET accessmanagement/api/v2/enduser/clientdelegations/agents/resources

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Data/TestEntities.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/Data/TestEntities.cs
@@ -120,6 +120,28 @@ public static class TestEntities
         }
     };
 
+    public static ConstantDefinition<Entity> OrganizationSolsidenSameie { get; } = new("f0d3bd4c-24c9-4a37-9a2e-1b5cc9be80d1")
+    {
+        Entity = new()
+        {
+            DateOfBirth = null,
+            DateOfDeath = null,
+            DeletedAt = null,
+            IsDeleted = false,
+            Name = "Solsiden Sameie ESEK",
+            OrganizationIdentifier = "815493002",
+            Parent = null,
+            ParentId = null,
+            PartyId = 50068513,
+            PersonIdentifier = null,
+            RefId = "815493002",
+            TypeId = EntityTypeConstants.Organization,
+            UserId = null,
+            Username = null,
+            VariantId = EntityVariantConstants.ESEK,
+        }
+    };
+
     public static ConstantDefinition<Entity> OrganizationNufExampleNUF { get; } = new("d4a7e3b1-9c2f-4a8e-b6d5-1f3e7a9c2b4d")
     {
         Entity = new()

--- a/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/TestDataSeeds.cs
+++ b/src/apps/Altinn.AccessManagement/test/Altinn.AccessManagement.TestUtils/TestDataSeeds.cs
@@ -43,6 +43,7 @@ public static class TestDataSeeds
             TestEntities.SystemUserClient,
             TestEntities.SystemUserStandard,
             TestEntities.OrganizationOkernBorettslag,
+            TestEntities.OrganizationSolsidenSameie,
             TestEntities.OrganizationNufExampleNUF,
             TestEntities.SIUserMarius,
             TestEntities.EmailUserMarius,


### PR DESCRIPTION
`RemoveAgentDelegation` matched the delegation package row on the `RolePackageId` and `AssignmentPackageId` it resolved at delete time. For a package whose RolePackage rows are entity variant scoped, such as `forretningsforer-eiendom` with one row for ESEK and one for BRL, the delete resolved that row without the variant filter the delegate path applies, so it could land on the other variant's row. The stored id then never matched, the response row reported `changed: false`, and the delegation stayed behind, removable only through the cascade delete on the client relation.

`(DelegationId, PackageId)` is unique on the delegation package, and the delegation is already resolved from the caller's client assignment, agent assignment and facilitator for the role in the request. The delete now matches on the package id alone, which also clears rows whose stored ids no longer resolve the same way, such as a wrong variant `RolePackageId` written before the delegate path filtered RolePackage rows on the client's entity variant.

Two test classes cover this: removal for a BRL client and an ESEK client that hold the same package through separate variant scoped rows, and removal of a row whose stored `RolePackageId` points at the wrong variant. The RolePackage rows for both variants already come from the static ingest, so the ESEK client is the only new seed entity.

`ClientDelegationService` is shared by the v1 and v2 controllers, so v1 deletes get the same fix. Nothing moves the other way: a delete that reported `changed: true` before still does, since the old match succeeding implies the row exists, which is all the new match requires.

The Bruno scenario `11_ForretningsforerVariantPackages` still cleans up through the cascade delete on the client relation. Those steps become package level deletes asserting `changed: true` once this is deployed to AT22, and the scenario files belong to #3847 until it merges.

Closes #3848
