### PR TITLE
test: remove variant scoped delegations at package level in the client delegation scenarios

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/02_AND_ClientAddsFacilitatorAsRightholder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/02_AND_ClientAddsFacilitatorAsRightholder.bru
@@ -31,6 +31,8 @@ script:pre-request {
 }
 
 tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
   test("AND the client adds the facilitator as rightholder, the request returns 200", function() {
     expect(res.status).to.equal(200);
   });

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/02_AND_ClientAddsFacilitatorAsRightholder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/02_AND_ClientAddsFacilitatorAsRightholder.bru
@@ -35,7 +35,10 @@ tests {
     expect(res.status).to.equal(200);
   });
 
-  test("AND the created assignment carries the rettighetshaver role", function() {
-    expect(res.getBody().roleId.toLowerCase()).to.equal("42cae370-2dc1-4fdc-9c67-c2f4b0f0f829");
+  test("AND the assignment connects the client to the facilitator with the rettighetshaver role", function() {
+    const body = res.getBody();
+    expect(body.roleId.toLowerCase()).to.equal("42cae370-2dc1-4fdc-9c67-c2f4b0f0f829");
+    expect(body.fromId.toLowerCase()).to.equal(td.REGN_Organisasjon.REGN_Org_Clients.client_B.partyUuid.toLowerCase());
+    expect(body.toId.toLowerCase()).to.equal(td.REGN_Organisasjon.partyUuid.toLowerCase());
   });
 }

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/04_AND_ClientChecksDelegableRightsForResource.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/10_ClientListRelationTypes/04_AND_ClientChecksDelegableRightsForResource.bru
@@ -47,5 +47,6 @@ tests {
     const readRight = res.getBody().rights.find(r => r.right.action.value === "read");
     expect(readRight, "expected a read right in the delegation check response").to.not.be.undefined;
     expect(readRight.result).to.be.true;
+    expect(readRight.right.key, "expected the read right to carry a right key").to.be.a("string").that.is.not.empty;
   });
 }

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/10_CLEANUP_BrlDelegationIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/10_CLEANUP_BrlDelegationIsRemoved.bru
@@ -4,9 +4,9 @@ meta {
   seq: 10
 }
 
-delete {
-  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/clients?party={{party}}&client={{client}}&agent={{agent}}&cascade=true
-  body: none
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages/delete?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
   auth: inherit
 }
 
@@ -14,12 +14,23 @@ params:query {
   party: {{party}}
   client: {{client}}
   agent: {{agent}}
-  cascade: true
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "forretningsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
 }
 
 docs {
-  CLEANUP: the BRL client is removed from the agent with cascade, which removes
-  the eiendom delegation with it.
+  CLEANUP: the eiendom delegation for the BRL client is removed at package
+  level. The package is backed by a variant scoped RolePackage row, so the
+  delete must resolve the BRL row for the delegation to be removed.
 }
 
 script:pre-request {
@@ -30,12 +41,19 @@ script:pre-request {
   bru.setVar("party", su.regnskapsforer.partyuuid);
   bru.setVar("client", su.brl_type_client_org.partyuuid);
   bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.forretningsforerEiendom);
 
   await loginAs(su.regnskapsforer.dagl);
 }
 
 tests {
-  test("CLEANUP removing the BRL client from the agent returns 204", function() {
-    expect(res.status).to.equal(204);
+  test("CLEANUP removing the eiendom package for the BRL client returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("CLEANUP the delete row reports a change", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(1);
+    expect(body[0].changed).to.be.true;
   });
 }

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/11_CLEANUP_EsekDelegationIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/11_CLEANUP_EsekDelegationIsRemoved.bru
@@ -4,9 +4,9 @@ meta {
   seq: 11
 }
 
-delete {
-  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/clients?party={{party}}&client={{client}}&agent={{agent}}&cascade=true
-  body: none
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages/delete?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
   auth: inherit
 }
 
@@ -14,12 +14,23 @@ params:query {
   party: {{party}}
   client: {{client}}
   agent: {{agent}}
-  cascade: true
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "forretningsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
 }
 
 docs {
-  CLEANUP: the ESEK client is removed from the agent with cascade, which removes
-  the eiendom delegation with it.
+  CLEANUP: the eiendom delegation for the ESEK client is removed at package
+  level. The package is backed by a variant scoped RolePackage row, so the
+  delete must resolve the ESEK row for the delegation to be removed.
 }
 
 script:pre-request {
@@ -30,12 +41,19 @@ script:pre-request {
   bru.setVar("party", su.regnskapsforer.partyuuid);
   bru.setVar("client", su.esek_type_client_org.partyuuid);
   bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.forretningsforerEiendom);
 
   await loginAs(su.regnskapsforer.dagl);
 }
 
 tests {
-  test("CLEANUP removing the ESEK client from the agent returns 204", function() {
-    expect(res.status).to.equal(204);
+  test("CLEANUP removing the eiendom package for the ESEK client returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("CLEANUP the delete row reports a change", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(1);
+    expect(body[0].changed).to.be.true;
   });
 }


### PR DESCRIPTION
Related to #3846

Scenario 11 delegated `forretningsforer-eiendom` for the BRL and the ESEK client and then cleaned up by removing the whole client relation with cascade. It was written that way because package level deletes of those delegations reported `changed: false` and left the row behind, which was #3848. That is fixed and deployed, so the two cleanup steps now do what the scenario is actually about: `POST agents/accesspackages/delete` for the delegated package, asserting 200 and a single row with `changed: true`. Both clients hold the package through separate variant scoped RolePackage rows, so the steps only pass if the delete resolves the right row for each. Step 12 still removes the agent with cascade, which disposes of the client assignments the package deletes leave behind.

Two assertion gaps in scenario 10 go with it:

- `02_AND_ClientAddsFacilitatorAsRightholder` asserted only `roleId`, so a swapped assignment would have passed. It now asserts `fromId` and `toId` as well, matching how `05_RightholderClientPackages` asserts the same call.
- `04_AND_ClientChecksDelegableRightsForResource` stored the delegable right key without checking it, so a response schema change would have surfaced as a confusing failure in the next step. The key is now asserted to be a non-empty string where it is read.

Verified against AT22, both folders run back to back twice with identical results: scenario 10 at 14 requests and 24 asserts, scenario 11 at 12 requests and 21 asserts, no failures. The second pass is what proves the new cleanup leaves no residue, since the GIVEN reset and the pre-delegation assertions in steps 03 to 05 see the same state as the first pass.

The NUF variant of the forretningsforer packages stays open on #3846. No unit of that type holds a forretningsforer relation to the facilitator in AT22 or TT02, so it needs register test data before it can be exercised.
