### PR TITLE
feat(#3815): Include Client-Delegated Resources in ConnectionQuery and AuthorizedParties response

### DIFF
--- a/src/apps/Altinn.AccessManagement/infra/main.tf
+++ b/src/apps/Altinn.AccessManagement/infra/main.tf
@@ -529,6 +529,12 @@ module "appsettings" {
       label       = "${lower(var.environment)}-access-management"
       value       = false
     },
+    {
+      name        = "AccessManagement.ConnectionQuery.IncludeClientDelegationResources"
+      description = "Specifies if client-delegated resources should be included in ConnectionQuery and AuthorizedParties response."
+      label       = "${lower(var.environment)}-access-management"
+      value       = false
+    },
   ]
   providers = {
     azurerm.hub = azurerm.hub

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/AccessMgmtFeatureFlags.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/AccessMgmtFeatureFlags.cs
@@ -127,4 +127,9 @@ public static class AccessMgmtFeatureFlags
     /// Feature flag for including v2 client-delegated resources in PIP GetAllDelegationChanges response.
     /// </summary>
     public const string IncludeClientDelegatedResourcesInPip = "AccessManagement.Pip.IncludeClientDelegatedResources";
+
+    /// <summary>
+    /// Feature flag for including client-delegated resources in ConnectionQuery and AuthorizedParties response.
+    /// </summary>
+    public const string IncludeClientDelegationResourcesInConnectionQuery = "AccessManagement.ConnectionQuery.IncludeClientDelegationResources";
 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.Core/Services/AuthorizedPartyRepoServiceEf.cs
@@ -7,11 +7,12 @@ using Altinn.AccessMgmt.PersistenceEF.Queries.Connection;
 using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
 using Altinn.Authorization.Api.Contracts.AccessManagement.Enums;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement;
 
 namespace Altinn.AccessMgmt.Core.Services;
 
 /// <inheritdoc/>
-public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery connectionQuery) : IAuthorizedPartyRepoServiceEf
+public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery connectionQuery, IFeatureManager featureManager) : IAuthorizedPartyRepoServiceEf
 {
     /// <inheritdoc/>
     public async Task<Entity?> GetEntity(Guid id, CancellationToken ct = default) =>
@@ -108,6 +109,9 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
         bool enrichEntities = false,
         CancellationToken ct = default)
     {
+        var includeResources = filters?.IncludeResources == true || filters?.ResourceFilter?.Keys?.Count > 0;
+        var includeDelegationResources = includeResources && await featureManager.IsEnabledAsync(AccessMgmtFeatureFlags.IncludeClientDelegationResourcesInConnectionQuery);
+
         return await connectionQuery.GetConnectionsAsync(
         new ConnectionQueryFilter()
         {
@@ -119,7 +123,8 @@ public class AuthorizedPartyRepoServiceEf(AppDbContext db, ConnectionQuery conne
             IncludeMainUnitConnections = true,
             IncludeDelegation = true,
             IncludePackages = filters?.IncludeAccessPackages == true || filters?.PackageFilter?.Keys?.Count > 0,
-            IncludeResources = filters?.IncludeResources == true || filters?.ResourceFilter?.Keys?.Count > 0,
+            IncludeResources = includeResources,
+            IncludeDelegationResources = includeDelegationResources,
             IncludeInstances = filters?.IncludeInstances == true || filters?.ResourceFilter?.Keys?.Count > 0,
             EnrichPackageResources = false,
             ExcludeDeleted = false

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -181,14 +181,14 @@ public class ConnectionQuery(AppDbContext db)
                         {
                             result = await resourceLoader.LoadResourcesByKeyAsync(result, rightholderAssignmentIds, filter, ct);
                         }
-                    }
 
-                    if (filter.IncludeDelegationResources && filter.IncludeDelegation)
-                    {
-                        var delegationIds = result.Where(r => r.DelegationId.HasValue).Select(r => (Guid)r.DelegationId!).Distinct().ToHashSet();
-                        if (delegationIds.Count > 0)
+                        if (filter.IncludeDelegation && filter.IncludeDelegationResources)
                         {
-                            result = await resourceLoader.LoadDelegationResourcesByKeyAsync(result, delegationIds, filter, ct);
+                            var delegationIds = result.Where(r => r.DelegationId.HasValue).Select(r => (Guid)r.DelegationId!).Distinct().ToHashSet();
+                            if (delegationIds.Count > 0)
+                            {
+                                result = await resourceLoader.LoadDelegationResourcesByKeyAsync(result, delegationIds, filter, ct);
+                            }
                         }
                     }
                 }

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQuery.cs
@@ -182,6 +182,15 @@ public class ConnectionQuery(AppDbContext db)
                             result = await resourceLoader.LoadResourcesByKeyAsync(result, rightholderAssignmentIds, filter, ct);
                         }
                     }
+
+                    if (filter.IncludeDelegationResources && filter.IncludeDelegation)
+                    {
+                        var delegationIds = result.Where(r => r.DelegationId.HasValue).Select(r => (Guid)r.DelegationId!).Distinct().ToHashSet();
+                        if (delegationIds.Count > 0)
+                        {
+                            result = await resourceLoader.LoadDelegationResourcesByKeyAsync(result, delegationIds, filter, ct);
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryFilter.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionQueryFilter.cs
@@ -69,6 +69,11 @@ public sealed class ConnectionQueryFilter
     public bool IncludeResources { get; init; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to include delegation resources from client delegations.
+    /// </summary>
+    public bool IncludeDelegationResources { get; init; } = false;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to include instances.
     /// </summary>
     public bool IncludeInstances { get; init; } = false;

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionResourceLoader.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionResourceLoader.cs
@@ -148,4 +148,69 @@ internal class ConnectionResourceLoader(AppDbContext db)
 
         return allKeys;
     }
+
+    /// <summary>
+    /// Loads delegation resources for connections with a DelegationId and merges them into the corresponding records.
+    /// </summary>
+    public async Task<List<ConnectionQueryExtendedRecord>> LoadDelegationResourcesByKeyAsync(List<ConnectionQueryExtendedRecord> allKeys, HashSet<Guid> delegationIds, ConnectionQueryFilter filter, CancellationToken ct)
+    {
+        var resourceSet = filter.ResourceIds?.Count > 0 ? new HashSet<Guid>(filter.ResourceIds) : null;
+
+        var delegationResources = await db.DelegationResources
+            .Where(dr => delegationIds.Contains(dr.DelegationId))
+            .Select(dr => new { dr.DelegationId, dr.Id, dr.ResourceId })
+            .WhereIf(resourceSet is not null, x => resourceSet!.Contains(x.ResourceId))
+            .Join(db.Resources, x => x.ResourceId, r => r.Id, (x, r) => new
+            {
+                x.DelegationId,
+                r.Id,
+                r.Name,
+                r.RefId
+            })
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        SortedList<Guid, List<ConnectionQueryResource>> resourcesByDelegation = [];
+        foreach (var dr in delegationResources)
+        {
+            if (resourcesByDelegation.TryGetValue(dr.DelegationId, out var list))
+            {
+                list.Add(new ConnectionQueryResource()
+                {
+                    Id = dr.Id,
+                    Name = dr.Name,
+                    RefId = dr.RefId
+                });
+            }
+            else
+            {
+                resourcesByDelegation[dr.DelegationId] =
+                [
+                    new ConnectionQueryResource()
+                    {
+                        Id = dr.Id,
+                        Name = dr.Name,
+                        RefId = dr.RefId
+                    }
+                ];
+            }
+        }
+
+        foreach (var key in allKeys)
+        {
+            if (key.DelegationId.HasValue && resourcesByDelegation.TryGetValue((Guid)key.DelegationId!, out var list))
+            {
+                if (key.Resources is null)
+                {
+                    key.Resources = list;
+                }
+                else
+                {
+                    key.Resources.AddRange(list);
+                }
+            }
+        }
+
+        return allKeys;
+    }
 }

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -786,7 +786,7 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
     }
 
     [Fact]
-    public async Task GetConnectionsFromOthers_IncludeDelegationFalse_DoesNotReturnDelegationResources()
+    public async Task GetConnectionsFromOthers_IncludeDelegationFalse_DoesNotReturnDelegationConnections()
     {
         var personId = TestDataSet.GetEntity("Gunnar").Id;
 

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Services/ConnectionQueryTests.cs
@@ -8,6 +8,7 @@ using Altinn.AccessMgmt.PersistenceEF.Queries.Connection.Models;
 using Altinn.Authorization.Api.Contracts.AccessManagement;
 using Microsoft.EntityFrameworkCore;
 using DelegationPackage = Altinn.AccessMgmt.PersistenceEF.Models.DelegationPackage;
+using DelegationResource = Altinn.AccessMgmt.PersistenceEF.Models.DelegationResource;
 
 namespace Altinn.AccessManagement.Tests.Integration.Services;
 
@@ -51,6 +52,7 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
         db.DelegationPackages.AddRange(TestDataSet.DelegationPackages);
         db.Set<AssignmentResource>().AddRange(TestDataSet.AssignmentResources);
         db.Set<AssignmentInstance>().AddRange(TestDataSet.AssignmentInstances);
+        db.Set<DelegationResource>().AddRange(TestDataSet.DelegationResources);
 
         await db.SaveChangesAsync(new Altinn.AccessMgmt.PersistenceEF.Extensions.AuditValues(SystemEntityConstants.StaticDataIngest, SystemEntityConstants.StaticDataIngest));
     }
@@ -756,6 +758,82 @@ public class ConnectionQueryTests : IClassFixture<EfDatabaseFixture>, IAsyncLife
 
     #endregion
 
+    #region IncludeDelegationResources
+
+    [Fact]
+    public async Task GetConnectionsFromOthers_IncludeDelegationResources_ReturnsDelegationResources()
+    {
+        var personId = TestDataSet.GetEntity("Gunnar").Id;
+
+        var filter = new ConnectionQueryFilter
+        {
+            ToIds = new[] { personId },
+            IncludeKeyRole = false,
+            IncludeDelegation = true,
+            IncludeResources = true,
+            IncludeDelegationResources = true,
+            EnrichEntities = false,
+        };
+
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, TestContext.Current.CancellationToken);
+
+        // Gunnar has a delegation from Baker Johnsen via Regnskaperne with a DelegationResource
+        var delegationConnections = dbResult.Where(r => r.DelegationId.HasValue).ToList();
+        Assert.NotEmpty(delegationConnections);
+
+        var resources = delegationConnections.SelectMany(c => c.Resources ?? []).ToList();
+        Assert.Contains(resources, r => r.Id == TestDataSet.DelegationTestResourceId);
+    }
+
+    [Fact]
+    public async Task GetConnectionsFromOthers_IncludeDelegationFalse_DoesNotReturnDelegationResources()
+    {
+        var personId = TestDataSet.GetEntity("Gunnar").Id;
+
+        var filter = new ConnectionQueryFilter
+        {
+            ToIds = new[] { personId },
+            IncludeKeyRole = false,
+            IncludeDelegation = false,
+            IncludeResources = true,
+            IncludeDelegationResources = true,
+            EnrichEntities = false,
+        };
+
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, TestContext.Current.CancellationToken);
+
+        // With IncludeDelegation = false, no delegation connections should appear
+        var delegationConnections = dbResult.Where(r => r.DelegationId.HasValue).ToList();
+        Assert.Empty(delegationConnections);
+    }
+
+    [Fact]
+    public async Task GetConnectionsFromOthers_IncludeDelegationResourcesFalse_DoesNotReturnDelegationResources()
+    {
+        var personId = TestDataSet.GetEntity("Gunnar").Id;
+
+        var filter = new ConnectionQueryFilter
+        {
+            ToIds = new[] { personId },
+            IncludeKeyRole = false,
+            IncludeDelegation = true,
+            IncludeResources = true,
+            IncludeDelegationResources = false,
+            EnrichEntities = false,
+        };
+
+        var dbResult = await _query.GetConnectionsFromOthersAsync(filter, TestContext.Current.CancellationToken);
+
+        // Delegation connections exist but should not have resources loaded
+        var delegationConnections = dbResult.Where(r => r.DelegationId.HasValue).ToList();
+        Assert.NotEmpty(delegationConnections);
+
+        var resources = delegationConnections.SelectMany(c => c.Resources ?? []).ToList();
+        Assert.Empty(resources);
+    }
+
+    #endregion
+
     #region IncludeInstances
 
     [Fact]
@@ -1282,6 +1360,7 @@ internal static class TestDataSet
 
     internal static readonly Guid TestResourceTypeId = Guid.Parse("0195efb8-7c80-7a01-8001-000000000050");
     internal static readonly Guid TestResourceId = Guid.Parse("0195efb8-7c80-7a01-8001-000000000051");
+    internal static readonly Guid DelegationTestResourceId = Guid.Parse("0195efb8-7c80-7a01-8001-000000000060");
 
 #pragma warning disable SA1401 // Fields should be private
     internal static List<ResourceType> ResourceTypes = new()
@@ -1295,6 +1374,15 @@ internal static class TestDataSet
 #pragma warning restore SA1401 // Fields should be private
     {
         new Resource() { Id = TestResourceId, Name = "Test Bakery Resource", Description = "Test resource", RefId = "test-bakery-resource", TypeId = TestResourceTypeId, ProviderId = ProviderConstants.Altinn3.Id },
+        new Resource() { Id = DelegationTestResourceId, Name = "Delegation Test Resource", Description = "Test delegation resource", RefId = "delegation-test-resource", TypeId = TestResourceTypeId, ProviderId = ProviderConstants.Altinn3.Id },
+    };
+
+#pragma warning disable SA1401 // Fields should be private
+    internal static List<DelegationResource> DelegationResources = new()
+#pragma warning restore SA1401 // Fields should be private
+    {
+        // Resource delegated via Baker Johnsen -> Gunnar delegation
+        new DelegationResource() { Id = Guid.Parse("0195efb8-7c80-7a01-8001-000000000061"), DelegationId = Guid.Parse("0195efb8-7c80-7bda-9f72-4ef5c897f619"), ResourceId = DelegationTestResourceId, AssignmentResourceId = Guid.Parse("0195efb8-7c80-7a01-8001-000000000052") },
     };
 
 #pragma warning disable SA1401 // Fields should be private


### PR DESCRIPTION
## Include Client-Delegated Resources in ConnectionQuery and AuthorizedParties response

Resolves #3815

### Background

When resources are delegated via Client Delegation, they are stored in the `DelegationResource` table but the `ConnectionQuery` only loaded resources from `AssignmentResources`. This meant the AuthorizedParties API response was missing resources for parties where access was granted through client delegation.

### Changes

**Feature toggle:**
- Added `IncludeClientDelegationResourcesInConnectionQuery` (`AccessManagement.ConnectionQuery.IncludeClientDelegationResources`) — separate from the PIP toggle, defaults to off.
- Added to terraform deployment in `infra/main.tf`.

**Filter parameter:**
- Added `IncludeDelegationResources` property to `ConnectionQueryFilter`. Callers set this based on the feature toggle, keeping the query layer free of `IFeatureManager` dependency.

**Resource loading:**
- Added `LoadDelegationResourcesByKeyAsync` in `ConnectionResourceLoader` — queries `db.DelegationResources` joined with `db.Resources`, groups by `DelegationId`, merges into `ConnectionQueryExtendedRecord.Resources`.
- Updated `ConnectionQuery` orchestration to call it when `IncludeDelegationResources && IncludeDelegation` are both true.

**Caller integration:**
- `AuthorizedPartyRepoServiceEf` now injects `IFeatureManager` and sets `IncludeDelegationResources = true` when the toggle is enabled and resources are requested.

**Downstream compatibility verified:**
- `EnrichWithResourceAccess` iterates `connection.Resources` generically — no changes needed.
- `FilterConnections` filters by `RefId` uniformly — delegation resources handled identically.

### Tests

Added 3 integration tests in `ConnectionQueryTests.cs`:
1. ✅ `IncludeDelegationResources = true` + `IncludeDelegation = true` → delegation resources appear
2. ✅ `IncludeDelegation = false` → no delegation connections/resources returned
3. ✅ `IncludeDelegationResources = false` → delegation connections present but resources not loaded

### Files changed

- `src/.../AccessMgmtFeatureFlags.cs` — new feature flag constant
- `src/.../ConnectionQueryFilter.cs` — new `IncludeDelegationResources` property
- `src/.../ConnectionResourceLoader.cs` — new `LoadDelegationResourcesByKeyAsync` method
- `src/.../ConnectionQuery.cs` — orchestration update
- `src/.../AuthorizedPartyRepoServiceEf.cs` — inject `IFeatureManager`, set filter
- `src/.../infra/main.tf` — terraform feature flag
- `test/.../ConnectionQueryTests.cs` — seed data + 3 new tests
