### PR TITLE
Avoid double entity join for all key roles except ParticipantSharedResponsibility

### DIFF
--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionBaseQueryBuilder.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionBaseQueryBuilder.cs
@@ -93,7 +93,7 @@ internal class ConnectionBaseQueryBuilder
                     IsRoleMap = false,
                 });
 
-        var keyrole =
+        var keyroleNoIks =
             direct
                 .Join(
                     db.Roles,
@@ -101,16 +101,13 @@ internal class ConnectionBaseQueryBuilder
                     r => r.Id,
                     (d, r) => new { d, r }
                 )
-                .Where(x => x.r.IsKeyRole)
+                .Where(x => x.r.IsKeyRole && x.r.Id != RoleConstants.ParticipantSharedResponsibility.Id)
                 .Join(
                     db.Assignments,
                     x => x.d.FromId,
                     a2 => a2.ToId,
                     (x, a2) => new { x, a2 }
                 )
-                .Where(z => 
-                    !(z.a2.From.VariantId == EntityVariantConstants.IKS.Id && z.a2.RoleId == RoleConstants.ParticipantSharedResponsibility.Id) &&
-                    !(z.a2.To.VariantId == EntityVariantConstants.IKS.Id && z.x.d.RoleId == RoleConstants.ParticipantSharedResponsibility.Id))
                 .Select(z => new ConnectionQueryBaseRecord
                 {
                     AssignmentId = z.a2.Id,
@@ -125,6 +122,35 @@ internal class ConnectionBaseQueryBuilder
                     IsMainUnitAccess = false,
                     IsRoleMap = false,
                 });
+
+        var keyrolePotentialIks =
+            direct
+                .Where(x => x.RoleId == RoleConstants.ParticipantSharedResponsibility.Id)
+                .Join(
+                    db.Assignments,
+                    x => x.FromId,
+                    a2 => a2.ToId,
+                    (x, a2) => new { x, a2 }
+                )
+                .Where(z =>
+                    !(z.a2.From.VariantId == EntityVariantConstants.IKS.Id && z.a2.RoleId == RoleConstants.ParticipantSharedResponsibility.Id) &&
+                    !(z.a2.To.VariantId == EntityVariantConstants.IKS.Id))
+                .Select(z => new ConnectionQueryBaseRecord
+                {
+                    AssignmentId = z.a2.Id,
+                    DelegationId = null,
+                    FromId = z.a2.FromId,
+                    ToId = z.x.ToId,
+                    RoleId = z.a2.RoleId,
+                    ViaId = z.x.FromId,
+                    ViaRoleId = z.x.RoleId,
+                    Reason = ConnectionReason.KeyRole,
+                    IsKeyRoleAccess = true,
+                    IsMainUnitAccess = false,
+                    IsRoleMap = false,
+                });
+
+        var keyrole = keyroleNoIks.Concat(keyrolePotentialIks);
 
         var a1 = filter.IncludeKeyRole
             ? direct.Concat(keyrole)

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionBaseQueryBuilder.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionBaseQueryBuilder.cs
@@ -126,25 +126,34 @@ internal class ConnectionBaseQueryBuilder
 
         var keyrolePotentialIks =
             direct
-                .Where(x => x.RoleId == RoleConstants.ParticipantSharedResponsibility.Id)
+                .Join(
+                    db.Roles,
+                    d => d.RoleId,
+                    r => r.Id,
+                    (d, r) => new { d, r }
+                )
+                .Where(x => x.r.IsKeyRole)
                 .Join(
                     db.Assignments,
-                    x => x.FromId,
+                    x => x.d.FromId,
                     a2 => a2.ToId,
                     (x, a2) => new { x, a2 }
                 )
                 .Where(z =>
+                    z.a2.RoleId == RoleConstants.ParticipantSharedResponsibility.Id ||
+                    z.x.d.RoleId == RoleConstants.ParticipantSharedResponsibility.Id)
+                .Where(z =>
                     !(z.a2.From.VariantId == EntityVariantConstants.IKS.Id && z.a2.RoleId == RoleConstants.ParticipantSharedResponsibility.Id) &&
-                    !(z.a2.To.VariantId == EntityVariantConstants.IKS.Id && z.x.RoleId == RoleConstants.ParticipantSharedResponsibility.Id))
+                    !(z.a2.To.VariantId == EntityVariantConstants.IKS.Id && z.x.d.RoleId == RoleConstants.ParticipantSharedResponsibility.Id))
                 .Select(z => new ConnectionQueryBaseRecord
                 {
                     AssignmentId = z.a2.Id,
                     DelegationId = null,
                     FromId = z.a2.FromId,
-                    ToId = z.x.ToId,
+                    ToId = z.x.d.ToId,
                     RoleId = z.a2.RoleId,
-                    ViaId = z.x.FromId,
-                    ViaRoleId = z.x.RoleId,
+                    ViaId = z.x.d.FromId,
+                    ViaRoleId = z.x.d.RoleId,
                     Reason = ConnectionReason.KeyRole,
                     IsKeyRoleAccess = true,
                     IsMainUnitAccess = false,

--- a/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionBaseQueryBuilder.cs
+++ b/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Queries/Connection/ConnectionBaseQueryBuilder.cs
@@ -108,6 +108,7 @@ internal class ConnectionBaseQueryBuilder
                     a2 => a2.ToId,
                     (x, a2) => new { x, a2 }
                 )
+                .Where(x => x.a2.RoleId != RoleConstants.ParticipantSharedResponsibility.Id)
                 .Select(z => new ConnectionQueryBaseRecord
                 {
                     AssignmentId = z.a2.Id,
@@ -134,7 +135,7 @@ internal class ConnectionBaseQueryBuilder
                 )
                 .Where(z =>
                     !(z.a2.From.VariantId == EntityVariantConstants.IKS.Id && z.a2.RoleId == RoleConstants.ParticipantSharedResponsibility.Id) &&
-                    !(z.a2.To.VariantId == EntityVariantConstants.IKS.Id))
+                    !(z.a2.To.VariantId == EntityVariantConstants.IKS.Id && z.x.RoleId == RoleConstants.ParticipantSharedResponsibility.Id))
                 .Select(z => new ConnectionQueryBaseRecord
                 {
                     AssignmentId = z.a2.Id,


### PR DESCRIPTION
## Description
- Avoid double entity join for all key roles except ParticipantSharedResponsibility
- 
## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
