### PR TITLE
chore: disable db-connection in authorization

### DIFF
--- a/src/apps/Altinn.Authorization/src/Altinn.Authorization/appsettings.json
+++ b/src/apps/Altinn.Authorization/src/Altinn.Authorization/appsettings.json
@@ -11,7 +11,7 @@
     "BlobLeaseTimeout": 15
   },
   "PostgreSQLSettings": {
-    "EnableDBConnection": "true",
+    "EnableDBConnection": "false",
     "AdminConnectionString": "Host=localhost;Port=5432;Username=platform_authorization_admin;Password={0};Database=authorizationdb",
     "ConnectionString": "Host=localhost;Port=5432;Username=platform_authorization;Password={0};Database=authorizationdb",
     "AuthorizationDbAdminPwd": "Password",


### PR DESCRIPTION
- the old db connection is no longer in use i Authorization
- cleanup issue for old unused db logic will be done seperately (se: #3851)

- config already disabled for all environments through values.yaml in studio-ops repo

- a new readonly EF connection might be added later as part of cleanup and to rely on data from own db in stead of relying of API call so Register, Profile etc.

OR
- authorization might as well be combined with AccessManagement as a singular product and get needed db access that way