### PR TITLE
bug(#3857): DelegationResources PIP does not enrich XACML context with viaParty org attributes

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs
@@ -471,8 +471,7 @@ namespace Altinn.AccessManagement.Core.Services
                     .ThenInclude(d => d.From)
                         .ThenInclude(a => a.From)
                 .Include(dr => dr.Delegation)
-                    .ThenInclude(d => d.To)
-                        .ThenInclude(a => a.To)
+                    .ThenInclude(d => d.Facilitator)
                 .Include(dr => dr.AssignmentResource)
                 .Include(dr => dr.Resource)
                 .Where(dr => offeringEntityIds.Contains(dr.Delegation.From.FromId))
@@ -481,13 +480,15 @@ namespace Altinn.AccessManagement.Core.Services
                 .ToListAsync(cancellationToken);
 
             // Map to DelegationChange objects
+            // The viaParty org is mapped as the covered-by party, matching the pattern used for keyrole-inherited delegations.
+            // The delegation policy blob has the viaParty org as the subject match, so the DecisionController's
+            // context enrichment needs CoveredByPartyId/ToUuid to add the org's party attributes to the XACML request.
             return clientDelegationResults.Select(dr =>
             {
                 var fromEntity = dr.Delegation.From.From;
-                var toEntity = dr.Delegation.To.To;
-                var toUuidType = MapEntityTypeToUuidType(toEntity.TypeId);
+                var viaParty = dr.Delegation.Facilitator;
 
-                var result = new DelegationChange
+                return new DelegationChange
                 {
                     ResourceId = dr.Resource.RefId,
                     DelegationChangeType = DelegationChangeType.Grant,
@@ -496,20 +497,10 @@ namespace Altinn.AccessManagement.Core.Services
                     OfferedByPartyId = fromEntity.PartyId ?? 0,
                     FromUuid = fromEntity.Id,
                     FromUuidType = MapEntityTypeToUuidType(fromEntity.TypeId),
-                    ToUuid = toEntity.Id,
-                    ToUuidType = toUuidType,
+                    CoveredByPartyId = viaParty?.PartyId,
+                    ToUuid = viaParty?.Id,
+                    ToUuidType = UuidType.Organization,
                 };
-
-                if (toUuidType == UuidType.Person)
-                {
-                    result.CoveredByUserId = toEntity.UserId;
-                }
-                else if (toUuidType == UuidType.Organization)
-                {
-                    result.CoveredByPartyId = toEntity.PartyId;
-                }
-
-                return result;
             }).ToList();
         }
 

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs
@@ -486,7 +486,8 @@ namespace Altinn.AccessManagement.Core.Services
             return clientDelegationResults.Select(dr =>
             {
                 var fromEntity = dr.Delegation.From.From;
-                var viaParty = dr.Delegation.Facilitator;
+                var viaParty = dr.Delegation.Facilitator
+                    ?? throw new InvalidOperationException($"Delegation {dr.DelegationId} is missing its Facilitator entity. FacilitatorId is required.");
 
                 return new DelegationChange
                 {
@@ -497,8 +498,8 @@ namespace Altinn.AccessManagement.Core.Services
                     OfferedByPartyId = fromEntity.PartyId ?? 0,
                     FromUuid = fromEntity.Id,
                     FromUuidType = MapEntityTypeToUuidType(fromEntity.TypeId),
-                    CoveredByPartyId = viaParty?.PartyId,
-                    ToUuid = viaParty?.Id,
+                    CoveredByPartyId = viaParty.PartyId,
+                    ToUuid = viaParty.Id,
                     ToUuidType = UuidType.Organization,
                 };
             }).ToList();

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/PolicyInformationPointClientDelegationResourceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/PolicyInformationPointClientDelegationResourceTest.cs
@@ -36,6 +36,7 @@ public class PolicyInformationPointClientDelegationResourceTest
     private const int RecipientUserId = 20900021;
     private const int RecipientPartyId = 50900021;
     private const int NonRecipientUserId = 20900022;
+    private const int ClientProviderPartyId = 50900023;
 
     // Assignment IDs
     private static readonly Guid AssignOrgToClientId = Guid.Parse("0196b000-0002-7001-8001-000000000020");
@@ -109,7 +110,7 @@ public class PolicyInformationPointClientDelegationResourceTest
                     VariantId = EntityVariantConstants.AS,
                     OrganizationIdentifier = "399900023",
                     RefId = "399900023",
-                    PartyId = 50900023,
+                    PartyId = ClientProviderPartyId,
                 },
                 new Entity()
                 {
@@ -245,7 +246,7 @@ public class PolicyInformationPointClientDelegationResourceTest
         Assert.Equal(OrgMainUnitId, delegation.FromUuid);
         Assert.Equal(ClientProviderId, delegation.ToUuid);
         Assert.Null(delegation.CoveredByUserId);
-        Assert.Equal(50900023, delegation.CoveredByPartyId);
+        Assert.Equal(ClientProviderPartyId, delegation.CoveredByPartyId);
     }
 
     /// <summary>
@@ -279,11 +280,11 @@ public class PolicyInformationPointClientDelegationResourceTest
         Assert.Equal(OrgMainUnitPartyId, delegation.OfferedByPartyId);
         Assert.Equal(ClientProviderId, delegation.ToUuid);
         Assert.Null(delegation.CoveredByUserId);
-        Assert.Equal(50900023, delegation.CoveredByPartyId);
+        Assert.Equal(ClientProviderPartyId, delegation.CoveredByPartyId);
     }
 
     /// <summary>
-    /// Party is the subunit of the main unit that has the delegation.
+    /// Party is the subunit of the main unit
     /// The query should resolve the parent and find the delegation.
     /// </summary>
     [Fact]

--- a/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/PolicyInformationPointClientDelegationResourceTest.cs
+++ b/src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/PolicyInformationPointClientDelegationResourceTest.cs
@@ -240,12 +240,12 @@ public class PolicyInformationPointClientDelegationResourceTest
             d.ResourceId == "nav_sykepenger_dialog" &&
             d.BlobStoragePolicyPath == ResourcePolicyPath);
 
-        // Verify from/to mapping is populated for PDP consumption
+        // Verify from/to mapping: viaParty org is the covered-by party (same pattern as keyrole delegations)
         Assert.Equal(OrgMainUnitPartyId, delegation.OfferedByPartyId);
         Assert.Equal(OrgMainUnitId, delegation.FromUuid);
-        Assert.Equal(PersonRecipientId, delegation.ToUuid);
-        Assert.Equal(RecipientUserId, delegation.CoveredByUserId);
-        Assert.Null(delegation.CoveredByPartyId);
+        Assert.Equal(ClientProviderId, delegation.ToUuid);
+        Assert.Null(delegation.CoveredByUserId);
+        Assert.Equal(50900023, delegation.CoveredByPartyId);
     }
 
     /// <summary>
@@ -275,11 +275,11 @@ public class PolicyInformationPointClientDelegationResourceTest
             d.ResourceId == "nav_sykepenger_dialog" &&
             d.BlobStoragePolicyPath == ResourcePolicyPath);
 
-        // Verify system user gets ToUuid/ToUuidType populated
+        // Verify viaParty org is the covered-by party (same for system user recipients)
         Assert.Equal(OrgMainUnitPartyId, delegation.OfferedByPartyId);
-        Assert.Equal(SystemUserRecipientId, delegation.ToUuid);
+        Assert.Equal(ClientProviderId, delegation.ToUuid);
         Assert.Null(delegation.CoveredByUserId);
-        Assert.Null(delegation.CoveredByPartyId);
+        Assert.Equal(50900023, delegation.CoveredByPartyId);
     }
 
     /// <summary>


### PR DESCRIPTION
## Bug: DelegationResources PIP does not enrich XACML context with viaParty org attributes (#3857)

### Problem
When a delegation is made to an organization via DelegationResources (v2 client delegations), the XACML delegation policy blob has the viaParty organization's partyId/partyUuid as the subject match. However, `GetClientDelegatedResources` in `PolicyInformationPoint` was mapping the **To** entity (the subject user) as the covered-by party on the `DelegationChange`. This meant the DecisionController's context enrichment never added the viaParty org's party attributes to the XACML request, causing policy evaluation to return NotApplicable.

### Fix
- Map the **viaParty org** (via `Delegation.Facilitator`) as the covered-by party on the `DelegationChange`, consistent with how keyrole-inherited delegations work:
  - `CoveredByPartyId` = viaParty org's PartyId
  - `ToUuid` = viaParty org's Id
  - `ToUuidType` = Organization
  - `CoveredByUserId` is no longer set (the subject user is already the authenticated principal in the XACML request)
- Added `.Include(dr => dr.Delegation).ThenInclude(d => d.Facilitator)` to load the viaParty entity
- Removed the now-unnecessary `.ThenInclude(d => d.To).ThenInclude(a => a.To)` include (the `To.ToId` filter is handled by EF via SQL)
- Updated integration test assertions to verify the new mapping

### Files changed
- `src/apps/Altinn.AccessManagement/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs`
- `src/apps/Altinn.AccessManagement/test/AccessMgmt.Tests/Integration/Controllers/PolicyInformationPointClientDelegationResourceTest.cs`
