### PR TITLE
test: cover the NUF scoped forretningsforer packages in the client delegation scenarios

### DIFF
--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/11_ForretningsforerVariantPackages/folder.bru
@@ -18,7 +18,6 @@ docs {
     And the delegations and the agent registration are cleaned up
 
   The facilitator and its forretningsforer clients come from the register test
-  data behind testdata/systemuser-clientdelegation. No NUF unit holds a
-  forretningsforer relation to the facilitator in AT22 or TT02, so the NUF
-  scoped packages are not covered here.
+  data behind testdata/systemuser-clientdelegation. The NUF scoped packages run
+  in their own scenario against a facilitator with NUF clients.
 }

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/01_GIVEN_AgentHasNoRegistration.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/01_GIVEN_AgentHasNoRegistration.bru
@@ -1,0 +1,38 @@
+meta {
+  name: 01_GIVEN_AgentHasNoRegistration
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  GIVEN the NUF facilitator has no agent registration for the agent person.
+  Reset step, idempotent 204.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.clientDelegationV2.forretningsforerNuf.facilitator.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.clientDelegationV2.forretningsforerNuf.facilitator.dagligleder);
+}
+
+tests {
+  test("GIVEN the facilitator has no registered agent, the reset delete returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/02_AND_AgentIsRegistered.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/02_AND_AgentIsRegistered.bru
@@ -1,0 +1,44 @@
+meta {
+  name: 02_AND_AgentIsRegistered
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+}
+
+body:json {
+  {
+    "personIdentifier": "{{agentPid}}",
+    "lastName": "{{agentLastName}}"
+  }
+}
+
+docs {
+  AND the agent person is registered as agent for the NUF facilitator by person
+  number.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.clientDelegationV2.forretningsforerNuf.facilitator.partyUuid);
+  bru.setVar("agentPid", td.REGN_Organisasjon.REGN_Agent.personidentity);
+  bru.setVar("agentLastName", td.REGN_Organisasjon.REGN_Agent.etternavn);
+
+  await loginAs(td.clientDelegationV2.forretningsforerNuf.facilitator.dagligleder);
+}
+
+tests {
+  test("AND registering the agent returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/03_THEN_NufClientCarriesNufPackages.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/03_THEN_NufClientCarriesNufPackages.bru
@@ -1,0 +1,52 @@
+meta {
+  name: 03_THEN_NufClientCarriesNufPackages
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/clients?party={{party}}&roles=forretningsforer
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  roles: forretningsforer
+}
+
+docs {
+  THEN the NUF client carries the NUF services package through the
+  forretningsforer role, and neither the eiendom package (scoped to ESEK and
+  BRL) nor the non delegable NUF access management package appears in the list.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.clientDelegationV2.forretningsforerNuf.facilitator.partyUuid);
+
+  await loginAs(td.clientDelegationV2.forretningsforerNuf.facilitator.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the role filtered client list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the NUF client carries the NUF services package and not the variant foreign ones", function() {
+    const nuf = td.clientDelegationV2.forretningsforerNuf.nufClient.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === nuf);
+    expect(entry, "expected the NUF client in the forretningsforer client list").to.not.be.undefined;
+    expect(entry.client.variant).to.equal("NUF");
+    const roleAccess = entry.access.find(a => a.role.code === "forretningsforer");
+    expect(roleAccess, "expected a forretningsforer access element").to.not.be.undefined;
+    const urns = roleAccess.packages.map(p => p.urn);
+    expect(urns).to.include(td.clientDelegationV2.packages.tjenesterNuf);
+    expect(urns).to.not.include(td.clientDelegationV2.packages.forretningsforerEiendom);
+    expect(urns).to.not.include(td.clientDelegationV2.packages.fforTilgangsstyrerNufNotDelegable);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/04_WHEN_NufPackageIsDelegatedToAgent.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/04_WHEN_NufPackageIsDelegatedToAgent.bru
@@ -1,0 +1,61 @@
+meta {
+  name: 04_WHEN_NufPackageIsDelegatedToAgent
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "forretningsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the NUF services package is delegated to the agent for the NUF client.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.clientDelegationV2.forretningsforerNuf.facilitator.partyUuid);
+  bru.setVar("client", td.clientDelegationV2.forretningsforerNuf.nufClient.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.tjenesterNuf);
+
+  await loginAs(td.clientDelegationV2.forretningsforerNuf.facilitator.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("WHEN the NUF services package is delegated, the request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the delegation row connects the NUF client to the agent through the facilitator", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array").with.lengthOf(1);
+    expect(body[0].changed).to.be.true;
+    expect(body[0].fromId.toLowerCase()).to.equal(td.clientDelegationV2.forretningsforerNuf.nufClient.partyUuid.toLowerCase());
+    expect(body[0].viaId.toLowerCase()).to.equal(td.clientDelegationV2.forretningsforerNuf.facilitator.partyUuid.toLowerCase());
+    expect(body[0].toId.toLowerCase()).to.equal(td.REGN_Organisasjon.REGN_Agent.userUuid.toLowerCase());
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/05_WHEN_NonDelegablePackageIsDelegatedThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/05_WHEN_NonDelegablePackageIsDelegatedThenRequestFails.bru
@@ -1,0 +1,59 @@
+meta {
+  name: 05_WHEN_NonDelegablePackageIsDelegatedThenRequestFails
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "forretningsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the NUF access management package is delegated, the request fails.
+
+  The package is scoped to NUF units through the forretningsforer role but is
+  not delegable onwards. Expects 400 with validation error AM.VLD-00033.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.clientDelegationV2.forretningsforerNuf.facilitator.partyUuid);
+  bru.setVar("client", td.clientDelegationV2.forretningsforerNuf.nufClient.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.fforTilgangsstyrerNufNotDelegable);
+
+  await loginAs(td.clientDelegationV2.forretningsforerNuf.facilitator.dagligleder);
+}
+
+tests {
+  test("WHEN the non delegable NUF package is delegated, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body reports validation error AM.VLD-00033", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00033")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/06_WHEN_EiendomIsDelegatedForNufClientThenRequestFails.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/06_WHEN_EiendomIsDelegatedForNufClientThenRequestFails.bru
@@ -1,0 +1,59 @@
+meta {
+  name: 06_WHEN_EiendomIsDelegatedForNufClientThenRequestFails
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "forretningsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  WHEN the eiendom package is delegated for the NUF client, the request fails.
+
+  The eiendom package is scoped to the ESEK and BRL unit types, so a NUF client
+  cannot receive it. Expects 400 with validation error AM.VLD-00026.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.clientDelegationV2.forretningsforerNuf.facilitator.partyUuid);
+  bru.setVar("client", td.clientDelegationV2.forretningsforerNuf.nufClient.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.forretningsforerEiendom);
+
+  await loginAs(td.clientDelegationV2.forretningsforerNuf.facilitator.dagligleder);
+}
+
+tests {
+  test("WHEN the eiendom package is delegated for the NUF client, the request returns 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("THEN the error body reports validation error AM.VLD-00026", function() {
+    const body = res.getBody();
+    expect(body.code).to.equal("STD-00000");
+    expect(body.validationErrors.some(e => e.code === "AM.VLD-00026")).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/07_THEN_AgentPackageListShowsNufClient.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/07_THEN_AgentPackageListShowsNufClient.bru
@@ -1,0 +1,47 @@
+meta {
+  name: 07_THEN_AgentPackageListShowsNufClient
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages?party={{party}}&agent={{agent}}
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+}
+
+docs {
+  THEN the agent package list shows the NUF client with the NUF services
+  package.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.clientDelegationV2.forretningsforerNuf.facilitator.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.clientDelegationV2.forretningsforerNuf.facilitator.dagligleder);
+}
+
+tests {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+
+  test("THEN the agent package list request returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("THEN the NUF client is listed with the NUF services package", function() {
+    const nuf = td.clientDelegationV2.forretningsforerNuf.nufClient.partyUuid.toLowerCase();
+    const entry = res.getBody().data.find(item => item.client.id.toLowerCase() === nuf);
+    expect(entry, "expected the NUF client in the agent package list").to.not.be.undefined;
+    const urns = entry.access.flatMap(a => a.packages.map(p => p.urn));
+    expect(urns).to.include(td.clientDelegationV2.packages.tjenesterNuf);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/08_CLEANUP_NufDelegationIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/08_CLEANUP_NufDelegationIsRemoved.bru
@@ -1,0 +1,53 @@
+meta {
+  name: 08_CLEANUP_NufDelegationIsRemoved
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents/accesspackages/delete?party={{party}}&client={{client}}&agent={{agent}}
+  body: json
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  client: {{client}}
+  agent: {{agent}}
+}
+
+body:json {
+  {
+    "values": [
+      {
+        "role": "forretningsforer",
+        "packages": ["{{package}}"]
+      }
+    ]
+  }
+}
+
+docs {
+  CLEANUP: the NUF services delegation is removed at package level. The package
+  has a single RolePackage row under forretningsforer, so the removal is not
+  affected by the variant row mismatch tracked in the delete path.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.clientDelegationV2.forretningsforerNuf.facilitator.partyUuid);
+  bru.setVar("client", td.clientDelegationV2.forretningsforerNuf.nufClient.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+  bru.setVar("package", td.clientDelegationV2.packages.tjenesterNuf);
+
+  await loginAs(td.clientDelegationV2.forretningsforerNuf.facilitator.dagligleder);
+}
+
+tests {
+  test("CLEANUP the NUF delegation delete returns 200 with a change", function() {
+    expect(res.status).to.equal(200);
+    expect(res.getBody().every(row => row.changed === true)).to.be.true;
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/09_CLEANUP_AgentIsRemoved.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/09_CLEANUP_AgentIsRemoved.bru
@@ -1,0 +1,37 @@
+meta {
+  name: 09_CLEANUP_AgentIsRemoved
+  type: http
+  seq: 9
+}
+
+delete {
+  url: {{baseUrl}}/accessmanagement/api/v2/enduser/clientdelegations/agents?party={{party}}&agent={{agent}}&cascade=true
+  body: none
+  auth: inherit
+}
+
+params:query {
+  party: {{party}}
+  agent: {{agent}}
+  cascade: true
+}
+
+docs {
+  CLEANUP: the agent registration for the NUF facilitator is removed.
+}
+
+script:pre-request {
+  const td = require(`./testdata/klient-delegation/${bru.getEnvVar("tokenEnv")}.js`);
+  const { loginAs } = require("./test/EnduserAPI/ClientDelegationsV2/helpers.js");
+
+  bru.setVar("party", td.clientDelegationV2.forretningsforerNuf.facilitator.partyUuid);
+  bru.setVar("agent", td.REGN_Organisasjon.REGN_Agent.userUuid);
+
+  await loginAs(td.clientDelegationV2.forretningsforerNuf.facilitator.dagligleder);
+}
+
+tests {
+  test("CLEANUP the agent removal returns 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/folder.bru
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/test/EnduserAPI/ClientDelegationsV2/12_ForretningsforerNufPackages/folder.bru
@@ -1,0 +1,20 @@
+meta {
+  name: 12_ForretningsforerNufPackages
+  seq: 12
+}
+
+docs {
+  Scenario: A NUF client carries the NUF scoped packages through forretningsforer
+
+    Given the facilitator has no agent registration for the agent person
+    And the agent person is registered as agent
+    Then the NUF client carries the NUF services package and not the eiendom package
+    When the NUF services package is delegated to the agent for the NUF client
+    When the non delegable NUF package is delegated the request fails
+    When the eiendom package is delegated for the NUF client the request fails
+    Then the agent package list shows the NUF client
+    And the delegation and the agent registration are cleaned up
+
+  The facilitator and its NUF clients come from register test data referenced in
+  testdata/klient-delegation under clientDelegationV2.forretningsforerNuf.
+}

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/at22.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/at22.js
@@ -85,6 +85,28 @@
         klientadministrator: "urn:altinn:accesspackage:klientadministrator",
         skattegrunnlag: "urn:altinn:accesspackage:skattegrunnlag",
         forretningsforerEiendom: "urn:altinn:accesspackage:forretningsforer-eiendom",
+        tjenesterNuf: "urn:altinn:accesspackage:tjenester-nuf",
+        fforTilgangsstyrerNufNotDelegable: "urn:altinn:accesspackage:ffor-tilgangsstyrer-nuf",
+      },
+      // Facilitator with forretningsforer relations to NUF clients.
+      forretningsforerNuf: {
+        facilitator: {
+          name: "OPPBLÅST UNG MINK ANS",
+          orgno: "314240200",
+          partyUuid: "41889f4c-48ce-44d9-ac23-aee0f9b1826b",
+          dagligleder: {
+            name: "ANSTENDIG ARTERIE",
+            pid: "15847099396",
+            userId: 20883145,
+            partyId: 50958336,
+            partyUuid: "b82992c6-9f7f-4445-bbe4-33a15873417a",
+          },
+        },
+        nufClient: {
+          name: "SAKTE FRISK STRUTS AB",
+          orgno: "311762966",
+          partyUuid: "56c38c7f-dbfb-4042-8058-bc424610311d",
+        },
       },
       // Forretningsforer client of the systemuser-clientdelegation facilitator whose
       // unit type (BBL) is outside the ESEK/BRL scope of forretningsforer-eiendom.

--- a/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/tt02.js
+++ b/src/apps/Altinn.AccessManagement/test/Bruno/AccessMgmt/testdata/klient-delegation/tt02.js
@@ -85,6 +85,28 @@
         klientadministrator: "urn:altinn:accesspackage:klientadministrator",
         skattegrunnlag: "urn:altinn:accesspackage:skattegrunnlag",
         forretningsforerEiendom: "urn:altinn:accesspackage:forretningsforer-eiendom",
+        tjenesterNuf: "urn:altinn:accesspackage:tjenester-nuf",
+        fforTilgangsstyrerNufNotDelegable: "urn:altinn:accesspackage:ffor-tilgangsstyrer-nuf",
+      },
+      // Facilitator with forretningsforer relations to NUF clients.
+      forretningsforerNuf: {
+        facilitator: {
+          name: "OPPBLÅST UNG MINK ANS",
+          orgno: "314240200",
+          partyUuid: "47a62cca-4840-438f-be18-26bd2aea29a7",
+          dagligleder: {
+            name: "ANSTENDIG ARTERIE",
+            pid: "15847099396",
+            userId: 160682,
+            partyId: 51209497,
+            partyUuid: "b8b84060-cb50-42f2-8b3d-39abfc76616a",
+          },
+        },
+        nufClient: {
+          name: "SAKTE FRISK STRUTS AB",
+          orgno: "311762966",
+          partyUuid: "f407a32c-a33e-4d94-b6ce-58b58b9c563f",
+        },
       },
       // Forretningsforer client of the systemuser-clientdelegation facilitator whose
       // unit type (BBL) is outside the ESEK/BRL scope of forretningsforer-eiendom.


### PR DESCRIPTION
Adds the last scenario from #3846 to the ClientDelegationsV2 Bruno suite: `12_ForretningsforerNufPackages`, running on the new register test data with a forretningsforer relation from NUF units.

The scenario verifies that the NUF client carries `tjenester-nuf` through the forretningsforer role while neither `forretningsforer-eiendom` (scoped to ESEK and BRL) nor the non delegable `ffor-tilgangsstyrer-nuf` appears in the client list, delegates the NUF services package to an agent, and asserts the two rejections: the non delegable package gives AM.VLD-00033 and the eiendom package for a NUF client gives AM.VLD-00026. Cleanup runs at package level, which works here because the package has a single RolePackage row under the role, so the delete path mismatch from #3848 does not apply.

The new facilitator and NUF client identities are added to `testdata/klient-delegation` for both AT22 and TT02, and the stale note in scenario 11 about missing NUF data is gone.

Verified against AT22: the scenario passes standalone (9 requests, 14 asserts) and the whole twelve scenario suite passes in one run (127 requests, 209 asserts).

Closes #3846
